### PR TITLE
Recusrive call of getValue() -> if the Entity does not hold the identifi...

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -301,6 +301,11 @@ class Proxy implements ObjectManagerAwareInterface
                 }
             }
         }
+        
+        //When an entity does not hold directly the identifier, this function has to be recursive!
+        if(is_object($value)){
+            $value = $this->getValue();
+        }
 
         return $value;
     }


### PR DESCRIPTION
...er directly

Example is:
Address <-> User (and the Address has the identity)

If you now make an ObjectSelect of User for another entity, currently an error will be raised.

With this fix everything is fine again :-)