### PR TITLE
doWrite() should be public

### DIFF
--- a/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
+++ b/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
@@ -55,7 +55,7 @@ class PropertyOutput extends Output
      * @param string $message
      * @param bool $newline
      */
-    protected function doWrite($message, $newline)
+    public function doWrite($message, $newline)
     {
         $this->message = $message;
     }


### PR DESCRIPTION
When trying to run a console based application:

// Returns nothing
[root@admin public]$ php ~otwebsoft/public/index.php
[root@admin public]$

Checking logs it results in the following:

PHP Fatal error:  Access level to DoctrineModule\Component\Console\Output\PropertyOutput::doWrite() must be public (as in class Symfony\Component\Console\Output\Output) in /vhosts/otwebsoft_worker/vendor/Library/DoctrineModule/src/DoctrineModule/Component/Console/Output/PropertyOutput.php on line 31

When changed to public, all errors are resolved and console is working once again.
