### PR TITLE
Changed default path to zend framework library to reflect changes into default ZendSkeletonApplication.

### DIFF
--- a/bin/doctrine-module.php
+++ b/bin/doctrine-module.php
@@ -40,7 +40,7 @@ while (!file_exists('config/application.config.php')) {
     chdir($dir);
 }
 
-require_once (getenv('ZF2_PATH') ?: 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
+require_once (getenv('ZF2_PATH') ?: 'vendor/zendframework/zendframework/library') . '/Zend/Loader/AutoloaderFactory.php';
 
 // setup autoloader
 AutoloaderFactory::factory();


### PR DESCRIPTION
ZendSkeletonApplication installed using composer use default path to zf2 that is vendor/zendframework/zendframework/library while bin/doctrine_module.php use vendor/ZendFramework/library.
Changing it block updating DoctrineModule using composer.
