### PR TITLE
Added ability for Hydrator to properly cast custom DBAL types.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "require": {
         "php":                                ">=5.3.23",
         "doctrine/common":                    ">=2.4,<2.6-dev",
+        "doctrine/dbal":                      "~2.4",
         "symfony/console":                    "~2.3",
         "zendframework/zend-authentication":  "~2.3",
         "zendframework/zend-cache":           "~2.3",
@@ -45,6 +46,7 @@
     },
     "require-dev": {
         "phpunit/phpunit":             "~3.7",
+        "doctrine/dbal":               "~2.4",
         "squizlabs/php_codesniffer":   "1.5.*",
         "zendframework/zendframework": "~2.3"
     },

--- a/docs/hydrator.md
+++ b/docs/hydrator.md
@@ -787,6 +787,13 @@ echo $data['foo']; // prints 'bar'
 
 It now only prints "bar", which shows clearly that the getter has not been called.
 
+### Custom type conversion
+
+The hydrator understands all the standard database types built into Doctrine and will convert accordingly, but if you are
+using custom types with the DBAL, the hydrator will need to know how to convert from an incoming data value to
+the type your field setter method expects (or property when using 'by reference'). To achieve this conversion your
+custom type class can implement `DoctrineModule\Stdlib\Hydrator\TypeConversionInterface`. Once implemented, `$hydrator->hydrate()`
+will detect your custom type and return a properly casted value.
 
 ### A complete example using Zend\Form
 

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -22,6 +22,7 @@ namespace DoctrineModule\Stdlib\Hydrator;
 use DateTime;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Stdlib\Hydrator\Strategy\AbstractCollectionStrategy;
 use InvalidArgumentException;
 use RuntimeException;
@@ -430,7 +431,9 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * Handle various type conversions that should be supported natively by Doctrine (like DateTime)
+     * Handle various type conversions that should be supported natively by Doctrine (like DateTime).
+     * Custom types can implement Doctrine\DoctrineModule\Stdlib\Hydrator\TypeConversionInterface
+     * to ensure the incoming hydration value is converted to the proper type.
      *
      * @param  mixed  $value
      * @param  string $typeOfField
@@ -438,6 +441,14 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function handleTypeConversions($value, $typeOfField)
     {
+        if (Type::hasType($typeOfField)) {
+            $type = Type::getType($typeOfField);
+
+            if ($type instanceof TypeConversionInterface) {
+                return $type->convertToHydratorValue($value);
+            }
+        }
+
         switch($typeOfField) {
             case 'datetimetz':
             case 'datetime':

--- a/src/DoctrineModule/Stdlib/Hydrator/TypeConversionInterface.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/TypeConversionInterface.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineModule\Stdlib\Hydrator;
+
+/**
+ * This interface can be used with custom Types to ensure that the
+ * proper type is set for the entity property value.
+ *
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @since   0.9.0
+ * @author  Jeff Turcotte <jeff.turcotte@gmail.com>
+ */
+interface TypeConversionInterface
+{
+    /**
+     * Convert the incoming hydration value to a value compatible with the custom type
+     *
+     * @param  mixed $value
+     * @return mixed 
+     */
+    public function convertToHydratorValue($value);
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/FixedArrayType.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/FixedArrayType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Doctrine\DBAL\Types\StringType;
+use DoctrineModule\Stdlib\Hydrator\TypeConversionInterface;
+use SplFixedArray;
+
+class FixedArrayType extends StringType implements TypeConversionInterface
+{
+    public function convertToHydratorValue($value)
+    {
+        return new SplFixedArray(1);
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithCustomType.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithCustomType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use SplFixedArray;
+
+class SimpleEntityWithCustomType
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var SplFixedArray
+     */
+    protected $fixedArray;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setFixedArray(SplFixedArray $fixedArray = null)
+    {
+        $this->fixedArray = $fixedArray;
+    }
+
+    public function getFixedArray()
+    {
+        return $this->fixedArray;
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -6,6 +6,7 @@ use DoctrineModuleTest\Stdlib\Hydrator\Asset\ContextStrategy;
 use PHPUnit_Framework_TestCase as BaseTestCase;
 use ReflectionClass;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineObjectHydrator;
 use DoctrineModule\Stdlib\Hydrator\Strategy;
 use DoctrineModule\Stdlib\Hydrator\Filter;
@@ -233,6 +234,70 @@ class DoctrineObjectTest extends BaseTestCase
             $this->objectManager,
             true
         );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
+    public function configureObjectManagerForSimpleEntityWithCustomType()
+    {
+        $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntityWithCustomType');
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue(array()));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'fixedArray')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('fixedArray')))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        if ($arg === 'id') {
+                            return 'integer';
+                        } elseif ($arg === 'fixedArray') {
+                            return 'fixed_array';
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->will($this->returnValue(false));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->will($this->returnValue(array('id')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this->hydratorByValue = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+
         $this->hydratorByReference = new DoctrineObjectHydrator(
             $this->objectManager,
             false
@@ -1852,6 +1917,20 @@ class DoctrineObjectTest extends BaseTestCase
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
         $this->assertNull($entity->getDate());
+    }
+
+    public function testHandleCustomTypeConversionUsingByValue()
+    {
+        $entity = new Asset\SimpleEntityWithCustomType();
+        $this->configureObjectManagerForSimpleEntityWithCustomType();
+
+        Type::addType('fixed_array', 'DoctrineModuleTest\Stdlib\Hydrator\Asset\FixedArrayType');
+
+        $data = array('fixedArray' => array());
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('SplFixedArray', $entity->getFixedArray());
     }
 
     public function testAssertNullValueHydratedForOneToOneWithOptionalMethodSignature()


### PR DESCRIPTION
This enhancement adds support for proper type conversion during hydration when using custom DBAL types. A custom type would implement `DoctrineModule\Stdlib\Hydrator\TypeConversionInterface` for the conversion to occur.