### PR TITLE
Adding custom Doctrine-Cli Commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,22 +21,21 @@ and attaching them to the provided CLI application as following:
 ```php
 namespace My;
 
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\ModuleManagerInterface;
 
-class Module implements BootstrapListenerInterface;
+class Module
 {
-    public function onBootstrap(EventInterface $e)
+    public function init(ModuleManagerInterface $manager)
     {
-        $application = $e->getTarget();
-        $events = $application->getEventManager()->getSharedManager();
+        $events = $manager->getEventManager()->getSharedManager();
 
         // Attach to helper set event and load the entity manager helper.
         $events->attach('doctrine', 'loadCli.post', function(EventInterface $e) {
             /* @var $cli \Symfony\Component\Console\Application */
             $cli = $e->getTarget();
 
-            $cli->addCommand(new \My\Own\Cli\Command());
+            $cli->add(new \My\Own\Cli\Command());
         });
     }
 }


### PR DESCRIPTION
It was not possible to add commands to doctrine-Cli commands list using onBootstrap method.
So in order to add our custom commands we need to use init method of Module class.

Second of all $cli object does not have addCommand method but it does have "add" for adding one commands at a time.
