### PR TITLE
Added functionality to support custom valueOption attributes

### DIFF
--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -58,7 +58,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @var array
      */
-    protected $attributes = array();
+    protected $option_attributes = array();
 
     /**
      * @var callable $labelGenerator A callable used to create a label based on an item in the collection an Entity
@@ -118,6 +118,10 @@ class Proxy implements ObjectManagerAwareInterface
         if (isset($options['empty_item_label'])) {
             $this->setEmptyItemLabel($options['empty_item_label']);
         }
+
+        if (isset($options['option_attributes'])) {
+            $this->setOptionAttributes($options['option_attributes']);
+        }
     }
 
     public function getValueOptions()
@@ -161,19 +165,19 @@ class Proxy implements ObjectManagerAwareInterface
     }
 
     /**
-     * @return array $attributes
+     * @return array
      */
-    public function getAttributes()
+    public function getOptionAttributes()
     {
-        return $this->attributes;
+        return $this->option_attributes;
     }
 
     /**
-     * @param array $attributes
+     * @param array $option_attributes
      */
-    public function setAttributes(array $attributes)
+    public function setOptionAttributes(array $option_attributes)
     {
-        $this->attributes = $attributes;
+        $this->option_attributes = $option_attributes;
     }
 
     /**
@@ -476,7 +480,7 @@ class Proxy implements ObjectManagerAwareInterface
         $identifier = $metadata->getIdentifierFieldNames();
         $objects    = $this->getObjects();
         $options    = array();
-        $attributes=array();
+        $optionAttributes=array();
 
         if ($this->displayEmptyItem) {
             $options[''] = $this->getEmptyItemLabel();
@@ -524,17 +528,18 @@ class Proxy implements ObjectManagerAwareInterface
                 $value = current($metadata->getIdentifierValues($object));
             }
 
-                foreach($this->getAttributes() as $attribute){
-                    $attributeValue=current($attribute);
-                    if (!is_callable(array($object, $attributeValue))) {
+                foreach($this->getOptionAttributes() as $optionAttribute){
+                    $methodName=current($optionAttribute);
+                    if (!is_callable(array($object, $methodName))) {
+
                         throw new RuntimeException(
-                            sprintf('Method "%s::%s" is not callable', $this->targetClass, $attributeValue)
+                            sprintf('Method "%s::%s" is not callable', $this->targetClass, $methodName)
                         );
                     }
-                    $attributes[key($attribute)] =(string) $object->{$attributeValue}();
+                    $optionAttributes[key($optionAttribute)] =(string) $object->{$methodName}();
                 }
 
-                $options[] = array('label' => $label, 'value' => $value, 'attributes'=>$attributes);
+                $options[] = array('label' => $label, 'value' => $value, 'attributes'=>$optionAttributes);
            
         }
 

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -528,14 +528,14 @@ class Proxy implements ObjectManagerAwareInterface
                 $value = current($metadata->getIdentifierValues($object));
             }
 
-            foreach($this->getOptionAttributes() as $optionAttribute) {
+            foreach ($this->getOptionAttributes() as $optionAttribute) {
                 $methodName=current($optionAttribute);
-                    if (!is_callable(array($object, $methodName))) {
+                if (!is_callable(array($object, $methodName))) {
 
                         throw new RuntimeException(
                             sprintf('Method "%s::%s" is not callable', $this->targetClass, $methodName)
                         );
-                    }
+                }
                     $optionAttributes[key($optionAttribute)] =(string) $object->{$methodName}();
             }
 

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -528,8 +528,8 @@ class Proxy implements ObjectManagerAwareInterface
                 $value = current($metadata->getIdentifierValues($object));
             }
 
-                foreach($this->getOptionAttributes() as $optionAttribute){
-                    $methodName=current($optionAttribute);
+            foreach($this->getOptionAttributes() as $optionAttribute) {
+                $methodName=current($optionAttribute);
                     if (!is_callable(array($object, $methodName))) {
 
                         throw new RuntimeException(
@@ -537,7 +537,7 @@ class Proxy implements ObjectManagerAwareInterface
                         );
                     }
                     $optionAttributes[key($optionAttribute)] =(string) $object->{$methodName}();
-                }
+            }
 
                 $options[] = array('label' => $label, 'value' => $value, 'attributes'=>$optionAttributes);
            

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -45,6 +45,11 @@ class ProxyTest extends PHPUnit_Framework_TestCase
     protected $proxy;
 
     /**
+     * @var array
+     */
+    protected $optionAttributes=array();
+
+    /**
      * {@inheritDoc}.
      */
     protected function setUp()
@@ -295,6 +300,44 @@ class ProxyTest extends PHPUnit_Framework_TestCase
         $this->proxy->setOptions(array('label_generator' => 'I throw an InvalidArgumentException'));
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage No method name was set
+     */
+    public function testExceptionThrownForMissingOptionAttributesMethod()
+    {
+        $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
+        $metadata    = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+    
+        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager->expects($this->once())
+        ->method('getClassMetadata')
+        ->with($this->equalTo($objectClass))
+        ->will($this->returnValue($metadata));
+    
+        $this->proxy->setOptions(
+            array(
+                'object_manager' => $objectManager,
+                'target_class'   => $objectClass,
+                'find_method'    => array('getName'),
+                'option_attributes'    => array(array('data-key'=>'missing_method'))
+            )
+        );
+    
+       $this->proxy->getValueOptions();
+    }
+
+    public function testUsingOptionAttributes()
+    {
+        $this->optionAttributes=array(array('data-key'=>'getFirstname'));
+        $this->prepareProxyWithOptionAttributes();
+
+        $currentValueOption = current($this->proxy->getValueOptions());
+        $this->assertArrayHasKey('attributes', $currentValueOption);
+        $this->assertArrayHasKey('data-key', $currentValueOption['attributes']);
+        $this->assertEquals('object one firstname',$currentValueOption['attributes']['data-key']);
+    }
+
     public function testCanWorkWithEmptyTables()
     {
         $this->prepareEmptyProxy();
@@ -393,7 +436,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
         $this->proxy->setOptions(
             array(
                 'object_manager' => $objectManager,
-                'target_class'   => $objectClass
+                'target_class'   => $objectClass,
             )
         );
 
@@ -471,6 +514,77 @@ class ProxyTest extends PHPUnit_Framework_TestCase
                         'criteria' => array('email' => 'object one email'),
                     ),
                 ),
+            )
+        );
+
+        $this->metadata = $metadata;
+    }
+
+    protected function prepareProxyWithOptionAttributes()
+{
+        $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
+        $objectOne   = new FormObject;
+        $objectTwo   = new FormObject;
+
+        $objectOne->setId(1)
+            ->setUsername('object one username')
+            ->setPassword('object one password')
+            ->setEmail('object one email')
+            ->setFirstname('object one firstname')
+            ->setSurname('object one surname');
+
+        $objectTwo->setId(2)
+            ->setUsername('object two username')
+            ->setPassword('object two password')
+            ->setEmail('object two email')
+            ->setFirstname('object two firstname')
+            ->setSurname('object two surname');
+
+        $result = new ArrayCollection(array($objectOne, $objectTwo));
+
+        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata
+            ->expects($this->any())
+            ->method('getIdentifierValues')
+            ->will(
+                $this->returnCallback(
+                    function () use ($objectOne, $objectTwo) {
+                        $input = func_get_args();
+                        $input = array_shift($input);
+
+                        if ($input == $objectOne) {
+                            return array('id' => 1);
+                        } elseif ($input == $objectTwo) {
+                            return array('id' => 2);
+                        }
+
+                        return array();
+                    }
+                )
+            );
+
+        $objectRepository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository->expects($this->any())
+            ->method('findAll')
+            ->will($this->returnValue($result));
+
+        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager->expects($this->any())
+            ->method('getClassMetadata')
+            ->with($this->equalTo($objectClass))
+            ->will($this->returnValue($metadata));
+
+        $objectManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->with($this->equalTo($objectClass))
+            ->will($this->returnValue($objectRepository));
+
+        $this->proxy->setOptions(
+            array(
+                'object_manager' =>    $objectManager,
+                'target_class'   =>    $objectClass,
+                'option_attributes' => $this->optionAttributes
             )
         );
 

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -324,7 +324,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
             )
         );
     
-       $this->proxy->getValueOptions();
+        $this->proxy->getValueOptions();
     }
 
     public function testUsingOptionAttributes()
@@ -335,7 +335,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
         $currentValueOption = current($this->proxy->getValueOptions());
         $this->assertArrayHasKey('attributes', $currentValueOption);
         $this->assertArrayHasKey('data-key', $currentValueOption['attributes']);
-        $this->assertEquals('object one firstname',$currentValueOption['attributes']['data-key']);
+        $this->assertEquals('object one firstname', $currentValueOption['attributes']['data-key']);
     }
 
     public function testCanWorkWithEmptyTables()
@@ -521,7 +521,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
     }
 
     protected function prepareProxyWithOptionAttributes()
-{
+    {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject;
         $objectTwo   = new FormObject;

--- a/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
@@ -40,7 +40,7 @@ class CollectionAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp ()
+    protected function setUp()
     {
         parent::setUp();
         $this->adapter = new CollectionAdapter(new ArrayCollection(range(1, 101)));


### PR DESCRIPTION
A useful feature with ZF2 form elements that have valueOptions is being able to set custom attributes on each valueOption.
In the following example the custom attribute 'data-key' is set on each valueOption.
```
$select=new \Zend\Form\Element\Select('test');
$select->setValueOptions(
    [
        ['attributes'=>['data-key'=>'value'],'value'=>'myValue','label'=>'myLabel'],
        ['attributes'=>['data-key'=>'value2'],'value'=>'myValue2','label'=>'myLabel2']
    ]

    );

echo $this->formselect($select);
```
the element view helper returns the following HTML:
```
<select name="test">
<option value="myValue" data-key="value">myLabel</option>
<option value="myValue2" data-key="value2">myLabel2</option>
</select>
```
Being able to add these attributes to valueoptions is extremely useful for passing additional values for front-end processing, like adding a boolean value for an objects status, category or timestamp, etc.

DoctrineModule currently only supports label and value attributes for its ObjectSelect feature. This PR includes functionality to define custom attributes using a option_attributes option.

The attributes would be defined using a new  'option_attributes' key :
```
$os->setOptions([
            'object_manager' => $odm,
            'target_class' => '\Entity\SomeEntity',
            'property' => 'name',
            'option_attributes' => [
            [ 'data-type'=>'getType']
            ],
            'find_method' => [
                'name' => 'findAll',
                'params' => []
           ]
        ]);
```
Whereby the key option_attributes accepts an array of key/values, the keys represent valid HTML attributes(these are already filtered in ZF2 Select) they typically include  attributes such as data-, aria-, onEvent, etc. The value (getType in the above code example) is a method which will be called on the object and used for the option attribute value.

```
data-key="value"
```