### PR TITLE
Fixed use statements for Zend\Stdlib\Options

### DIFF
--- a/src/DoctrineModule/Options/Cache.php
+++ b/src/DoctrineModule/Options/Cache.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
-class Cache extends Options
+class Cache extends AbstractOptions
 {
     /**
      * Class used to instantiate the cache.

--- a/src/DoctrineModule/Options/Configuration.php
+++ b/src/DoctrineModule/Options/Configuration.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
-class Configuration extends Options
+class Configuration extends AbstractOptions
 {
     /**
      * Set the cache key for the result cache. Cache key

--- a/src/DoctrineModule/Options/Connection.php
+++ b/src/DoctrineModule/Options/Connection.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
-class Connection extends Options
+class Connection extends AbstractOptions
 {
     /**
      * Set the configuration key for the Configuration. Configuration key

--- a/src/DoctrineModule/Options/Driver.php
+++ b/src/DoctrineModule/Options/Driver.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
-class Driver extends Options
+class Driver extends AbstractOptions
 {
     /**
      * The class name of the Driver.

--- a/src/DoctrineModule/Options/EventManager.php
+++ b/src/DoctrineModule/Options/EventManager.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\Options;
+use Zend\Stdlib\AbstractOptions;
 
-class EventManager extends Options
+class EventManager extends AbstractOptions
 {
     /**
      * An array of subscribers. The array can contain the FQN of the

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -14,7 +14,7 @@ abstract class AbstractFactory implements FactoryInterface
     protected $name;
 
     /**
-     * @var \Zend\Stdlib\Options
+     * @var \Zend\Stdlib\AbstractOptions
      */
     protected $options;
 
@@ -40,7 +40,7 @@ abstract class AbstractFactory implements FactoryInterface
      * @param ServiceLocatorInterface $sl
      * @param string $key
      * @param null|string $name
-     * @return \Zend\Stdlib\Options
+     * @return \Zend\Stdlib\AbstractOptions
      * @throws \RuntimeException
      */
     public function getOptions(ServiceLocatorInterface $sl, $key, $name = null)


### PR DESCRIPTION
Updated use statement based on changes made to Zend Framework https://github.com/zendframework/zf2/commit/b372296f13d9155ca92718e06dae130ad4a10a5f

This fixes a recent issue related to changes in Zend Framework 2 class names https://github.com/doctrine/DoctrineORMModule/issues/59
