### PR TITLE
Removed obsolete Travis build for 5.3 and added builds for 5.6 and 7.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
   - hhvm
 
 matrix:
   allow_failures:
+    - php: 7.0
     - php: hhvm
 
 before_script:
-  - composer update --prefer-source
+  - composer install --no-interaction --prefer-source
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/clover.xml
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php build/coverage-checker.php build/clover.xml 70; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.3' ]; then ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/; fi"
+  - '[[ $TRAVIS_PHP_VERSION = hhvm ]] || php build/coverage-checker.php build/clover.xml 70'
+  - ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/
 
 after_script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml; fi"
+  - |
+    [[ $TRAVIS_PHP_VERSION = hhvm ]] || {
+      wget https://scrutinizer-ci.com/ocular.phar
+      php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml
+    }


### PR DESCRIPTION
PHP 5.4 is stipulated as the minimum required version in `composer.json` and the builds for 5.3 always fails so I removed the obsolete 5.3 build.
