### PR TITLE
Replace composer bin-dir with bin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,5 @@
             "DoctrineModule": "src/"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    }
+    "bin": ["bin/doctrine"]
 }


### PR DESCRIPTION
The current composer.json doesn't cause the doctrine shell script to be linked into the users bin directory. This fixes that.

http://getcomposer.org/doc/articles/vendor-bins.md
