### PR TITLE
Call hydrateValue also on simple fields in case a strategy is attached

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -250,7 +250,7 @@ class DoctrineObject extends AbstractHydrator
                     continue;
                 }
 
-                $object->$setter($value);
+                $object->$setter($this->hydrateValue($field, $value));
             }
         }
 
@@ -292,7 +292,7 @@ class DoctrineObject extends AbstractHydrator
                     $this->toMany($object, $field, $target, $value);
                 }
             } else {
-                $reflProperty->setValue($object, $value);
+                $reflProperty->setValue($object, $this->hydrateValue('field', $value));
             }
         }
 

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleStrategy.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleStrategy.php
@@ -1,0 +1,17 @@
+<?php
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Zend\Stdlib\Hydrator\Strategy\StrategyInterface;
+
+class SimpleStrategy implements StrategyInterface
+{
+    public function extract($value)
+    {
+        return 'modified while extracting';
+    }
+
+    public function hydrate($value)
+    {
+        return 'modified while hydrating';
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -1273,4 +1273,60 @@ class DoctrineObjectTest extends BaseTestCase
         $object = $this->hydratorByValue->hydrate($data, $entity);
         $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $object->getToOne(false));
     }
+
+    public function testUsesStrategyOnSimpleFieldsWhenHydratingByValue()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $entity = new Asset\SimpleEntity();
+        $this->configureObjectManagerForSimpleEntity();
+        $data = array('field' => 'foo');
+
+        $this->hydratorByValue->addStrategy('field', new Asset\SimpleStrategy());
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity);
+        $this->assertEquals('From setter: modified while hydrating', $entity->getField(false));
+    }
+
+    public function testUsesStrategyOnSimpleFieldsWhenHydratingByReference()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $entity = new Asset\SimpleEntity();
+        $this->configureObjectManagerForSimpleEntity();
+        $data = array('field' => 'foo');
+
+        $this->hydratorByReference->addStrategy('field', new Asset\SimpleStrategy());
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity);
+        $this->assertEquals('modified while hydrating', $entity->getField(false));
+    }
+
+    public function testUsesStrategyOnSimpleFieldsWhenExtractingByValue()
+    {
+        $entity = new Asset\SimpleEntity();
+        $entity->setId(2);
+        $entity->setField('foo', false);
+
+        $this->configureObjectManagerForSimpleEntity();
+
+        $this->hydratorByValue->addStrategy('field', new Asset\SimpleStrategy());
+        $data = $this->hydratorByValue->extract($entity);
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity);
+        $this->assertEquals(array('id' => 2, 'field' => 'modified while extracting'), $data);
+    }
+
+    public function testUsesStrategyOnSimpleFieldsWhenExtractingByReference()
+    {
+        $entity = new Asset\SimpleEntity();
+        $entity->setId(2);
+        $entity->setField('foo', false);
+
+        $this->configureObjectManagerForSimpleEntity();
+
+        $this->hydratorByReference->addStrategy('field', new Asset\SimpleStrategy());
+        $data = $this->hydratorByReference->extract($entity);
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity);
+        $this->assertEquals(array('id' => 2, 'field' => 'modified while extracting'), $data);
+    }
 }


### PR DESCRIPTION
Currently an attached strategy is not called when hydrating simple fields. (It gets called for the extracting part.) This PR fixes it.
