### PR TITLE
Allow to specify specific field to identity, and more flexible callable function

### DIFF
--- a/src/DoctrineModule/Authentication/Adapter/DoctrineObject.php
+++ b/src/DoctrineModule/Authentication/Adapter/DoctrineObject.php
@@ -309,7 +309,7 @@ class DoctrineObject implements AdapterInterface
             $credentialValue = call_user_func($callable, $identity, $credentialValue);
         }
 
-        if ($credentialValue === false || $credentialValue != $documentCredential) {
+        if ($credentialValue !== true && $credentialValue != $documentCredential) {
             $this->authenticationResultInfo['code'] = AuthenticationResult::FAILURE_CREDENTIAL_INVALID;
             $this->authenticationResultInfo['messages'][] = 'Supplied credential is invalid.';
             return $this->authenticateCreateAuthResult();


### PR DESCRIPTION
I have made two small modifications to the Authentication adapter :

1) The first one deals with credentialCallable : with MD5-like hashing, the current way works well, however it doesn't work using Blowfish crypt. So now, if the credentialCallable returns true, it considers to be valid.

2) I don't really want to store the full identity object, but rather only the id. So I can specify an identityCallable closure that take an identity object, and returns one field or an array.

I know it overlaps with some features of ZfcUser, but it's pretty useful to have them here, tbh.
