### PR TITLE
Adds support for Zend Hydrator Filters in the DoctrineObject Hydrator.

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -171,9 +171,15 @@ class DoctrineObject extends AbstractHydrator
     {
         $fieldNames = array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
         $methods    = get_class_methods($object);
+        $filter     = $object instanceof FilterProviderInterface
+            ? $object->getFilter()
+            : $this->filterComposite;
 
         $data = array();
         foreach ($fieldNames as $fieldName) {
+            if ($filter && !$filter->filter($fieldName)) {
+                continue;
+            }
             $getter = 'get' . ucfirst($fieldName);
             $isser  = 'is' . ucfirst($fieldName);
 
@@ -200,9 +206,15 @@ class DoctrineObject extends AbstractHydrator
     {
         $fieldNames = array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
         $refl       = $this->metadata->getReflectionClass();
+        $filter     = $object instanceof FilterProviderInterface
+            ? $object->getFilter()
+            : $this->filterComposite;
 
         $data = array();
         foreach ($fieldNames as $fieldName) {
+            if ($filter && !$filter->filter($fieldName)) {
+                continue;
+            }
             $reflProperty = $refl->getProperty($fieldName);
             $reflProperty->setAccessible(true);
 

--- a/src/DoctrineModule/Stdlib/Hydrator/Filter/PropertyName.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Filter/PropertyName.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Filter;
+
+use Zend\Stdlib\Hydrator\Filter\FilterInterface;
+
+/**
+ * Provides a filter to restrict returned fields by whitelisting or
+ * blacklisting property names.
+ *
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class PropertyName implements FilterInterface
+{
+    /**
+     * The propteries to exclude.
+     *
+     * @var array
+     */
+    protected $properties = array();
+
+    /**
+     * Either an exclude or an include.
+     *
+     * @var bool
+     */
+    protected $exclude = null;
+
+    /**
+     * @param [ string | array ] $properties The properties to exclude or include.
+     * @param bool               $exclude    If the method should be excluded
+     */
+    public function __construct($properties, $exclude = true)
+    {
+        $this->exclude    = $exclude;
+        $this->properties = is_array($properties)
+            ? $properties
+            : array($properties);
+    }
+
+    public function filter($property)
+    {
+        return in_array($property, $this->properties)
+            ? !$this->exclude
+            : $this->exclude;
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -8,6 +8,7 @@ use ReflectionClass;
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineObjectHydrator;
 use DoctrineModule\Stdlib\Hydrator\Strategy;
+use DoctrineModule\Stdlib\Hydrator\Filter;
 
 class DoctrineObjectTest extends BaseTestCase
 {
@@ -1930,5 +1931,39 @@ class DoctrineObjectTest extends BaseTestCase
         $data = $this->hydratorByValue->extract($entity);
         $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleIsEntity', $entity);
         $this->assertEquals(array('id' => 2, 'done' => true), $data);
+    }
+
+    public function testExtractWithPropertyNameFilterByValue()
+    {
+        $entity = new Asset\SimpleEntity();
+        $entity->setId(2);
+        $entity->setField('foo', false);
+
+        $filter = new Filter\PropertyName(array('id'), false);
+
+        $this->configureObjectManagerForSimpleEntity();
+
+        $this->hydratorByValue->addFilter('propertyname', $filter);
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals(array('id'), array_keys($data), 'Only the "id" field should have been extracted.');
+    }
+
+    public function testExtractWithPropertyNameFilterByReference()
+    {
+        $entity = new Asset\SimpleEntity();
+        $entity->setId(2);
+        $entity->setField('foo', false);
+
+        $filter = new Filter\PropertyName(array('id'), false);
+
+        $this->configureObjectManagerForSimpleEntity();
+
+        $this->hydratorByReference->addFilter('propertyname', $filter);
+        $data = $this->hydratorByReference->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals(array('id'), array_keys($data), 'Only the "id" field should have been extracted.');
     }
 }


### PR DESCRIPTION
Zend Hydrators normally support [filters](http://zf2.readthedocs.org/en/latest/modules/zend.stdlib.hydrator.filter.html) to modify the results returned.  This patch adds checks for filters on a property name basis back into the hydrator.

A sample filter is also included, which implements simple whitelisting and blacklisting of property names.

Tests are included applying this filter during extract by reference and extract by value.
