### PR TITLE
Initialize findMethodParams as array

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -326,7 +326,7 @@ class Proxy implements ObjectManagerAwareInterface
                 throw new RuntimeException('No method name was set');
             }
             $findMethodName   = $findMethod['name'];
-            $findMethodParams = isset($findMethod['params']) ? array_change_key_case($findMethod['params']) : null;
+            $findMethodParams = isset($findMethod['params']) ? array_change_key_case($findMethod['params']) : array();
 
             $repository = $this->objectManager->getRepository($this->targetClass);
             if (!method_exists($repository, $findMethodName)) {


### PR DESCRIPTION
Inititialize $findMethodParams as array, otherwise a warning will be thrown by line#345 array_key_exists.
