### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8.x-dev"
+            "dev-master": "0.8.x-dev",
+            "dev-1.0.x" : "1.0.x-dev"
         }
     },
     "bin": [


### PR DESCRIPTION
If I understand this http://getcomposer.org/doc/articles/aliases.md correctly, this should now be possible: ?

`require: { "doctrine/doctrine-module": "1.0.*"}`
