### PR TITLE
#268: ObjectSelect does not set selected value for not lodaded entities

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -23,6 +23,7 @@ use RuntimeException;
 use ReflectionMethod;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\Proxy as PersistenceProxy;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 
 class Proxy implements ObjectManagerAwareInterface
@@ -292,6 +293,10 @@ class Proxy implements ObjectManagerAwareInterface
             } else {
                 $metadata   = $om->getClassMetadata(get_class($value));
                 $identifier = $metadata->getIdentifierFieldNames();
+                
+                if ($value instanceof PersistenceProxy) {
+                    $value->__load();
+                }
 
                 // TODO: handle composite (multiple) identifiers
                 if (count($identifier) > 1) {


### PR DESCRIPTION
I had the same Problem that not loaded entities (for example associated entites) are not loaded in form selects. Therefore editing was a Problem - with this small code change proxy objects are loaded if they are not initialized. I know that this is solved in Doctrine 2.4 - it's a quick fix for People who had to work with Doctrine 2.3.4 :)
