### PR TITLE
Extend abstract adapter

### DIFF
--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -20,7 +20,7 @@
 namespace DoctrineModule\Authentication\Adapter;
 
 use DoctrineModule\Options\Authentication as AuthenticationOptions;
-use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\Adapter\AbstractAdapter;
 use Zend\Authentication\Adapter\Exception;
 use Zend\Authentication\Result as AuthenticationResult;
 
@@ -33,22 +33,8 @@ use Zend\Authentication\Result as AuthenticationResult;
  * @author  Tim Roediger <superdweebie@gmail.com>
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  */
-class ObjectRepository implements AdapterInterface
+class ObjectRepository extends AbstractAdapter
 {
-    /**
-     * User supplied identity.
-     *
-     * @var string
-     */
-    protected $identityValue;
-
-    /**
-     * User supplied credential.
-     *
-     * @var string
-     */
-    protected $credentialValue;
-
     /**
      * @var AuthenticationOptions
      */
@@ -90,19 +76,21 @@ class ObjectRepository implements AdapterInterface
      *
      * @param  mixed $identityValue
      * @return ObjectRepository
+     * @deprecated use setIdentity instead
      */
     public function setIdentityValue($identityValue)
     {
-        $this->identityValue = $identityValue;
+        $this->identity = $identityValue;
         return $this;
     }
 
     /**
      * @return string
+     * @deprecated use getIdentity instead
      */
     public function getIdentityValue()
     {
-        return $this->identityValue;
+        return $this->identity;
     }
 
     /**
@@ -110,19 +98,21 @@ class ObjectRepository implements AdapterInterface
      *
      * @param  mixed $credentialValue
      * @return ObjectRepository
+     * @deprecated use setCredential instead
      */
     public function setCredentialValue($credentialValue)
     {
-        $this->credentialValue = $credentialValue;
+        $this->credential = $credentialValue;
         return $this;
     }
 
     /**
      * @return string
+     * @deprecated use getCredential instead
      */
     public function getCredentialValue()
     {
-        return $this->credentialValue;
+        return $this->credential;
     }
 
     /**
@@ -132,7 +122,7 @@ class ObjectRepository implements AdapterInterface
     {
         $this->setup();
         $options  = $this->options;
-        $identity = $options->getObjectRepository()->findOneBy(array($options->getIdentityProperty() => $this->identityValue));
+        $identity = $options->getObjectRepository()->findOneBy(array($options->getIdentityProperty() => $this->identity));
 
         if (!$identity) {
             $this->authenticationResultInfo['code'] = AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND;
@@ -174,7 +164,7 @@ class ObjectRepository implements AdapterInterface
             ));
         }
 
-        $credentialValue = $this->credentialValue;
+        $credentialValue = $this->credential;
         $callable = $this->options->getCredentialCallable();
 
         if ($callable) {
@@ -203,14 +193,14 @@ class ObjectRepository implements AdapterInterface
      */
     protected function setup()
     {
-        if (null === $this->identityValue) {
+        if (null === $this->identity) {
             throw new Exception\RuntimeException(
                 'A value for the identity was not provided prior to authentication with ObjectRepository authentication '
                     . 'adapter'
             );
         }
 
-        if (null === $this->credentialValue) {
+        if (null === $this->credential) {
             throw new Exception\RuntimeException(
                 'A credential value was not provided prior to authentication with ObjectRepository authentication adapter'
             );
@@ -218,7 +208,7 @@ class ObjectRepository implements AdapterInterface
 
         $this->authenticationResultInfo = array(
             'code' => AuthenticationResult::FAILURE,
-            'identity' => $this->identityValue,
+            'identity' => $this->identity,
             'messages' => array()
         );
     }

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -69,7 +69,7 @@ class ObjectRepositoryTest extends BaseTestCase
             'object_manager' => $this->getMock('Doctrine\Common\Persistence\ObjectManager'),
             'identity_class' => 'DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject',
         ));
-        $adapter->setCredentialValue('a credetential');
+        $adapter->setCredential('a credetential');
         $adapter->authenticate();
     }
 
@@ -85,7 +85,7 @@ class ObjectRepositoryTest extends BaseTestCase
             'identity_class' => 'DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject',
         ));
 
-        $adapter->setIdentityValue('an identity');
+        $adapter->setIdentity('an identity');
         $adapter->authenticate();
     }
 
@@ -132,8 +132,8 @@ class ObjectRepositoryTest extends BaseTestCase
             'identity_property' => 'username'
         ));
 
-        $adapter->setIdentityValue('a username');
-        $adapter->setCredentialValue('a password');
+        $adapter->setIdentity('a username');
+        $adapter->setCredential('a password');
 
         $result = $adapter->authenticate();
 
@@ -167,8 +167,8 @@ class ObjectRepositoryTest extends BaseTestCase
             'identity_property' => 'username'
         ));
 
-        $adapter->setIdentityValue('a username');
-        $adapter->setCredentialValue('a password');
+        $adapter->setIdentity('a username');
+        $adapter->setCredential('a password');
 
         $result = $adapter->authenticate();
 
@@ -200,7 +200,7 @@ class ObjectRepositoryTest extends BaseTestCase
         ));
 
         $adapter->setIdentityValue('a username');
-        $adapter->setCredentialValue('a password');
+        $adapter->setCredential('a password');
         $adapter->authenticate();
     }
 
@@ -230,14 +230,14 @@ class ObjectRepositoryTest extends BaseTestCase
             }
         ));
 
-        $adapter->setIdentityValue('username');
-        $adapter->setCredentialValue('password');
+        $adapter->setIdentity('username');
+        $adapter->setCredential('password');
 
         $result = $adapter->authenticate();
 
         $this->assertTrue($result->isValid());
 
-        $adapter->setCredentialValue('wrong password');
+        $adapter->setCredential('wrong password');
         $result = $adapter->authenticate();
 
         $this->assertFalse($result->isValid());
@@ -261,8 +261,8 @@ class ObjectRepositoryTest extends BaseTestCase
             'identity_property' => 'username'
         ));
 
-        $adapter->setIdentityValue('a username');
-        $adapter->setCredentialValue('a password');
+        $adapter->setIdentity('a username');
+        $adapter->setCredential('a password');
 
         $adapter->authenticate();
     }


### PR DESCRIPTION
As DoctrineModule depends on ZF 2.*, we can take advantage of the latest AbstractAdapter instead of directly implementing AdapterInterface.

There is no BC, just deprecate the old getter/setter.
