### PR TITLE
minor cs fix

### DIFF
--- a/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
@@ -40,7 +40,7 @@ class CollectionAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp ()
+    protected function setUp()
     {
         parent::setUp();
         $this->adapter = new CollectionAdapter(new ArrayCollection(range(1, 101)));


### PR DESCRIPTION
this space is making the travis tests to fail under php 5.4 and 5.5
