### PR TITLE
Clarified how to pass sort information.

### DIFF
--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -123,7 +123,12 @@ $this->add(
                 'name'   => 'findBy',
                 'params' => array(
                     'criteria' => array('active' => 1),
+                    
+                    // Use key 'orderBy' if using ORM
                     'orderBy'  => array('lastname' => 'ASC'),
+                    
+                    // Use key 'sort' if using ODM
+                    'sort'  => array('lastname' => 'ASC')
                 ),
             ),
         ),


### PR DESCRIPTION
Keys differ for ORM and MongoODM.

MongoODM findBy method signature now uses sort rather than orderBy
