### PR TITLE
Adding ZF2 Skeleton Autoloader to CLI Tool

### DIFF
--- a/bin/doctrine-module.php
+++ b/bin/doctrine-module.php
@@ -39,7 +39,10 @@ while (!file_exists('config/application.config.php')) {
     chdir($dir);
 }
 
-if (!(@include_once __DIR__ . '/../vendor/autoload.php') && !(@include_once __DIR__ . '/../../../autoload.php')) {
+if (!(@include_once __DIR__ . '/../../../../init_autoloader.php')
+    && !(@include_once __DIR__ . '/../vendor/autoload.php')
+    && !(@include_once __DIR__ . '/../../../autoload.php')
+) {
     throw new RuntimeException('Error: vendor/autoload.php could not be found. Did you run php composer.phar install?');
 }
 


### PR DESCRIPTION
Currently the CLI tool assumes that you installed ZF2 through composer.  This may not always be the case.  Some installs can be done via Zend Server, Pyrus, or Manually.

To get around that I added the ZF2 Skeleton apps autoloader to the autoload include stack.  This way if found it will use the ZF2's autoloader definition and should take care of the above issues.

Comments Welcome

Thanks,
Westin
