### PR TITLE
New CLI tools do not handle input parameters

### DIFF
--- a/src/DoctrineModule/Component/Console/Input/RequestInput.php
+++ b/src/DoctrineModule/Component/Console/Input/RequestInput.php
@@ -18,7 +18,7 @@
 
 namespace DoctrineModule\Component\Console\Input;
 
-use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Zend\Console\Request;
 
@@ -28,7 +28,7 @@ use Zend\Console\Request;
  * @license MIT
  * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
  */
-class RequestInput extends StringInput
+class RequestInput extends ArgvInput
 {
     /**
      * Constructor
@@ -38,11 +38,13 @@ class RequestInput extends StringInput
      */
     public function __construct(Request $request, InputDefinition $definition = null)
     {
-        $parameters = '';
+        $parameters = array(
+            null,
+        );
 
         foreach ($request->getParams() as $key => $param) {
             if (is_numeric($key)) {
-                $parameters .= $param . ' ';
+                $parameters[] = $param;
             }
         }
 


### PR DESCRIPTION
The new CLI tools added in #226 do not play nicely with parameters passed via the command line:

```
$ php ./public/index.php orm:schema-tool:update --dump-sql --force --complete

  [InvalidArgumentException]
  The "1" argument does not exist.

Exception trace:
 () at .../vendor/symfony/console/Symfony/Component/Console/Input/ArrayInput.php:204
 Symfony\Component\Console\Input\ArrayInput->addArgument() at .../vendor/symfony/console/Symfony/Component/Console/Input/ArrayInput.php:143
 Symfony\Component\Console\Input\ArrayInput->parse() at .../vendor/symfony/console/Symfony/Component/Console/Input/Input.php:60
 Symfony\Component\Console\Input\Input->bind() at .../vendor/symfony/console/Symfony/Component/Console/Command/Command.php:226
 Symfony\Component\Console\Command\Command->run() at .../vendor/symfony/console/Symfony/Component/Console/Application.php:882
 Symfony\Component\Console\Application->doRunCommand() at .../vendor/symfony/console/Symfony/Component/Console/Application.php:212
 Symfony\Component\Console\Application->doRun() at .../vendor/symfony/console/Symfony/Component/Console/Application.php:119
 Symfony\Component\Console\Application->run() at .../vendor/doctrine/doctrine-module/src/DoctrineModule/Controller/CliController.php:51
 DoctrineModule\Controller\CliController->cliAction() at .../vendor/zendframework/zendframework/library/Zend/Mvc/Controller/AbstractActionController.php:83
 [...]

orm:schema-tool:update [--complete] [--dump-sql] [--force]
```

The problem is that `ArrayInput` expects parameters to be in `["--key" => "value", ...]` format but `ConsoleRequest` contains unparsed parameters in the format `["--key=value", ...]`.

This patch fixes the issue by replacing `ArrayInput` with `StringInput` so that the parameters are correctly (re-) parsed by Symfony.

```
$ php ./public/index.php orm:schema-tool:update --dump-sql --force --complete
Nothing to update - your database is already in sync with the current entity metadata.
```
