### PR TITLE
Improvement for backwards compatibility

### DIFF
--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -69,7 +69,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     {
         $matches = array();
 
-        if (! preg_match('/^doctrine\.(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/', $name, $matches)) {
+        if (! preg_match('/^doctrine\.(?P<serviceType>[a-z0-9_]+)\.(?P<serviceName>[a-z0-9_]+)$/', $name, $matches)) {
             return false;
         }
 


### PR DESCRIPTION
?P should be used to speficy a subpattern, is recommended for backwards compatibility as can be seen on official documentation http://www.php.net/manual/pt_BR/function.preg-match.php.
I've spent some time to figure it out...
