### PR TITLE
Updating the CLI with the latest fixes from ORM Module to DiC aliases

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -5,7 +5,7 @@ chdir(__DIR__);
 $previousDir = '.';
 while (!file_exists('config/application.config.php')) {
     $dir = dirname(getcwd());
-    if($previousDir === $dir) {
+    if ($previousDir === $dir) {
         throw new RuntimeException(
             'Unable to locate "config/application.config.php":'
                 . ' is DoctrineModule in a subdir of your application skeleton?'
@@ -15,13 +15,13 @@ while (!file_exists('config/application.config.php')) {
     chdir($dir);
 }
 
-require_once (getenv('ZF2_PATH') ?: 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
+require_once (getenv('ZF2_PATH') ? : 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
 Zend\Loader\AutoloaderFactory::factory();
 
 $appConfig = include 'config/application.config.php';
 
-$moduleManager    = new Zend\Module\Manager($appConfig['modules']);
-$listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
+$moduleManager = new Zend\Module\Manager($appConfig['modules']);
+$listenerOptions = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
 $defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
 
 $defaultListeners->getConfigListener()->addConfigGlobPath("config/autoload/{,*.}{global,local}.config.php");
@@ -29,7 +29,7 @@ $moduleManager->events()->attachAggregate($defaultListeners);
 $moduleManager->loadModules();
 
 // Create application, bootstrap, and run
-$bootstrap   = new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->getMergedConfig());
+$bootstrap = new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->getMergedConfig());
 $application = new Zend\Mvc\Application;
 $bootstrap->bootstrap($application);
 $locator = $application->getLocator();
@@ -55,7 +55,9 @@ if (class_exists('Doctrine\ODM\MongoDB\Version')) {
 }
 
 if (class_exists('Doctrine\ORM\Version')) {
-    $helpers['em'] = new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($locator->get('doctrine_em'));
+    $em = $locator->get('Doctrine\ORM\EntityManager');
+    $helpers['em'] = new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($em);
+    $helpers['db'] = new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($em->getConnection());
     $cli->addCommands(array(
         // DBAL Commands
         new \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand(),
@@ -80,7 +82,7 @@ if (class_exists('Doctrine\ORM\Version')) {
     ));
 }
 
-$helperSet = isset($helperSet) ? $helperSet : new \Symfony\Component\Console\Helper\HelperSet();
+$helperSet = $cli->getHelperSet();
 foreach ($helpers as $name => $helper) {
     $helperSet->set($helper, $name);
 }


### PR DESCRIPTION
This patch fixes the DBAL CLI (missing helper) and assumes now `Doctrine\ORM\EntityManager` instead of `doctrine_em` in DiC as of doctrine/DoctrineORMModule#19
