### PR TITLE
use FilterProviderInterface

### DIFF
--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleFilter.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Zend\Stdlib\Hydrator\Filter\FilterInterface;
+
+class SimpleFilter implements FilterInterface
+{
+    /**
+     * Should return true, if the given filter
+     * does not match
+     *
+     * @param string $property The name of the property
+     * @return bool
+     */
+    public function filter($property)
+    {
+        return $property !== 'password';
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleFilterProvider.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleFilterProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Zend\Stdlib\Hydrator\Filter\FilterProviderInterface;
+
+class SimpleFilterProvider implements FilterProviderInterface
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setPassword($password)
+    {
+        $this->password = $password;
+    }
+
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    public function getFilter()
+    {
+        return new SimpleFilter();
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -736,6 +736,76 @@ class DoctrineObjectTest extends BaseTestCase
         );
     }
 
+    public function configureObjectManagerForSimpleFilterProvider()
+    {
+        $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleFilterProvider');
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleFilterProvider'));
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue(array()));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'password')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('password')))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        if ('id' === $arg) {
+                            return 'integer';
+                        }
+
+                        if ('password' === $arg) {
+                            return 'string';
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->will($this->returnValue(false));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->will($this->returnValue(array('id')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this->hydratorByValue = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
     public function testObjectIsPassedForContextToStrategies()
     {
         $entity = new Asset\ContextEntity();
@@ -2077,5 +2147,18 @@ class DoctrineObjectTest extends BaseTestCase
         $this->hydratorByValue->setNamingStrategy(new UnderscoreNamingStrategy());
         $entity = $this->hydratorByValue->hydrate(array('camel_case' => $name), new NamingStrategyEntity());
         $this->assertEquals($name, $entity->getCamelCase());
+    }
+
+    public function testExtractWithFilterProvider()
+    {
+        $entity = new Asset\SimpleFilterProvider();
+        $entity->setId(1);
+        $entity->setPassword('secret');
+
+        $this->configureObjectManagerForSimpleFilterProvider();
+
+        $data = $this->hydratorByValue->extract($entity);
+        $this->assertEquals(1, $data['id']);
+        $this->assertEquals(array('id'), array_keys($data), 'Only the "id" field should have been extracted.');
     }
 }


### PR DESCRIPTION
The `FilterProviderInterface` is referenced twice in the `DoctrineObject` class however that class does not exist in the `DoctrineModule\Stdlib\Hydrator` namespace. I'm assuming the `use` statement was omitted accidentally as `instanceof` will not catch nonexistent classes.

This is a duplicate of #408 however I've attempted to add unit tests to help get this in sooner rather than later.
