### PR TITLE
Allow to configure repository method for Authentication identity retrieval

### DIFF
--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -129,10 +129,8 @@ class ObjectRepository extends AbstractAdapter
     public function authenticate()
     {
         $this->setup();
-        $options  = $this->options;
-        $identity = $options
-            ->getObjectRepository()
-            ->findOneBy(array($options->getIdentityProperty() => $this->identity));
+
+        $identity = $this->findIdentityObject();
 
         if (!$identity) {
             $this->authenticationResultInfo['code'] = AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND;
@@ -239,5 +237,20 @@ class ObjectRepository extends AbstractAdapter
             $this->authenticationResultInfo['identity'],
             $this->authenticationResultInfo['messages']
         );
+    }
+
+    /**
+     * @return null|object The found identity object or NULL if it was not found
+     */
+    protected function findIdentityObject()
+    {
+        $repository = $this->options->getObjectRepository();
+        $method     = $this->options->getObjectRepositoryMethod();
+
+        if ($method) {
+            return call_user_func_array(array($repository, $method), array($this->identity));
+        }
+
+        return $repository->findOneBy(array($this->options->getIdentityProperty() => $this->identity));
     }
 }

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -81,6 +81,13 @@ class Authentication extends AbstractOptions
     protected $objectRepository;
 
     /**
+     * A property of the configured object repository that can retrieve an identity object from an identity value
+     *
+     * @var null|string
+     */
+    protected $objectRepositoryMethod;
+
+    /**
      * Entity's class name
      *
      * @var string
@@ -166,6 +173,23 @@ class Authentication extends AbstractOptions
         }
 
         return $this->objectManager->getRepository($this->identityClass);
+    }
+
+    /**
+     * @param null|string $objectRepositoryMethod
+     * @return $this
+     */
+    public function setObjectRepositoryMethod($objectRepositoryMethod)
+    {
+        $this->objectRepositoryMethod = $objectRepositoryMethod;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getObjectRepositoryMethod()
+    {
+        return $this->objectRepositoryMethod;
     }
 
     /**

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -305,4 +305,28 @@ class ObjectRepositoryTest extends BaseTestCase
 
         $this->assertFalse($adapter->authenticate()->isValid());
     }
+
+    public function testWillUseRepositoryMethod()
+    {
+        $entity = new IdentityObject();
+        $entity->setPassword('The123Password');
+
+        $objectRepository = $this->getMock('DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObjectRepository');
+        $objectRepository
+            ->expects($this->once())
+            ->method('findByEmail')
+            ->with($this->equalTo('some@email.com'))
+            ->will($this->returnValue($entity));
+
+        $adapter = new ObjectRepositoryAdapter();
+        $adapter->setOptions(array(
+            'object_repository'         => $objectRepository,
+            'object_repository_method'  => 'findByEmail',
+            'credential_property'       => 'password',
+        ));
+        $adapter->setIdentity('some@email.com');
+        $adapter->setCredential('The123Password');
+
+        $this->assertTrue($adapter->authenticate()->isValid());
+    }
 }

--- a/tests/DoctrineModuleTest/Authentication/Adapter/TestAsset/IdentityObjectRepository.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/TestAsset/IdentityObjectRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DoctrineModuleTest\Authentication\Adapter\TestAsset;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+
+abstract class IdentityObjectRepository implements ObjectRepository
+{
+    abstract public function findByEmail($email);
+} 


### PR DESCRIPTION
This PR adds the `object_repository_method`
 authentication option. When this option is set, the adapter will use this repository method to retrieve the identity object from the identity value.
