### PR TITLE
update hydrator with the new available interface/method in doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,12 @@
         "module",
         "zf2"
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/fabiocarneiro/common"
+        }
+    ],
     "authors":     [
         {
             "name": "Kyle Spraggs",
@@ -33,7 +39,7 @@
     "minimum-stability": "dev",
     "require": {
         "php":                                ">=5.3.23",
-        "doctrine/common":                    ">=2.4,<2.6-dev",
+        "doctrine/common":                    "dev-new-interface-for-classmetadata-properties",
         "symfony/console":                    "~2.3",
         "zendframework/zend-authentication":  "~2.3",
         "zendframework/zend-cache":           "~2.3",

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -30,6 +30,7 @@ use Zend\Stdlib\ArrayObject;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator\AbstractHydrator;
 use Zend\Stdlib\Hydrator\Filter\FilterProviderInterface;
+use Doctrine\Common\Persistence\Mapping\PropertyNamesAware;
 
 /**
  * This hydrator has been completely refactored for DoctrineModule 0.7.0. It provides an easy and powerful way
@@ -161,6 +162,20 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
+     * Retrieve the field names from metadata
+     *
+     * @return array
+     */
+    protected function getFieldnames()
+    {
+        if ($this->metadata instanceof PropertyNamesAware) {
+            return $this->metadata->getMappedPropertyNames();
+        }
+
+        return array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
+    }
+
+    /**
      * Extract values from an object using a by-value logic (this means that it uses the entity
      * API, in this case, getters)
      *
@@ -170,7 +185,7 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByValue($object)
     {
-        $fieldNames = array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
+        $fieldNames = $this->getFieldnames();
         $methods    = get_class_methods($object);
         $filter     = $object instanceof FilterProviderInterface
             ? $object->getFilter()
@@ -211,7 +226,7 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByReference($object)
     {
-        $fieldNames = array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
+        $fieldNames = $this->getFieldnames();
         $refl       = $this->metadata->getReflectionClass();
         $filter     = $object instanceof FilterProviderInterface
             ? $object->getFilter()

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -162,11 +162,11 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * Retrieve the field names from metadata
+     * Retrieve the mapped property names from metadata
      *
      * @return array
      */
-    protected function getFieldnames()
+    protected function getMappedPropertyNames()
     {
         if ($this->metadata instanceof PropertyNamesAware) {
             return $this->metadata->getMappedPropertyNames();
@@ -185,30 +185,30 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByValue($object)
     {
-        $fieldNames = $this->getFieldnames();
+        $propertyNames = $this->getMappedPropertyNames();
         $methods    = get_class_methods($object);
         $filter     = $object instanceof FilterProviderInterface
             ? $object->getFilter()
             : $this->filterComposite;
 
         $data = array();
-        foreach ($fieldNames as $fieldName) {
-            if ($filter && !$filter->filter($fieldName)) {
+        foreach ($propertyNames as $propertyName) {
+            if ($filter && !$filter->filter($propertyName)) {
                 continue;
             }
-            $getter = 'get' . ucfirst($fieldName);
-            $isser  = 'is' . ucfirst($fieldName);
+            $getter = 'get' . ucfirst($propertyName);
+            $isser  = 'is' . ucfirst($propertyName);
 
-            $dataFieldName = $this->computeExtractFieldName($fieldName);
+            $dataFieldName = $this->computeExtractFieldName($propertyName);
             if (in_array($getter, $methods)) {
-                $data[$dataFieldName] = $this->extractValue($fieldName, $object->$getter(), $object);
+                $data[$dataFieldName] = $this->extractValue($propertyName, $object->$getter(), $object);
             } elseif (in_array($isser, $methods)) {
-                $data[$dataFieldName] = $this->extractValue($fieldName, $object->$isser(), $object);
-            } elseif (substr($fieldName, 0, 2) === 'is'
-                && ctype_upper(substr($fieldName, 2, 1))
-                && in_array($fieldName, $methods)) {
+                $data[$dataFieldName] = $this->extractValue($propertyName, $object->$isser(), $object);
+            } elseif (substr($propertyName, 0, 2) === 'is'
+                && ctype_upper(substr($propertyName, 2, 1))
+                && in_array($propertyName, $methods)) {
 
-                $data[$dataFieldName] = $this->extractValue($fieldName, $object->$fieldName(), $object);
+                $data[$dataFieldName] = $this->extractValue($propertyName, $object->$propertyName(), $object);
             }
 
             // Unknown fields are ignored
@@ -226,22 +226,22 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByReference($object)
     {
-        $fieldNames = $this->getFieldnames();
+        $propertyNames = $this->getMappedPropertyNames();
         $refl       = $this->metadata->getReflectionClass();
         $filter     = $object instanceof FilterProviderInterface
             ? $object->getFilter()
             : $this->filterComposite;
 
         $data = array();
-        foreach ($fieldNames as $fieldName) {
-            if ($filter && !$filter->filter($fieldName)) {
+        foreach ($propertyNames as $propertyName) {
+            if ($filter && !$filter->filter($propertyName)) {
                 continue;
             }
-            $reflProperty = $refl->getProperty($fieldName);
+            $reflProperty = $refl->getProperty($propertyName);
             $reflProperty->setAccessible(true);
 
-            $dataFieldName = $this->computeExtractFieldName($fieldName);
-            $data[$dataFieldName] = $this->extractValue($fieldName, $reflProperty->getValue($object), $object);
+            $dataFieldName = $this->computeExtractFieldName($propertyName);
+            $data[$dataFieldName] = $this->extractValue($propertyName, $reflProperty->getValue($object), $object);
         }
 
         return $data;

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/ClassMetadataPropertyNamesAware.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/ClassMetadataPropertyNamesAware.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\PropertyNamesAware;
+
+interface ClassMetadataPropertyNamesAware extends ClassMetadata, PropertyNamesAware
+{
+    
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/EmbeddableObject.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/EmbeddableObject.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+class EmbeddableObject
+{
+    /**
+     * @var int
+     */
+    protected $foo;
+    /**
+     * @var string
+     */
+    protected $bar;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithEmbeddedObject.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleEntityWithEmbeddedObject.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+class SimpleEntityWithEmbeddedObject
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var SimpleEntity
+     */
+    protected $toOne;
+
+    /**
+     * @var EmbeddableObject
+     */
+    protected $embedded;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getToOne()
+    {
+        return $this->toOne;
+    }
+
+    public function getEmbedded()
+    {
+        return $this->embedded;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function setToOne(SimpleEntity $toOne)
+    {
+        $this->toOne = $toOne;
+    }
+
+    public function setEmbedded(EmbeddableObject $embedded)
+    {
+        $this->embedded = $embedded;
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -41,8 +41,9 @@ class DoctrineObjectTest extends BaseTestCase
     {
         parent::setUp();
 
-        $this->metadata         = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $this->objectManager    = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->metadata = $this->getMock('DoctrineModuleTest\Stdlib\Hydrator\Asset\ClassMetadataPropertyNamesAware');
+
+        $this->objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
 
         $this->objectManager->expects($this->any())
                             ->method('getClassMetadata')
@@ -68,6 +69,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'field')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
             ->will($this->returnValue(array('id', 'field')));
 
         $this
@@ -141,6 +148,12 @@ class DoctrineObjectTest extends BaseTestCase
         $this
             ->metadata
             ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('camelCase')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->equalTo('camelCase'))
             ->will($this->returnValue('string'));
@@ -192,6 +205,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'done')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
             ->will($this->returnValue(array('id', 'done')));
 
         $this
@@ -265,6 +284,12 @@ class DoctrineObjectTest extends BaseTestCase
         $this
             ->metadata
             ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'isActive')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('isActive')))
             ->will(
@@ -333,6 +358,12 @@ class DoctrineObjectTest extends BaseTestCase
         $this
             ->metadata
             ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'field')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('field')))
             ->will($this->returnValue('string'));
@@ -379,6 +410,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'date')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
             ->will($this->returnValue(array('id', 'date')));
 
         $this
@@ -443,6 +480,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->expects($this->any())
             ->method('getAssociationNames')
             ->will($this->returnValue(array('toOne')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'toOne')));
 
         $this
             ->metadata
@@ -537,6 +580,12 @@ class DoctrineObjectTest extends BaseTestCase
         $this
             ->metadata
             ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'toOne')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
             ->method('getTypeOfField')
             ->with(
                 $this->logicalOr(
@@ -622,6 +671,75 @@ class DoctrineObjectTest extends BaseTestCase
         );
     }
 
+    public function configureObjectManagerForSimpleEntityWithEmbeddable()
+    {
+        $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntityWithEmbeddedObject');
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue(array('toOne')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(array('id', 'embedded')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'embedded', 'toOne')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('date')))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        if ($arg === 'id') {
+                            return 'integer';
+                        } elseif ($arg === 'embedded') {
+                            return 'embedded';
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->will($this->returnValue(true));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->will($this->returnValue(array('id')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this->hydratorByValue = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
     public function configureObjectManagerForOneToManyEntity()
     {
         $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntity');
@@ -637,6 +755,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->expects($this->any())
             ->method('getAssociationNames')
             ->will($this->returnValue(array('entities')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'entities')));
 
         $this
             ->metadata
@@ -728,6 +852,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->expects($this->any())
             ->method('getAssociationNames')
             ->will($this->returnValue(array('entities')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getMappedPropertyNames')
+            ->will($this->returnValue(array('id', 'entities')));
 
         $this
             ->metadata
@@ -932,6 +1062,31 @@ class DoctrineObjectTest extends BaseTestCase
 
         $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $entity);
         $this->assertEquals('bar', $entity->getField(false));
+    }
+
+    public function testExtractEmbeddedByValue()
+    {
+        $embedded = new Asset\EmbeddableObject();
+        $embedded->setFoo(3);
+        $embedded->setBar('bar');
+
+        $toOne = new Asset\SimpleEntity();
+        $toOne->setId(2);
+        $toOne->setField('foo', false);
+
+        $entity = new Asset\SimpleEntityWithEmbeddedObject();
+        $entity->setId(2);
+        $entity->setEmbedded($embedded);
+        $entity->setToOne($toOne);
+
+        $this->configureObjectManagerForSimpleEntityWithEmbeddable();
+
+        $data = $this->hydratorByValue->extract($entity);
+
+        $this->assertEquals(2, $data['id']);
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $data['toOne']);
+        $this->assertSame($toOne, $data['toOne']);
+        $this->assertSame($embedded, $data['embedded']);
     }
 
     public function testExtractOneToOneAssociationByValue()


### PR DESCRIPTION
There is a new interface in https://github.com/doctrine/common/pull/343, this is the implementation that will make possible to work with embeddables in DoctrineObject hydrator through this classmetadata implementation https://github.com/doctrine/doctrine2/pull/1185.

**This modification in composer.json is purposeful and will be removed as soon as/if doctrine/common PR gets merged w/ forced push. The objective is to make it possible to travis test the DoctrineModule with the new interface and show that this pr is dependent from a pr in doctrine/common**