### PR TITLE
Set include project loader instead of include only composer autoloader

### DIFF
--- a/bin/doctrine-module.php
+++ b/bin/doctrine-module.php
@@ -39,7 +39,9 @@ while (!file_exists('config/application.config.php')) {
     chdir($dir);
 }
 
-if (!(@include_once __DIR__ . '/../vendor/autoload.php') && !(@include_once __DIR__ . '/../../../autoload.php')) {
+if (is_readable('init_autoloader.php')) {
+    include_once 'init_autoloader.php';
+} elseif (!(@include_once __DIR__ . '/../vendor/autoload.php') && !(@include_once __DIR__ . '/../../../autoload.php')) {
     throw new RuntimeException('Error: vendor/autoload.php could not be found. Did you run php composer.phar install?');
 }
 


### PR DESCRIPTION
composer autoloader load only classes installed by composer. Now there
can be loaded any custom Module, Library or Class required by Project
Application and had not installed by composer.

We should use convention file name to include into any php script that knows how load Classes for WHOLE project, not only vendor packages installed by composer.
