### PR TITLE
[Hydrator] Allow nullable associations

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -111,6 +111,10 @@ class DoctrineObject implements HydratorInterface
         $this->metadata = $this->objectManager->getClassMetadata(get_class($object));
 
         foreach($data as $field => &$value) {
+            if ($value === null) {
+                continue;
+            }
+
             // @todo DateTime (and other types) conversion should be handled by doctrine itself in future
             if (in_array($this->metadata->getTypeOfField($field), array('datetime', 'time', 'date'))) {
                 if (is_int($value)) {

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -143,6 +143,19 @@ class DoctrineObjectTest extends BaseTestCase
         }
     }
 
+    public function testCanHydrateEntityWithNullableAssociation()
+    {
+        $data = array(
+            'country' => null
+        );
+
+        $this->metadata->expects($this->never())
+                ->method('hasAssociation');
+
+        $object = $this->hydrator->hydrate($data, new stdClass());
+        $this->assertNull($object->country);
+    }
+
     public function testHydrateHandlesDateTimeFieldsCorrectly()
     {
         $this->metadata->expects($this->exactly(2))


### PR DESCRIPTION
This is a fix to allow associations to be null.

With the previous implementation a `Doctrine\ORM\ORMException::missingIdentifierField` is thrown, as the method `Doctrine\Common\Persistence\ObjectManager::find` is called with null.
