### PR TITLE
lifetime for zend cache storage

### DIFF
--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -72,8 +72,19 @@ class ZendStorageCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = false)
     {
-        // @todo check if lifetime can be set
-        return $this->storage->setItem($id, $data);
+        if ($lifeTime) {
+            // TTL is per-storage in Zend\Cache\Storage\StorageInterface
+            $options = $this->storage->getOptions();
+            $oldTtl = $options->getTtl();
+            $options->setTtl($lifeTime);
+            $this->storage->setOptions($options);
+            $result = $this->storage->setItem($key, $value);
+            $options->setTtl($oldTtl);
+            $this->storage->setOptions($options);
+        } else {
+            $result = $this->storage->setItem($id, $data);
+        }
+        return $result;
     }
 
     /**

--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -72,18 +72,21 @@ class ZendStorageCache extends CacheProvider
      */
     protected function doSave($id, $data, $lifeTime = false)
     {
-        if ($lifeTime) {
+        if ($lifeTime !== false) {
             // TTL is per-storage in Zend\Cache\Storage\StorageInterface
             $options = $this->storage->getOptions();
             $oldTtl = $options->getTtl();
             $options->setTtl($lifeTime);
             $this->storage->setOptions($options);
-            $result = $this->storage->setItem($key, $value);
+        }
+
+        $result = $this->storage->setItem($id, $data);
+
+        if ($lifeTime !== false) {
             $options->setTtl($oldTtl);
             $this->storage->setOptions($options);
-        } else {
-            $result = $this->storage->setItem($id, $data);
         }
+
         return $result;
     }
 

--- a/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
+++ b/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
@@ -64,6 +64,15 @@ class ZendStorageCacheTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($cache->fetch('test_object_key') instanceof \ArrayObject);
     }
 
+    public function testTtl()
+    {
+        $cache = $this->getCacheDriver();
+        $cache->save('test_ttl', 'testing ttl', 2);
+        $this->assertTrue($cache->contains('test_ttl'));
+        sleep(4);
+        $this->assertTrue($cache->contains('test_ttl'));
+    }
+
     public function testDeleteAll()
     {
         $cache = $this->getCacheDriver();

--- a/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
+++ b/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
@@ -21,6 +21,7 @@ namespace DoctrineModuleTest\Cache;
 
 use DoctrineModule\Cache\ZendStorageCache;
 use Doctrine\Common\Cache\Cache;
+use Zend\Cache\Storage\Adapter\Memcached;
 use Zend\Cache\Storage\Adapter\Memory;
 use PHPUnit_Framework_TestCase;
 
@@ -66,11 +67,24 @@ class ZendStorageCacheTest extends PHPUnit_Framework_TestCase
 
     public function testTtl()
     {
-        $cache = $this->getCacheDriver();
-        $cache->save('test_ttl', 'testing ttl', 2);
-        $this->assertTrue($cache->contains('test_ttl'));
-        sleep(4);
-        $this->assertTrue($cache->contains('test_ttl'));
+        $zfStorage = new Memory();
+
+        $zfStorage->getOptions()->setTtl(10);
+        $cache = new ZendStorageCache($zfStorage);
+
+        $cache->save('test_ttl1', 'test', 1);
+        $this->assertTrue($cache->contains('test_ttl1'));
+        sleep(3);
+        $this->assertFalse($cache->contains('test_ttl1'));
+
+        $zfStorage = new Memory();
+        $zfStorage->getOptions()->setTtl(2);
+        $cache = new ZendStorageCache($zfStorage);
+
+        $cache->save('test_ttl2', 'test', 2);
+        $this->assertTrue($cache->contains('test_ttl2'));
+        sleep(3);
+        $this->assertFalse($cache->contains('test_ttl2'));
     }
 
     public function testDeleteAll()


### PR DESCRIPTION
After a failure with ZF2, this is a proposal for accepting the `$lifeTime` parameter with `ZendStorageCache`.

You can read [the PRs 6001 and 5386](https://github.com/zendframework/zf2/pull/6001) for the full story :wink: 