### PR TITLE
Addition of magic function __set_state

### DIFF
--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -56,4 +56,16 @@ class AdapterFactory extends AbstractFactory
     {
         return 'DoctrineModule\Options\Authentication';
     }
+    
+    /**
+     * {@inheritDoc}
+     * 
+     * @param type $array
+     * @return \DoctrineModule\Service\Authentication\AdapterFactory
+     */
+    public static function __set_state($array)
+    {
+        $name = $array['name'];
+        return new AdapterFactory($name);
+    }
 }

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -52,4 +52,16 @@ class AuthenticationServiceFactory extends AbstractFactory
     {
         throw new \BadMethodCallException('Not implemented');
     }
+    
+    /**
+     * {@inheritDoc}
+     * 
+     * @param type $array
+     * @return \DoctrineModule\Service\Authentication\AuthenticationServiceFactory
+     */
+    public static function __set_state($array)
+    {
+        $name = $array['name'];
+        return new AuthenticationServiceFactory($name);
+    }
 }

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -61,4 +61,16 @@ class StorageFactory extends AbstractFactory
     {
         return 'DoctrineModule\Options\Authentication';
     }
+    
+    /**
+     * {@inheritDoc}
+     * 
+     * @param type $array
+     * @return \DoctrineModule\Service\Authentication\StorageFactory
+     */
+    public static function __set_state($array)
+    {
+        $name = $array['name'];
+        return new StorageFactory($name);
+    }
 }


### PR DESCRIPTION
Zend Framework 2 creates a module config cache when directed through
application.config.php. That file changes the factories section to
instantiate factories through the magic method __set_state. Not having
it causes the cache to fail because the affected classes do not have
this static method.
