### PR TITLE
call parent hydrateValue for scalar fields

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -250,6 +250,7 @@ class DoctrineObject extends AbstractHydrator
                     continue;
                 }
 
+                $value = $this->hydrateValue($field, $value);
                 $object->$setter($value);
             }
         }


### PR DESCRIPTION
Strategies (e.g. Zend\Stdlib\Hydrator\Strategy\ClosureStrategy) didn't work for scalar fields.
