### PR TITLE
Fixed documentation for Example 4

### DIFF
--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -138,8 +138,8 @@ $this->add(
 
 ### Example 4 : including an empty option
 
-If you want to include an empty option at the top, set the `include_empty_option` setting to true.
-You can also specify the `empty_option_label` setting, the default is an empty string.
+If you want to include an empty option at the top, set the `display_empty_item` setting to true.
+You can also specify the `empty_item_label` setting, the default is an empty string.
 
 ```php
 $this->add(


### PR DESCRIPTION
The documentation has old values from the original commit.

* `include_empty_option` should be `display_empty_item`
* `empty_option_label` should be `empty_item_label`

`DoctrineModule\Form\Element\Proxy::setOptions()` uses:

```
        if (isset($options['display_empty_item'])) {
            $this->setDisplayEmptyItem($options['display_empty_item']);
        }

        if (isset($options['empty_item_label'])) {
            $this->setEmptyItemLabel($options['empty_item_label']);
        }
```