### PR TITLE
MappingDriver does not have a addDriver method.

### DIFF
--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -22,6 +22,7 @@ namespace DoctrineModule\Service;
 use InvalidArgumentException;
 use Doctrine\Common\Annotations;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use DoctrineModule\Options\Driver as DriverOptions;


### PR DESCRIPTION
`addDriver` method only exists in `MappingDriverChain` class but in `DoctrineModule\Service\DriverFactory::createDriver()` on line 118 the check is only made on `MappingDriver`.
