### PR TITLE
Ensure that tryConvertArrayToObject returns an object.

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -335,7 +335,7 @@ class DoctrineObject extends AbstractHydrator
             $identifierValues[$identifierName] = $data[$identifierName];
         }
 
-        return $this->find($identifierValues, $metadata->getName());
+        return $this->find($identifierValues, $metadata->getName()) ?: $object;
     }
 
     /**


### PR DESCRIPTION
If an ID value is passed which is not found, previously no object would be returned, eventually causing the hydration to return a null instead of an object.

One situation in which this is likely to occur is when an external ID is used as a primary key; in this case, the generator is NONE, but because the id value is provided externally it is passed into the inflation. For new entities, this will not be found, so null is returned and hydration fails.

I'm not completely sure of the implications of this; tests pass, but are there some situations out there where returning an object here instead of null will break things?  Should there be an additional check here to only permit this if the generators for all identifiers are all NONE?