### PR TITLE
Enhancement: use exit code from run()

### DIFF
--- a/bin/doctrine-module.php
+++ b/bin/doctrine-module.php
@@ -49,4 +49,4 @@ $application = Application::init(include 'config/application.config.php');
 
 /* @var $cli \Symfony\Component\Console\Application */
 $cli = $application->getServiceManager()->get('doctrine.cli');
-$cli->run();
+exit($cli->run());


### PR DESCRIPTION
Necessary to be able to tell if command ran successfully or not.

Can you guys backport this to a release prior to ZF 2.3 as well? Would be helpful.
