### PR TITLE
Use the local variable findMethod in loadObjects

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -322,7 +322,7 @@ class Proxy implements ObjectManagerAwareInterface
         if (!$findMethod) {
             $this->objects = $this->objectManager->getRepository($this->targetClass)->findAll();
         } else {
-            if (!isset($this->findMethod['name'])) {
+            if (!isset($findMethod['name'])) {
                 throw new RuntimeException('No method name was set');
             }
             $findMethodName   = $findMethod['name'];


### PR DESCRIPTION
- Since $findMethod already holds the $this->findMethod array, might as
  well use the local copy.
