### PR TITLE
Revert PR #177 - Zend\Mvc now requires Zend\Config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "symfony/console": ">=2.0.13",
         "zendframework/zend-authentication": "2.*",
         "zendframework/zend-cache": "2.*",
-        "zendframework/zend-config": "2.*",
         "zendframework/zend-paginator": "2.*",
         "zendframework/zend-stdlib": "2.*",
         "zendframework/zend-mvc": "2.*",


### PR DESCRIPTION
This can be merged after https://github.com/zendframework/zf2/pull/4216 be merged.
Removes **Zend\Config** dependency since we don't directly depends on it.
