### PR TITLE
Move authentication storage default

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -43,7 +43,7 @@ return array(
             'zenddata' => array(
             ),
         ),
-        
+
         'authentication' => array(
             'adapter' => array(
                 'default' => array(
@@ -57,6 +57,7 @@ return array(
                 'default' => array(
                     'object_manager' => 'doctrine.objectmanager.default',
                     'identity_class' => 'Application\Model\User',
+                    'storage'        => 'DoctrineModule\Authentication\Storage\Session'
                 )
             ),
             'service' => array(

--- a/src/DoctrineModule/Options/Authentication/StorageOptions.php
+++ b/src/DoctrineModule/Options/Authentication/StorageOptions.php
@@ -19,7 +19,6 @@
 
 namespace DoctrineModule\Options\Authentication;
 
-use Zend\Authentication\Storage\Session as SessionStorage;
 use Zend\Authentication\Storage\StorageInterface;
 
 /**
@@ -34,12 +33,12 @@ class StorageOptions extends AbstractAuthenticationOptions
     /**
      * This is the storage instance that the object key will be stored in.
      *
-     * @var \Zend\Authentication\Storage\StorageInterface|string
+     * @var \Zend\Authentication\Storage\StorageInterfac
      */
     protected $storage;
 
     /**
-     * @return \Zend\Authentication\Storage\StorageInterface|string
+     * @return \Zend\Authentication\Storage\StorageInterface
      */
     public function getStorage()
     {
@@ -47,9 +46,9 @@ class StorageOptions extends AbstractAuthenticationOptions
     }
 
     /**
-     * @param \Zend\Authentication\Storage\StorageInterface|string $storage
+     * @param \Zend\Authentication\Storage\StorageInterface $storage
      */
-    public function setStorage($storage)
+    public function setStorage(StorageInterface $storage)
     {
         $this->storage = $storage;
     }

--- a/src/DoctrineModule/Options/Authentication/StorageOptions.php
+++ b/src/DoctrineModule/Options/Authentication/StorageOptions.php
@@ -36,7 +36,7 @@ class StorageOptions extends AbstractAuthenticationOptions
      *
      * @var \Zend\Authentication\Storage\StorageInterface|string
      */
-    protected $storage = 'DoctrineModule\Authentication\Storage\Session';
+    protected $storage;
 
     /**
      * @return \Zend\Authentication\Storage\StorageInterface|string


### PR DESCRIPTION
This makes it behave better with the builder - if no `storage` option is set by the user, the default is still fetched from the sm by the builder.

Also means the config is clearer to end users.

No bc breaks.
