### PR TITLE
Should not depend on dev-master (especially on Zend Framework)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "dev-master",
-        "doctrine/data-fixtures": "dev-master",
+        "doctrine/common": ">=2.0",
+        "doctrine/data-fixtures": ">=v1.0.0-ALPHA2",
         "symfony/yaml": ">=2.0.13",
         "symfony/console": ">=2.0.13",
-        "zendframework/zendframework": "dev-master"
+        "zendframework/zendframework": ">=2.0.0beta5"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
We are using DoctrineORMModule & DoctrineModule in production with ZF beta 5, however, we need to be able to lock in the specific version for change control and qa needs.  The current composer setup forces us to use dev-master (git clones) versus the released tags.  I've simply converted the values in the composer.json file to reflect >= of the latest release. There is another pull request in DoctrineORMModule for this as well.
