### PR TITLE
Adopt module to normal using class annotation mapping without required importing entities mapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "2.*",
+        "doctrine/common": ">=2.2.0, <2.2.99",
         "doctrine/data-fixtures": "dev-master",
         "symfony/yaml": "2.0.*",
         "symfony/console": "2.0.*"

--- a/src/DoctrineModule/Doctrine/Common/DriverChain.php
+++ b/src/DoctrineModule/Doctrine/Common/DriverChain.php
@@ -20,12 +20,10 @@
 namespace DoctrineModule\Doctrine\Common;
 
 use InvalidArgumentException;
-use ReflectionClass;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Annotations\IndexedReader;
 use DoctrineModule\Doctrine\Instance;
 
 /**
@@ -127,12 +125,11 @@ class DriverChain extends Instance
      */
     protected function getCachedReader()
     {
-    	if (null === self::$cachedReader) {
-	    	$reader = new AnnotationReader;
-			//$indexedReader 	    = new IndexedReader($reader);
-			//self::$cachedReader = new CachedReader($indexedReader, $this->cache);
-			self::$cachedReader = new CachedReader($reader, $this->cache);
-    	}
+        if (null === self::$cachedReader) {
+            $reader = new SimpleAnnotationReader;
+            $reader->addNamespace('Doctrine\ORM\Mapping');
+            self::$cachedReader = new CachedReader($reader, $this->cache);
+        }
     	return self::$cachedReader;
     }
 }


### PR DESCRIPTION
Now you can use annotation like in doctrine documentation wrote. Without declaration 

```
use Doctrine\ORM\Mapping as ORM;
@ORM\Entity
.....
```

Also, adapt config to get correct release of doctrine without large repositories. Cleaned up this class.
