### PR TITLE
Remove DoctrineModuleTest namespace from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     "minimum-stability": "dev",
     "autoload": {
         "psr-0": {
-            "DoctrineModule": "src/",
-            "DoctrineModuleTest": "tests/"
+            "DoctrineModule": "src/"
         }
     },
     "bin": [

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -37,9 +37,18 @@ while (!file_exists('config/application.config.php')) {
     chdir($dir);
 }
 
-if (!(@include_once __DIR__ . '/../vendor/autoload.php') && !(@include_once __DIR__ . '/../../../autoload.php')) {
-    throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
+switch (true){
+    case file_exists(__DIR__ . '/../vendor/autoload.php'):
+        $loader = include_once __DIR__ . '/../vendor/autoload.php';
+        break;
+    case file_exists(__DIR__ . '/../../../autoload.php'):
+        $loader = include_once __DIR__ . '/../../../autoload.php';
+        break;
+    default:
+        throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
 }
+
+$loader->add('DoctrineModuleTest', __DIR__);
 
 if (!$config = @include __DIR__ . '/TestConfiguration.php') {
     $config = require __DIR__ . '/TestConfiguration.php.dist';


### PR DESCRIPTION
Remove a namespace from the autoloader that is not needed in production. It just slows things down for no gain.
