### PR TITLE
Remove php 5.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/clover.xml
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php build/coverage-checker.php build/clover.xml 70; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.3' ]; then ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/; fi"
+  - ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/
 
 after_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"


### PR DESCRIPTION
Fix Continuous integration, removing tests for php 5.3 on travis. On composer we already set to accept only `>=5.4` php version