### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php":                                ">=5.4",
         "doctrine/common":                    ">=2.4,<2.6-dev",
-        "symfony/console":                    "~2.3",
+        "symfony/console":                    "~2.3|~3.0",
         "zendframework/zend-authentication":  "~2.3",
         "zendframework/zend-cache":           "~2.3",
         "zendframework/zend-paginator":       "~2.3",


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0