### PR TITLE
Replaced deprecated method

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -74,7 +74,7 @@ class User extends Form
        	));
 
        	$emailInput->getValidatorChain()
-                      ->addValidator($noObjectExistsValidator);
+                      ->attach($noObjectExistsValidator);
 	}
 }
 ```


### PR DESCRIPTION
addValidator() of ZF2 ValidatorChain is deprecated, attach() should be used.
