### PR TITLE
Fixing #41 and testing new functionality

### DIFF
--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -2,28 +2,52 @@
 
 namespace DoctrineModule\Service;
 
-use RuntimeException;
+use InvalidArgumentException;
 use Doctrine\Common\EventManager;
+use Doctrine\Common\EventSubscriber;
 use DoctrineModule\Service\AbstractFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
+/**
+ * Factory responsible for creating EventManager instances
+ */
 class EventManagerFactory extends AbstractFactory
 {
+    /**
+     * {@inheritDoc}
+     */
     public function createService(ServiceLocatorInterface $sl)
     {
         /** @var $options \DoctrineModule\Options\EventManager */
-        $options = $this->getOptions($sl, 'eventmanager');
-        $evm     = new EventManager;
+        $options      = $this->getOptions($sl, 'eventmanager');
+        $eventManager = new EventManager();
 
-        foreach($options->getSubscribers() as $subscriber) {
-            if (is_subclass_of($subscriber, 'Doctrine\Common\EventSubscriber')) {
-                $evm->addEventSubscriber(new $subscriber);
-            } else {
-                $evm->addEventSubscriber($sl->get($subscriber));
+        foreach($options->getSubscribers() as $subscriberName) {
+            $subscriber = $subscriberName;
+
+            if (is_string($subscriber)) {
+                if ($sl->has($subscriber)) {
+                    $subscriber = $sl->get($subscriber);
+                } else if (class_exists($subscriber)) {
+                    $subscriber = new $subscriber();
+                }
             }
+
+            if ($subscriber instanceof EventSubscriber) {
+                $eventManager->addEventSubscriber($subscriber);
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf(
+                'Invalid event subscriber "%s" given, must be a service name, '
+                . 'class name or an instance implementing Doctrine\Common\EventSubscriber',
+                is_object($subscriberName)
+                    ? get_class($subscriberName)
+                    : (is_string($subscriberName) ? $subscriberName : gettype($subscriber))
+            ));
         }
 
-        return $evm;
+        return $eventManager;
     }
 
     /**

--- a/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModuleTest\Service;
+
+use PHPUnit_Framework_TestCase as BaseTestCase;
+use DoctrineModule\Service\EventManagerFactory;
+use Zend\ServiceManager\ServiceManager;
+use DoctrineModuleTest\Service\TestAsset\DummyEventSubscriber;
+
+/**
+ * Base test case to be used when a service manager instance is required
+ */
+class EventManagerFactoryTest extends BaseTestCase
+{
+    public function testWillInstantiateFromFQCN()
+    {
+        $name = 'eventManagerFactory';
+        $factory = new EventManagerFactory($name);
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'Configuration',
+            array(
+                'doctrine' => array(
+                    'eventmanager' => array(
+                        $name => array(
+                            'subscribers' => array(
+                                __NAMESPACE__ . '\TestAsset\DummyEventSubscriber'
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        /* $var $eventManager \Doctrine\Common\EventManager */
+        $eventManager = $factory->createService($serviceManager);
+        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+
+        $listeners = $eventManager->getListeners('dummy');
+        $this->assertCount(1, $listeners);
+    }
+
+    public function testWillAttachEventListenersFromConfiguredInstances()
+    {
+        $name = 'eventManagerFactory';
+        $factory = new EventManagerFactory($name);
+        $subscriber = new DummyEventSubscriber();
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'Configuration',
+            array(
+                'doctrine' => array(
+                    'eventmanager' => array(
+                        $name => array(
+                            'subscribers' => array(
+                                $subscriber,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        /* $var $eventManager \Doctrine\Common\EventManager */
+        $eventManager = $factory->createService($serviceManager);
+        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+
+        $listeners = $eventManager->getListeners();
+        $this->assertArrayHasKey('dummy', $listeners);
+        $listeners = $eventManager->getListeners('dummy');
+        $this->assertContains($subscriber, $listeners);
+    }
+
+    public function testWillAttachEventListenersFromServiceManagerAlias()
+    {
+        $name = 'eventManagerFactory';
+        $factory = new EventManagerFactory($name);
+        $subscriber = new DummyEventSubscriber();
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('dummy-subscriber', $subscriber);
+        $serviceManager->setService(
+            'Configuration',
+            array(
+                'doctrine' => array(
+                    'eventmanager' => array(
+                        $name => array(
+                            'subscribers' => array(
+                                'dummy-subscriber'
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        /* $var $eventManager \Doctrine\Common\EventManager */
+        $eventManager = $factory->createService($serviceManager);
+        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+
+        $listeners = $eventManager->getListeners();
+        $this->assertArrayHasKey('dummy', $listeners);
+        $listeners = $eventManager->getListeners('dummy');
+        $this->assertContains($subscriber, $listeners);
+    }
+
+    public function testWillRefuseNonExistingSubscriber()
+    {
+        $name = 'eventManagerFactory';
+        $factory = new EventManagerFactory($name);
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'Configuration',
+            array(
+                'doctrine' => array(
+                    'eventmanager' => array(
+                        $name => array(
+                            'subscribers' => array(
+                                'non-existing-subscriber'
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $this->setExpectedException('InvalidArgumentException');
+        $factory->createService($serviceManager);
+    }
+}

--- a/tests/DoctrineModuleTest/Service/TestAsset/DummyEventSubscriber.php
+++ b/tests/DoctrineModuleTest/Service/TestAsset/DummyEventSubscriber.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModuleTest\Service\TestAsset;
+
+use Doctrine\Common\EventSubscriber;
+
+/**
+ * Dummy event subscriber used to test injections
+ */
+class DummyEventSubscriber implements EventSubscriber
+{
+    /**
+     * Empty callback method
+     */
+    public function dummy()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function getSubscribedEvents()
+    {
+        return array(
+            'dummy'
+        );
+    }
+}


### PR DESCRIPTION
Fixing #41, allowing usage of instantiated event subscribers/service names or fully qualified class names to attach subscribers to the `EventManager` produced by the `EventManagerFactory`.

[![Build Status](https://secure.travis-ci.org/doctrine/DoctrineModule.png?branch=hotfix/issue-41-event-listeners)](http://travis-ci.org/doctrine/DoctrineModule)
