### PR TITLE
Hydrator doesn't work for boolean field types that start with "is"

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -182,17 +182,17 @@ class DoctrineObject extends AbstractHydrator
                 continue;
             }
             $getter = 'get' . ucfirst($fieldName);
-            if (substr($fieldName, 0, 2) == 'is' && ctype_upper(substr($fieldName, 2, 1))) {
-                $isser = $fieldName;
-            } else {
-                $isser  = 'is' . ucfirst($fieldName);
-            }
+            $isser  = 'is' . ucfirst($fieldName);
 
             $dataFieldName = $this->computeExtractFieldName($fieldName);
             if (in_array($getter, $methods)) {
                 $data[$dataFieldName] = $this->extractValue($fieldName, $object->$getter(), $object);
             } elseif (in_array($isser, $methods)) {
                 $data[$dataFieldName] = $this->extractValue($fieldName, $object->$isser(), $object);
+            } elseif (substr($fieldName, 0, 2) == 'is' && ctype_upper(substr($fieldName, 2, 1))
+                && in_array($fieldName, $methods)) {
+
+                $data[$dataFieldName] = $this->extractValue($fieldName, $object->$fieldName(), $object);
             }
 
             // Unknown fields are ignored

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithIsBoolean.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithIsBoolean.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
 
-class SimpleIsEntity
+class SimpleEntityWithIsBoolean
 {
     /**
      * @var int
@@ -12,7 +12,7 @@ class SimpleIsEntity
     /**
      * @var bool
      */
-    protected $done;
+    protected $isActive;
 
     public function setId($id)
     {
@@ -24,13 +24,13 @@ class SimpleIsEntity
         return $this->id;
     }
 
-    public function setDone($done)
+    public function setIsActive($isActive)
     {
-        $this->done = (bool) $done;
+        $this->isActive = (bool) $isActive;
     }
 
-    public function isDone()
+    public function isActive()
     {
-        return $this->done;
+        return $this->isActive;
     }
 }


### PR DESCRIPTION
My Doctrine entity has a isApproved method and a setIsApproved method. But my field is also called isApproved and not just approved. Only with the supplied code in this pull request that will work.
