### PR TITLE
Adds strategies for handling associations during extraction.

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/AbstractExtractObjectStrategy.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/AbstractExtractObjectStrategy.php
@@ -1,0 +1,174 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Strategy;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Provides a base implementation for extraction strategies which rely
+ * on Doctrine's metadata to process entities.
+ * 
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+abstract class AbstractExtractObjectStrategy extends AbstractCollectionStrategy
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * All object strategies require an object manager.
+     *
+     * @param ObjectManager $objectManager
+     */
+    public function __construct(ObjectManager $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Process any object values; no object values are untouched.
+     *
+     * @return mixed
+     */
+    public function extract($value)
+    {
+        if (!is_object($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Collection) {
+            return $this->extractCollection($value);
+        } else {
+            return $this->extractObject($value);
+        }
+    }
+
+    /**
+     * Process a Collection value.
+     *
+     * @param Collection $collection
+     *
+     * @return array
+     */
+    abstract protected function extractCollection(Collection $collection);
+
+    /**
+     * Process an single object value.
+     *
+     * @param mixed $object
+     *
+     * @return mixed
+     */
+    abstract protected function extractObject($object);
+
+    /**
+     * Get the identifier for the provided object.
+     *
+     * Children must implement this to choose between getting values by
+     * reference or by value.  Concrete implementations for each strategy
+     * are provided in {@link getIdentifierByValue()} and
+     * {@link getIdentifierByReference()}.
+     *
+     * @param mixed         $object
+     * @param ClassMetadata $identifiers
+     *
+     * @return mixed
+     */
+    abstract protected function getIdentifier($object, $metadata);
+
+    /**
+     * Get the metadata for an object.
+     *
+     * @param [ object | string ] $object The object to get metadata for, or
+     *                                    the class name.
+     *
+     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     */
+    protected function getMetadata($object)
+    {
+        return $this->objectManager->getClassMetadata(
+            is_object($object) ? get_class($object) : $object
+        );
+    }
+
+    /**
+     * No action is taken on hydration.
+     *
+     * @return mixed
+     */
+    public function hydrate($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Get the ID from an object by value.
+     *
+     * @param mixed         $object
+     * @param ClassMetadata $identifiers
+     *
+     * @return mixed
+     */
+    protected function getIdentifierByValue($object, $metadata)
+    {
+        $values      = array();
+        $identifiers = $metadata->getIdentifier();
+
+        foreach ($identifiers as $fieldName) {
+            $getter   = 'get' . ucfirst($fieldName);
+            $values[] = $object->$getter();
+        }
+
+        return count($values) == 1
+            ? current($values)
+            : $values;
+    }
+
+    /**
+     * Get the ID from an object by reference.
+     *
+     * @param mixed         $object
+     * @param ClassMetadata $identifiers
+     *
+     * @return mixed
+     */
+    protected function getIdentifierByReference($object, $metadata)
+    {
+        $values      = array();
+        $refl        = new \ReflectionClass($object);
+        $identifiers = $metadata->getIdentifier();
+
+        foreach ($identifiers as $fieldName) {
+            $reflProperty = $refl->getProperty($fieldName);
+            $reflProperty->setAccessible(true);
+
+            $values[] = $reflProperty->getValue($object);
+        }
+
+        return count($values) == 1
+            ? current($values)
+            : $values;
+    }
+}

--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractIdByReference.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractIdByReference.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Strategy;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Implements a strategy that only extracts the ID fields of entities
+ * in collections.
+ * 
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class ExtractIdByReference extends ExtractIdByValue
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifier($object, $metadata)
+    {
+        return $this->getIdentifierByReference($object, $metadata);
+    }
+}

--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractIdByValue.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractIdByValue.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Strategy;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Implements a strategy that only extracts the ID fields of entities
+ * in collections.
+ * 
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class ExtractIdByValue extends AbstractExtractObjectStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifier($object, $metadata)
+    {
+        return $this->getIdentifierByValue($object, $metadata);
+    }
+
+    /**
+     * Handle a single object.
+     */
+    protected function extractObject($object)
+    {
+        $metadata = $this->getMetadata($object);
+
+        return $this->getIdentifier($object, $metadata);
+    }
+
+    /**
+     * Handle a set of entities.
+     */
+    protected function extractCollection(Collection $collection)
+    {
+        if ($collection->isEmpty()) {
+            return [];
+        }
+
+        $results  = [];
+        $object   = $collection->first();
+        $metadata = $this->getMetadata($object);
+
+        foreach ($collection as $object) {
+            $results[] = $this->getIdentifier($object, $metadata);
+        }
+
+        return $results;
+    }
+}

--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractRecursiveByReference.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractRecursiveByReference.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Strategy;
+
+use Doctrine\Common\Collections\Collection;
+use Zend\Stdlib\Hydrator\Strategy\StrategyInterface;
+
+/**
+ * Implements a strategy that recursively extracts any other entities
+ * in collections.
+ * 
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class ExtractRecursiveByReference extends ExtractRecursiveByValue
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifier($object, $metadata)
+    {
+        return $this->getIdentifierByReference($object, $metadata);
+    }
+}

--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractRecursiveByValue.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/ExtractRecursiveByValue.php
@@ -1,0 +1,204 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator\Strategy;
+
+use Doctrine\Common\Collections\Collection;
+use Zend\Stdlib\Hydrator\Strategy\StrategyInterface;
+
+/**
+ * Implements a strategy that recursively extracts any other entities
+ * in collections.
+ * 
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Liam O'Boyle <liam@ontheroad.net.nz>
+ */
+class ExtractRecursiveByValue extends AbstractExtractObjectStrategy
+{
+    /**
+     * Stores a hash of each object seen to be used for loop detection.
+     *
+     * @var array
+     */
+    protected $entitiesSeen = [];
+
+    /**
+     * A strategy to apply after the first level of recursion, as a
+     * way to sensibly limit recursion for common cases (e.g. by
+     * specifying ExtractId as a fallback strategy, any further
+     * recursion is halted and only ids are returned).
+     *
+     * @var StrategyInterface
+     */
+    protected $fallback;
+
+    /**
+     * The class of hydrator to use for recursively hydrating.
+     *
+     * @var string
+     */
+    protected $hydratorClass = 'DoctrineModule\Stdlib\Hydrator\DoctrineObject';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifier($object, $metadata)
+    {
+        return $this->getIdentifierByValue($object, $metadata);
+    }
+
+    /**
+     * Get the fallback strategy for use after the first recursion.
+     *
+     * @return StrategyInterface
+     */
+    public function getFallback()
+    {
+        return $this->fallback ?: $this;
+    }
+
+    /**
+     * Set the fallback strategy.
+     *
+     * @param StrategyInterface $fallback
+     *
+     * @return ExtractRecursiveByValue $this
+     */
+    public function setFallback(StrategyInterface $fallback)
+    {
+        $this->fallback = $fallback;
+
+        return $this;
+    }
+
+    /**
+     * Get the hydrator class.
+     *
+     * @return string
+     */
+    public function getHydratorClass()
+    {
+        return $this->hydratorClass;
+    }
+
+    /**
+     * Set the hydrator class.
+     *
+     * @param string $class
+     *
+     * @return ExtractRecursiveByValue $this
+     */
+    public function setHydratorClass($class)
+    {
+        $this->hydratorClass = $class;
+
+        return $this;
+    }
+
+    /**
+     * Get a hydrator for the next level.
+     *
+     * @param mixed $object
+     *
+     * @return Hydrator
+     */
+    protected function getHydrator($object)
+    {
+        $metadata    = $this->getMetadata($object);
+        $identifiers = $metadata->getIdentifier();
+        $class       = $this->hydratorClass;
+        $hydrator    = new $class($this->objectManager, get_class($object));
+
+        // Add a strategy to all association fields
+        $fallback = $this->getFallback();
+        foreach ($metadata->getAssociationNames() as $field) {
+            $hydrator->addStrategy($field, $fallback);
+        }
+
+        return $hydrator;
+    }
+
+    /**
+     * Check if an object has been seen before, to avoid loops.
+     *
+     * @param mixed $object
+     *
+     * @return boolean
+     */
+    protected function hasSeen($object)
+    {
+        return in_array(spl_object_hash($object), $this->entitiesSeen);
+    }
+
+    /**
+     * Record an object sighting, to avoid loops.
+     *
+     * @param mixed $object
+     *
+     * @return ExtractRecursiveByValue $this
+     */
+    protected function saw($object)
+    {
+        $this->entitiesSeen[] = spl_object_hash($object);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function extractObject($object)
+    {
+        if ($this->hasSeen($object)) {
+            return $this->getIdentifier($object);
+        } else {
+            $this->saw($object);
+
+            return $this->getHydrator($object)->extract($object);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function extractCollection(Collection $collection)
+    {
+        if ($collection->isEmpty()) {
+            return [];
+        }
+
+        $results     = [];
+        $object      = $collection->first();
+        $hydrator    = $this->getHydrator($object);
+        $metadata    = $this->getMetadata($object);
+        $identifiers = $metadata->getIdentifier();
+
+        foreach ($collection as $object) {
+            if ($this->hasSeen($object)) {
+                $results[] = $this->getIdentifier($object, $identifiers);
+            } else {
+                $this->saw($object);
+                $results[] = $hydrator->extract($object);
+            }
+        }
+
+        return $results;
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -1931,4 +1931,213 @@ class DoctrineObjectTest extends BaseTestCase
         $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleIsEntity', $entity);
         $this->assertEquals(array('id' => 2, 'done' => true), $data);
     }
+
+    public function testExtractOneToOneAssociationByValueWithOnlyId()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toOne = new Asset\SimpleEntity();
+        $toOne->setId(3);
+        $toOne->setField('foo', false);
+
+        $entity = new Asset\OneToOneEntity();
+        $entity->setId(2);
+        $entity->setToOne($toOne);
+
+        $this->configureObjectManagerForOneToOneEntity();
+
+        $this->hydratorByValue->addStrategy('toOne', new Strategy\ExtractIdByValue($this->objectManager)); 
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals($toOne->getId(), $data['toOne']);
+    }
+
+    public function testExtractOneToOneAssociationByReferenceWithOnlyId()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toOne = new Asset\SimpleEntity();
+        $toOne->setId(3);
+        $toOne->setField('foo', false);
+
+        $entity = new Asset\OneToOneEntity();
+        $entity->setId(2);
+        $entity->setToOne($toOne);
+
+        $this->configureObjectManagerForOneToOneEntity();
+
+        $this->hydratorByValue->addStrategy('toOne', new Strategy\ExtractIdByReference($this->objectManager)); 
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals($toOne->getId(), $data['toOne']);
+    }
+
+    public function testExtractOneToManyAssociationByValueWithOnlyId()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toMany1 = new Asset\SimpleEntity();
+        $toMany1->setId(2);
+        $toMany1->setField('foo', false);
+
+        $toMany2 = new Asset\SimpleEntity();
+        $toMany2->setId(3);
+        $toMany2->setField('bar', false);
+
+        $collection = new ArrayCollection(array($toMany1, $toMany2));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
+        $entity = new Asset\OneToManyEntity();
+        $entity->setId(4);
+        $entity->addEntities($collection);
+
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this->hydratorByValue->addStrategy('entities', new Strategy\ExtractIdByValue($this->objectManager)); 
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(4, $data['id']);
+        $this->assertEquals(array(2, 3), $data['entities']);
+    }
+
+    public function testExtractOneToManyAssociationByReferenceWithOnlyId()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toMany1 = new Asset\SimpleEntity();
+        $toMany1->setId(2);
+        $toMany1->setField('foo', false);
+
+        $toMany2 = new Asset\SimpleEntity();
+        $toMany2->setId(3);
+        $toMany2->setField('bar', false);
+
+        $collection = new ArrayCollection(array($toMany1, $toMany2));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
+        $entity = new Asset\OneToManyEntity();
+        $entity->setId(4);
+        $entity->addEntities($collection);
+
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this->hydratorByReference->addStrategy('entities', new Strategy\ExtractIdByReference($this->objectManager)); 
+        $data = $this->hydratorByReference->extract($entity);
+
+        $this->assertEquals(4, $data['id']);
+        $this->assertEquals(array(2, 3), $data['entities']);
+    }
+
+    public function testExtractOneToOneAssociationByValueWithRecursion()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toOne = new Asset\SimpleEntity();
+        $toOne->setId(3);
+        $toOne->setField('foo', false);
+
+        $entity = new Asset\OneToOneEntity();
+        $entity->setId(2);
+        $entity->setToOne($toOne);
+
+        $this->configureObjectManagerForOneToOneEntity();
+
+        $this->hydratorByValue->addStrategy('toOne', new Strategy\ExtractRecursiveByValue($this->objectManager)); 
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals($toOne->getId(), $data['toOne']['id']);
+    }
+
+    public function testExtractOneToOneAssociationByReferenceWithRecursion()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toOne = new Asset\SimpleEntity();
+        $toOne->setId(3);
+        $toOne->setField('foo', false);
+
+        $entity = new Asset\OneToOneEntity();
+        $entity->setId(2);
+        $entity->setToOne($toOne);
+
+        $this->configureObjectManagerForOneToOneEntity();
+
+        $this->hydratorByReference->addStrategy('toOne', new Strategy\ExtractRecursiveByReference($this->objectManager)); 
+        $data = $this->hydratorByReference->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertEquals($toOne->getId(), $data['toOne']['id']);
+    }
+
+    public function testExtractOneToManyAssociationByValueWithRecursion()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toMany1 = new Asset\SimpleEntity();
+        $toMany1->setId(2);
+        $toMany1->setField('foo', false);
+
+        $toMany2 = new Asset\SimpleEntity();
+        $toMany2->setId(3);
+        $toMany2->setField('bar', false);
+
+        $collection = new ArrayCollection(array($toMany1, $toMany2));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
+        $entity = new Asset\OneToManyEntity();
+        $entity->setId(4);
+        $entity->addEntities($collection);
+
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this->hydratorByValue->addStrategy('entities', new Strategy\ExtractRecursiveByValue($this->objectManager)); 
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(4, $data['id']);
+        $this->assertEquals(array(array('id' => 2), array('id' => 3)), $data['entities']);
+    }
+
+    public function testExtractOneToManyAssociationByReferenceWithRecursion()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $toMany1 = new Asset\SimpleEntity();
+        $toMany1->setId(2);
+        $toMany1->setField('foo', false);
+
+        $toMany2 = new Asset\SimpleEntity();
+        $toMany2->setId(3);
+        $toMany2->setField('bar', false);
+
+        $collection = new ArrayCollection(array($toMany1, $toMany2));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array('id')));
+
+        $entity = new Asset\OneToManyEntity();
+        $entity->setId(4);
+        $entity->addEntities($collection);
+
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this->hydratorByReference->addStrategy('entities', new Strategy\ExtractRecursiveByReference($this->objectManager)); 
+        $data = $this->hydratorByReference->extract($entity);
+
+        $this->assertEquals(4, $data['id']);
+        $this->assertEquals(array(array('id' => 2), array('id' => 3)), $data['entities']);
+    }
+
 }


### PR DESCRIPTION
The default result of extraction is to leave embedded collections or entities.  In many situations, the desired behaviour is to perform an extraction on the related entities as well.

Two strategies are added to handle this situation (each with byValue and byReference implementations).

* ExtractId returns only the identifier of any associated entities, or an array of identifiers for a collection.
* ExtractRecursive creates new hydrators and extracts any associated entities that it finds.  Infinite recursion (in the case of loops) is prevented by one of two strategies, either by providing a "fallback" strategy (which is used after the first level of recursion) which terminates (e.g. the ExtractId above), or by automatic loop detection, which ensures that the same entity is not processed more than once.