### PR TITLE
find_method: allow also Doctrine\ORM\QueryBuilder

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -27,6 +27,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use Traversable;
 use Zend\Stdlib\Guard\GuardUtils;
+use Doctrine\ORM\QueryBuilder;
 
 class Proxy implements ObjectManagerAwareInterface
 {
@@ -424,6 +425,10 @@ class Proxy implements ObjectManagerAwareInterface
                 }
             }
             $objects = $r->invokeArgs($repository, $args);
+            
+            if($objects instanceof QueryBuilder){
+                $objects = $objects->getQuery()->getResult();
+            }
         }
 
         GuardUtils::guardForArrayOrTraversable(


### PR DESCRIPTION
I likely return the Doctrine\ORM\QueryBuilder from the repo, so i can reuse the query for more use cases...

But DoctrineModule currently wants the result object,with this patch you can return the QueryBuilder 
