### PR TITLE
Adding first version of composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "doctrine/DoctrineModule",
+    "description": "Zend Framework 2 Module that provides Doctrine basic functionality required for ORM and ODM modules",
+    "version": "1.0.0b",
+    "type": "library",
+    "keywords": [
+        "doctrine",
+        "module",
+        "zf2"
+    ],
+    "homepage": "http://www.doctrine-project.org/",
+    "authors": [
+        {
+            "name": "Kyle Spraggs",
+            "email": "theman@spiffyjr.me",
+            "homepage": "http://www.spiffyjr.me/"
+        },
+        {
+            "name": "Marco Pivetta",
+            "email": "ocramius@gmail.com",
+            "homepage": "http://marco-pivetta.com/"
+        },
+        {
+            "name": "Evan Coury",
+            "email": "me@evancoury.com",
+            "homepage": "http://blog.evan.pro/"
+        },
+        {
+            "name": "Guilherme Blanco",
+            "email": "guilhermeblanco@hotmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+
+    "autoload": {
+        "psr-0": {
+            "DoctrineModule": "src/"
+        }
+    },
+    "config": {
+        "bin-dir": "bin"
+    }
+}


### PR DESCRIPTION
Adding `composer.json` file to be able to register the module on packagist (doesn't provide any features right now except this metadata)
