### PR TITLE
Get identifier from uninitialized entity proxies

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -199,25 +199,24 @@ class Proxy
             throw new RuntimeException('No target class was set');
         }
 
-        $metadata = $om->getClassMetadata($targetClass);
         if (is_object($value)) {
+            $uow = $om->getUnitOfWork();
             if ($value instanceof Collection) {
                 $data = array();
                 foreach($value as $object) {
-                    $values = $metadata->getIdentifierValues($object);
+                    $values = $uow->getEntityIdentifier($object);
                     $data[] = array_shift($values);
                 }
 
                 $value = $data;
-            } else {
-                $metadata   = $om->getClassMetadata(get_class($value));
-                $identifier = $metadata->getIdentifierFieldNames();
+            } elseif (is_a($value, $targetClass)) {
+                $identifier = $uow->getEntityIdentifier($value);
 
                 // TODO: handle composite (multiple) identifiers
                 if (count($identifier) > 1) {
-                    //$value = $key;
+                    //$value = $identifier;
                 } else {
-                    $value = current($om->getUnitOfWork()->getEntityIdentifier($value));
+                    $value = current($identifier);
                 }
             }
         }


### PR DESCRIPTION
Fix for #122.

Replace `$om->getClassMetadata()` with `$om->getUnitOfWork()` to gracefully get the entity identifier from uninitialized entity proxies without triggering a lazy-load.

This is based on the answer to this SO question:
http://stackoverflow.com/questions/8211679/can-you-get-a-foreign-key-from-an-object-in-doctine2-without-loading-that-object
