### PR TITLE
Syncing changes to the ZendSkeletonApplication autoload config listener

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -11,7 +11,7 @@ $moduleManager    = new Zend\Module\Manager($appConfig['modules']);
 $listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
 $defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
 
-$defaultListeners->getConfigListener()->addConfigGlobPath('config/autoload/*.config.php');
+$defaultListeners->getConfigListener()->addConfigGlobPath("config/autoload/{,*.}{global,local}.config.php");
 $moduleManager->events()->attachAggregate($defaultListeners);
 $moduleManager->loadModules();
 


### PR DESCRIPTION
As reported in doctrine/DoctrineModule#2 , this change simply aligns the config listener to the changes happened in zendframework/ZendSkeletonApplication
