### PR TITLE
Create new objects as required during hydration.

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -360,8 +360,9 @@ class DoctrineObject extends AbstractHydrator
                 $value,
                 array_flip($metadata->getIdentifier())
             );
-            $object = $this->find($identifiers, $target) ?: new $target;
-            return $this->hydrate($value, $object);
+            $object   = $this->find($identifiers, $target) ?: new $target;
+            $hydrator = new $this($this->objectManager, $this->byValue);
+            return $hydrator->hydrate($value, $object);
         }
 
         return $this->find($value, $target);
@@ -392,6 +393,7 @@ class DoctrineObject extends AbstractHydrator
         $metadata   = $this->objectManager->getClassMetadata($target);
         $identifier = $metadata->getIdentifier();
         $idkeys     = array_flip($identifier);
+        $hydrator   = null;
 
 
         // If the collection contains identifiers, fetch the objects from database
@@ -400,7 +402,8 @@ class DoctrineObject extends AbstractHydrator
                 // $value is most likely an array of fieldset data
                 $identifiers  = array_intersect_key($value, $idkeys);
                 $item         = $this->find($identifiers, $target) ?: new $target;
-                $collection[] = $this->hydrate($value, $item);
+                $hydrator     = $hydrator ?: new $this($this->objectManager, $this->byValue);
+                $collection[] = $hydrator->hydrate($value, $item);
             } else {
                 $collection[] = $this->find($value, $target);
             }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -576,6 +576,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
 
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
         $this->hydratorByValue     = new DoctrineObjectHydrator(
             $this->objectManager,
             true
@@ -666,6 +672,114 @@ class DoctrineObjectTest extends BaseTestCase
             ->expects($this->any())
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
+        $this->hydratorByValue     = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
+    public function configureObjectManagerForOneToManyNewArrayEntity()
+    {
+        $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyArrayEntity');
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(array('id')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue(array('entities')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities'), $this->equalTo('field')))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        switch ($arg) {
+                            case 'id':
+                                return 'integer';
+                            case 'entities':
+                                return 'Doctrine\Common\Collections\ArrayCollection';
+                            case 'field':
+                                return 'string';
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities'), $this->equalTo('field')))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        switch ($arg) {
+                            case 'id':
+                            case 'field':
+                                return false;
+                            case 'entities':
+                                return true;
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('isSingleValuedAssociation')
+            ->with('entities')
+            ->will($this->returnValue(false));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('isCollectionValuedAssociation')
+            ->with('entities')
+            ->will($this->returnValue(true));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationTargetClass')
+            ->with('entities')
+            ->will($this->returnValue('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity'));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
 
         $this->hydratorByValue     = new DoctrineObjectHydrator(
             $this->objectManager,
@@ -987,6 +1101,53 @@ class DoctrineObjectTest extends BaseTestCase
             'From getter: Modified from setToOne setter',
             $entityInDatabaseWithIdOfOne->getField()
         );
+    }
+
+    public function testHydrateOneToOneAssociationByValueUsingFullArrayForNewRelation()
+    {
+        $entity = new Asset\OneToOneEntityNotNullable;
+        $this->configureObjectManagerForOneToOneEntityNotNullable();
+
+        // Use new entity as relation
+        $data = array('toOne' => array('id' => null, 'field' => 'foo'));
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf(
+            'DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToOneEntityNotNullable',
+            $entity
+        );
+        $this->assertInstanceOf(
+            'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
+            $entity->getToOne(false)
+        );
+        // Checks that a new entity was created
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity->getToOne(false));
+    }
+
+    public function testHydrateOneToManyAssociationByValueUsingFullArrayForNewRelation()
+    {
+        $entity = new Asset\OneToManyEntity;
+        $this->configureObjectManagerForOneToManyNewArrayEntity();
+
+        // Use new entity as relation
+        $data = array('entities' => array(array('id' => null, 'field' => 'foo')));
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf(
+            'DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntity',
+            $entity
+        );
+        $children = $entity->getEntities();
+        $this->assertEquals(1, count($children));
+        $child = $children->first();
+        $this->assertInstanceOf(
+            'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
+            $child
+        );
+        // Checks that a new entity was created
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $child);
     }
 
     public function testHydrateOneToOneAssociationByReferenceUsingIdentifierArrayForRelation()


### PR DESCRIPTION
This patch allows the hydrator to create new entities as required during
inflation, if an existing entity cannot be found and there is data where
it expects to be, e.g. instead of

```php
<?php
$new = new Entity;
$new->setFoo('bar');
$data = array(
    'entities' => array($new)
);
$hydrator->hydrate($data, $entity);
?>
```

it is instead possible to do

```php
<?php
$data = array(
    'entities' => array('foo' => 'bar')
);
$hydrator->hydrate($data, $entity);
?>
```
