### PR TITLE
Feature/optgroup support

### DIFF
--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -241,3 +241,102 @@ id  | property   | category
     </optgroup>
 </select>
 ```
+
+### Example 7: <optgroup> formatting on empty optgroups 
+
+In case you define an `optgroup_identifier` and the data inside this column is empty or `null` you have two options of
+rendering these cases. From a UX point of view you should group all "loose" entries inside a group that you call 
+"others" or the likes of that. But you're also able to render them without any grouping at all. Here's both examples:
+
+#### 7.1: Rendering without a default group
+
+To render without a default group you have to change nothing. This is the default behavior
+
+**Add the Select list like this:**
+
+```php
+$this->add(
+    array(
+        'type' => 'DoctrineModule\Form\Element\ObjectSelect',
+        'name' => 'name',
+        'options' => array(
+            'object_manager'      => $this->getObjectManager(),
+            'target_class'        => 'Module\Entity\SomeEntity',
+            'property'            => 'property',
+            'optgroup_identifier' => 'category'
+        ),
+    )
+);
+```
+
+**With your data structure like this:**
+
+```
+id  | property   | category
+1   | Football   | sports
+2   | Basketball | 
+3   | Spaghetti  | food
+```
+
+**Will create a HTML Select list like this:**
+
+```html
+<select name="name">
+    <optgroup label="sports">
+        <option value="1">Football</option>
+    </optgroup>
+    <optgroup label="food">
+        <option value="3">Spaghetti</option>
+    </optgroup>
+    <option value="2">Basketball</option>
+</select>
+```
+
+Notice how the value for "Basketball" has not been wrapped with an `<optgroup>` element.
+
+#### 7.2: Rendering with a default group
+
+To group all loose values into a unified group, simply add the `optgroup_default` parameter to the options.
+
+**Add the Select list like this:**
+
+```php
+$this->add(
+    array(
+        'type' => 'DoctrineModule\Form\Element\ObjectSelect',
+        'name' => 'name',
+        'options' => array(
+            'object_manager'      => $this->getObjectManager(),
+            'target_class'        => 'Module\Entity\SomeEntity',
+            'property'            => 'property',
+            'optgroup_identifier' => 'category',
+            'optgroup_default'    => 'Others'
+        ),
+    )
+);
+```
+
+**With your data structure like this:**
+
+```
+id  | property   | category
+1   | Football   | sports
+2   | Basketball | 
+3   | Spaghetti  | food
+```
+
+**Will create a HTML Select list like this:**
+
+```html
+<select name="name">
+    <optgroup label="sports">
+        <option value="1">Football</option>
+    </optgroup>
+    <optgroup label="others">
+        <option value="2">Basketball</option>
+    </optgroup>
+    <optgroup label="food">
+        <option value="3">Spaghetti</option>
+    </optgroup>
+</select>
+```

--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -193,3 +193,51 @@ The above example will generate HTML options with a data-key attribute:
 <option value="myValue2" data-key="value2">myLabel2</option>
 </select>
 ```
+
+### Example 6: Implementing <optgroup> support
+
+Once lists become larger there's a big user-experience bonus when lists are groupt using the html <optgroup> attribute.
+DoctrineModule provides this functionality with the `optgroup_identifier`.
+
+The assumption DoctrineModule does however is that your data structure has the optgroup-grouping in mind. See the 
+following example:
+
+**Add the Select list like this:**
+
+```php
+$this->add(
+    array(
+        'type' => 'DoctrineModule\Form\Element\ObjectSelect',
+        'name' => 'name',
+        'options' => array(
+            'object_manager'      => $this->getObjectManager(),
+            'target_class'        => 'Module\Entity\SomeEntity',
+            'property'            => 'property',
+            'optgroup_identifier' => 'category'
+        ),
+    )
+);
+```
+
+**With your data structure like this:**
+
+```
+id  | property   | category
+1   | Football   | sports
+2   | Basketball | sports
+3   | Spaghetti  | food
+```
+
+**Will create a HTML Select list like this:**
+
+```html
+<select name="name">
+    <optgroup label="sports">
+        <option value="1">Football</option>
+        <option value="2">Basketball</option>
+    </optgroup>
+    <optgroup label="food">
+        <option value="3">Spaghetti</option>
+    </optgroup>
+</select>
+```

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -467,7 +467,8 @@ class Proxy implements ObjectManagerAwareInterface
             return;
         }
 
-        $findMethod = (array)$this->getFindMethod();
+        $findMethod = (array) $this->getFindMethod();
+
         if (!$findMethod) {
             $findMethodName = 'findAll';
             $repository     = $this->objectManager->getRepository($this->targetClass);

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -574,10 +574,30 @@ class Proxy implements ObjectManagerAwareInterface
                         sprintf('Method "%s::%s" is not callable', $this->targetClass, $methodName)
                     );
                 }
+
                 $optionAttributes[key($optionAttribute)] = (string)$object->{$methodName}();
             }
 
-            $options[] = array('label' => $label, 'value' => $value, 'attributes' => $optionAttributes);
+            if (null !== ($optgroupIdentifier = $this->getOptgroupIdentifier())) {
+                $optgroupGetter = 'get' . ucfirst($optgroupIdentifier);
+
+                if (!is_callable(array($object, $optgroupGetter))) {
+                    throw new RuntimeException(
+                        sprintf('Method "%s::%s" is not callable', $this->targetClass, $optgroupGetter)
+                    );
+                }
+
+                $optgroup = $object->{$optgroupGetter}();
+
+                $options[$optgroup]['label']     = $optgroup;
+                $options[$optgroup]['options'][] = array(
+                    'label'      => $label,
+                    'value'      => $value,
+                    'attributes' => $optionAttributes
+                );
+            } else {
+                $options[] = array('label' => $label, 'value' => $value, 'attributes' => $optionAttributes);
+            }
         }
 
         $this->valueOptions = $options;

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -86,12 +86,12 @@ class Proxy implements ObjectManagerAwareInterface
     protected $emptyItemLabel = '';
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $optgroupIdentifier;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $optgroupDefault;
 
@@ -320,7 +320,7 @@ class Proxy implements ObjectManagerAwareInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getOptgroupIdentifier()
     {
@@ -332,11 +332,11 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function setOptgroupIdentifier($optgroupIdentifier)
     {
-        $this->optgroupIdentifier = $optgroupIdentifier;
+        $this->optgroupIdentifier = (string) $optgroupIdentifier;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getOptgroupDefault()
     {
@@ -348,7 +348,7 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function setOptgroupDefault($optgroupDefault)
     {
-        $this->optgroupDefault = $optgroupDefault;
+        $this->optgroupDefault = (string) $optgroupDefault;
     }
 
     /**
@@ -360,7 +360,7 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function setIsMethod($method)
     {
-        $this->isMethod = (bool)$method;
+        $this->isMethod = (bool) $method;
 
         return $this;
     }
@@ -582,7 +582,7 @@ class Proxy implements ObjectManagerAwareInterface
                     );
                 }
 
-                $label = (string)$object;
+                $label = (string) $object;
             }
 
             if (count($identifier) > 1) {
@@ -600,7 +600,7 @@ class Proxy implements ObjectManagerAwareInterface
                     );
                 }
 
-                $optionAttributes[key($optionAttribute)] = (string)$object->{$methodName}();
+                $optionAttributes[key($optionAttribute)] = (string) $object->{$methodName}();
             }
 
             // If no optgroup_identifier has been configured, apply default handling and continue

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -19,12 +19,12 @@
 
 namespace DoctrineModule\Form\Element;
 
-use InvalidArgumentException;
-use RuntimeException;
-use ReflectionMethod;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
+use InvalidArgumentException;
+use ReflectionMethod;
+use RuntimeException;
 use Traversable;
 use Zend\Stdlib\Guard\GuardUtils;
 
@@ -146,7 +146,8 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the label for the empty option
      *
-     * @param string          $emptyItemLabel
+     * @param string $emptyItemLabel
+     *
      * @return Proxy
      */
     public function setEmptyItemLabel($emptyItemLabel)
@@ -183,7 +184,8 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set a flag, whether to include the empty option at the beginning or not
      *
-     * @param boolean         $displayEmptyItem
+     * @param boolean $displayEmptyItem
+     *
      * @return Proxy
      */
     public function setDisplayEmptyItem($displayEmptyItem)
@@ -204,7 +206,8 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the object manager
      *
-     * @param  ObjectManager  $objectManager
+     * @param  ObjectManager $objectManager
+     *
      * @return Proxy
      */
     public function setObjectManager(ObjectManager $objectManager)
@@ -227,7 +230,8 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the FQCN of the target object
      *
-     * @param  string         $targetClass
+     * @param  string $targetClass
+     *
      * @return Proxy
      */
     public function setTargetClass($targetClass)
@@ -250,7 +254,8 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the property to use as the label in the options
      *
-     * @param  string         $property
+     * @param  string $property
+     *
      * @return Proxy
      */
     public function setProperty($property)
@@ -279,7 +284,7 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function setLabelGenerator($callable)
     {
-        if (! is_callable($callable)) {
+        if (!is_callable($callable)) {
             throw new InvalidArgumentException(
                 'Property "label_generator" needs to be a callable function or a \Closure'
             );
@@ -299,12 +304,13 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set if the property is a method to use as the label in the options
      *
-     * @param  boolean         $method
+     * @param  boolean $method
+     *
      * @return Proxy
      */
     public function setIsMethod($method)
     {
-        $this->isMethod = (bool) $method;
+        $this->isMethod = (bool)$method;
 
         return $this;
     }
@@ -320,6 +326,7 @@ class Proxy implements ObjectManagerAwareInterface
     /** Set the findMethod property to specify the method to use on repository
      *
      * @param array $findMethod
+     *
      * @return Proxy
      */
     public function setFindMethod($findMethod)
@@ -341,6 +348,7 @@ class Proxy implements ObjectManagerAwareInterface
 
     /**
      * @param $targetEntity
+     *
      * @return string|null
      */
     protected function generateLabel($targetEntity)
@@ -354,6 +362,7 @@ class Proxy implements ObjectManagerAwareInterface
 
     /**
      * @param  $value
+     *
      * @return array|mixed|object
      * @throws RuntimeException
      */
@@ -368,9 +377,11 @@ class Proxy implements ObjectManagerAwareInterface
         }
 
         $metadata = $om->getClassMetadata($targetClass);
+
         if (is_object($value)) {
             if ($value instanceof Collection) {
                 $data = array();
+
                 foreach ($value as $object) {
                     $values = $metadata->getIdentifierValues($object);
                     $data[] = array_shift($values);
@@ -406,7 +417,7 @@ class Proxy implements ObjectManagerAwareInterface
             return;
         }
 
-        $findMethod = (array) $this->getFindMethod();
+        $findMethod = (array)$this->getFindMethod();
         if (!$findMethod) {
             $findMethodName = 'findAll';
             $repository     = $this->objectManager->getRepository($this->targetClass);
@@ -417,8 +428,8 @@ class Proxy implements ObjectManagerAwareInterface
             }
             $findMethodName   = $findMethod['name'];
             $findMethodParams = isset($findMethod['params']) ? array_change_key_case($findMethod['params']) : array();
+            $repository       = $this->objectManager->getRepository($this->targetClass);
 
-            $repository = $this->objectManager->getRepository($this->targetClass);
             if (!method_exists($repository, $findMethodName)) {
                 throw new RuntimeException(
                     sprintf(
@@ -431,6 +442,7 @@ class Proxy implements ObjectManagerAwareInterface
 
             $r    = new ReflectionMethod($repository, $findMethodName);
             $args = array();
+
             foreach ($r->getParameters() as $param) {
                 if (array_key_exists(strtolower($param->getName()), $findMethodParams)) {
                     $args[] = $findMethodParams[strtolower($param->getName())];
@@ -480,7 +492,7 @@ class Proxy implements ObjectManagerAwareInterface
         $identifier       = $metadata->getIdentifierFieldNames();
         $objects          = $this->getObjects();
         $options          = array();
-        $optionAttributes =array();
+        $optionAttributes = array();
 
         if ($this->displayEmptyItem) {
             $options[''] = $this->getEmptyItemLabel();
@@ -501,6 +513,7 @@ class Proxy implements ObjectManagerAwareInterface
                 }
 
                 $getter = 'get' . ucfirst($property);
+
                 if (!is_callable(array($object, $getter))) {
                     throw new RuntimeException(
                         sprintf('Method "%s::%s" is not callable', $this->targetClass, $getter)
@@ -519,7 +532,7 @@ class Proxy implements ObjectManagerAwareInterface
                     );
                 }
 
-                $label = (string) $object;
+                $label = (string)$object;
             }
 
             if (count($identifier) > 1) {
@@ -529,17 +542,17 @@ class Proxy implements ObjectManagerAwareInterface
             }
 
             foreach ($this->getOptionAttributes() as $optionAttribute) {
-                $methodName =current($optionAttribute);
+                $methodName = current($optionAttribute);
+
                 if (!is_callable(array($object, $methodName))) {
-                        throw new RuntimeException(
-                            sprintf('Method "%s::%s" is not callable', $this->targetClass, $methodName)
-                        );
+                    throw new RuntimeException(
+                        sprintf('Method "%s::%s" is not callable', $this->targetClass, $methodName)
+                    );
                 }
-                    $optionAttributes[key($optionAttribute)] =(string) $object->{$methodName}();
+                $optionAttributes[key($optionAttribute)] = (string)$object->{$methodName}();
             }
 
-                $options[] = array('label' => $label, 'value' => $value, 'attributes'=>$optionAttributes);
-           
+            $options[] = array('label' => $label, 'value' => $value, 'attributes' => $optionAttributes);
         }
 
         $this->valueOptions = $options;

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -85,6 +85,11 @@ class Proxy implements ObjectManagerAwareInterface
      */
     protected $emptyItemLabel = '';
 
+    /**
+     * @var string
+     */
+    protected $optgroupIdentifier;
+
     public function setOptions($options)
     {
         if (isset($options['object_manager'])) {
@@ -121,6 +126,10 @@ class Proxy implements ObjectManagerAwareInterface
 
         if (isset($options['option_attributes'])) {
             $this->setOptionAttributes($options['option_attributes']);
+        }
+
+        if (isset($options['optgroup_identifier'])) {
+            $this->setOptgroupIdentifier($options['optgroup_identifier']);
         }
     }
 
@@ -299,6 +308,22 @@ class Proxy implements ObjectManagerAwareInterface
     public function getLabelGenerator()
     {
         return $this->labelGenerator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOptgroupIdentifier()
+    {
+        return $this->optgroupIdentifier;
+    }
+
+    /**
+     * @param string $optgroupIdentifier
+     */
+    public function setOptgroupIdentifier($optgroupIdentifier)
+    {
+        $this->optgroupIdentifier = $optgroupIdentifier;
     }
 
     /**

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -308,13 +308,13 @@ class ProxyTest extends PHPUnit_Framework_TestCase
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $metadata    = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-    
+
         $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
         $objectManager->expects($this->once())
         ->method('getClassMetadata')
         ->with($this->equalTo($objectClass))
         ->will($this->returnValue($metadata));
-    
+
         $this->proxy->setOptions(
             array(
                 'object_manager' => $objectManager,
@@ -323,7 +323,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
                 'option_attributes'    => array(array('data-key'=>'missing_method'))
             )
         );
-    
+
         $this->proxy->getValueOptions();
     }
 
@@ -409,6 +409,89 @@ class ProxyTest extends PHPUnit_Framework_TestCase
                             return array('id' => 1);
                         } elseif ($input == $objectTwo) {
                             return array('id' => 2);
+                        }
+
+                        return array();
+                    }
+                )
+            );
+
+        $objectRepository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository->expects($this->any())
+            ->method('findAll')
+            ->will($this->returnValue($result));
+
+        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager->expects($this->any())
+            ->method('getClassMetadata')
+            ->with($this->equalTo($objectClass))
+            ->will($this->returnValue($metadata));
+
+        $objectManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->with($this->equalTo($objectClass))
+            ->will($this->returnValue($objectRepository));
+
+        $this->proxy->setOptions(
+            array(
+                'object_manager' => $objectManager,
+                'target_class'   => $objectClass,
+            )
+        );
+
+        $this->metadata = $metadata;
+    }
+
+    protected function prepareProxyWithOptgroupPreset()
+    {
+        $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
+        $objectOne   = new FormObject;
+        $objectTwo   = new FormObject;
+        $objectThree = new FormObject;
+
+        $objectOne->setId(1)
+            ->setUsername('object one username')
+            ->setPassword('object one password')
+            ->setEmail('object one email')
+            ->setFirstname('object one firstname')
+            ->setSurname('object one surname')
+            ->setOptgroup('Group One');
+
+        $objectTwo->setId(2)
+            ->setUsername('object two username')
+            ->setPassword('object two password')
+            ->setEmail('object two email')
+            ->setFirstname('object two firstname')
+            ->setSurname('object two surname')
+            ->setOptgroup('Group One');
+
+        $objectThree->setId(3)
+            ->setUsername('object three username')
+            ->setPassword('object three password')
+            ->setEmail('object three email')
+            ->setFirstname('object three firstname')
+            ->setSurname('object three surname')
+            ->setOptgroup('Group Two');
+
+        $result = new ArrayCollection(array($objectOne, $objectTwo, $objectThree));
+
+        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata
+            ->expects($this->any())
+            ->method('getIdentifierValues')
+            ->will(
+                $this->returnCallback(
+                    function () use ($objectOne, $objectTwo, $objectThree) {
+                        $input = func_get_args();
+                        $input = array_shift($input);
+
+                        if ($input == $objectOne) {
+                            return array('id' => 1);
+                        } elseif ($input == $objectTwo) {
+                            return array('id' => 2);
+                        } elseif ($input == $objectThree) {
+                            return array('id' => 3);
                         }
 
                         return array();

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -373,6 +373,108 @@ class ProxyTest extends PHPUnit_Framework_TestCase
         $this->proxy->getValueOptions();
     }
 
+    /**
+     * A \RuntimeException should be thrown when the optgroup_identifier option does not reflect an existing method
+     * within the target object
+     */
+    public function testExceptionThrownWhenOptgroupIdentifiesNotCallable()
+    {
+        $this->prepareProxyWithOptgroupPreset();
+
+        $this->proxy->setOptions(
+            array(
+                'optgroup_identifier' => 'NonExistantFunctionName'
+            )
+        );
+
+        $this->setExpectedException('RuntimeException');
+
+        $this->proxy->getValueOptions();
+    }
+
+    /**
+     * Tests that the returned value_options have a proper format given the default data provided for the test as of
+     * writing. The output should have the following result:
+     *
+     * <code>
+     * $valueOptions = array(
+     *      "Group One" => array(
+     *          "label"   => "Group One",
+     *          "options" => array(
+     *              0 => array(
+     *                  "label" => "object one username",
+     *                  "value" => 1
+     *              ),
+     *              1 => array(
+     *                  "label" => "object two username",
+     *                  "value" => 2
+     *              )
+     *          )
+     *      ),
+     *      "Group Two" => array(
+     *          "label"   => "Group Two",
+     *          "options" => array(
+     *              0 => array(
+     *                  "label" => "object three username",
+     *                  "value" => 3
+     *              )
+     *          )
+     *      )
+     * )
+     * </code>
+     */
+    public function testValueOptionsGeneratedProperlyWithOptgroups()
+    {
+        $this->prepareProxyWithOptgroupPreset();
+
+        $this->proxy->setOptions(
+            array(
+                'optgroup_identifier' => 'optgroup'
+            )
+        );
+
+        $valueOptions = $this->proxy->getValueOptions();
+
+        $this->assertInternalType('array', $valueOptions);
+
+        $this->assertCount(2, $valueOptions);
+
+        $this->assertArrayHasKey('Group One', $valueOptions);
+        $this->assertArrayHasKey('Group Two', $valueOptions);
+
+        $groupOne = $valueOptions['Group One'];
+        $groupTwo = $valueOptions['Group Two'];
+
+        $this->assertArrayHasKey('label', $groupOne);
+        $this->assertArrayHasKey('label', $groupTwo);
+
+        $this->assertArrayHasKey('options', $groupOne);
+        $this->assertArrayHasKey('options', $groupTwo);
+
+        $groupOneOptions = $groupOne['options'];
+        $groupTwoOptions = $groupTwo['options'];
+
+        $this->assertInternalType('array', $groupOneOptions);
+        $this->assertInternalType('array', $groupTwoOptions);
+
+        $this->assertCount(2, $groupOneOptions);
+        $this->assertCount(1, $groupTwoOptions);
+
+        $this->assertEquals(
+            $groupOneOptions[0],
+            array('label' => 'object one username', 'value' => 1, 'attributes' => array())
+        );
+        $this->assertEquals(
+            $groupOneOptions[1],
+            array('label' => 'object two username', 'value' => 2, 'attributes' => array())
+        );
+
+        $this->assertEquals(
+            $groupTwoOptions[0],
+            array('label' => 'object three username', 'value' => 3, 'attributes' => array())
+        );
+    }
+
     protected function prepareProxy()
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';

--- a/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
+++ b/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
@@ -58,6 +58,11 @@ class FormObject
      */
     protected $password;
 
+    /**
+     * @var string|null
+     */
+    protected $optgroup;
+
     public function __toString()
     {
         return $this->username;
@@ -70,7 +75,8 @@ class FormObject
      */
     public function setId($id)
     {
-        $this->id = (int) $id;
+        $this->id = (int)$id;
+
         return $this;
     }
 
@@ -81,7 +87,8 @@ class FormObject
      */
     public function setEmail($email)
     {
-        $this->email = (string) $email;
+        $this->email = (string)$email;
+
         return $this;
     }
 
@@ -100,7 +107,8 @@ class FormObject
      */
     public function setPassword($password)
     {
-        $this->password = (string) $password;
+        $this->password = (string)$password;
+
         return $this;
     }
 
@@ -119,7 +127,8 @@ class FormObject
      */
     public function setUsername($username)
     {
-        $this->username = (string) $username;
+        $this->username = (string)$username;
+
         return $this;
     }
 
@@ -138,7 +147,8 @@ class FormObject
      */
     public function setFirstname($firstname)
     {
-        $this->firstname = (string) $firstname;
+        $this->firstname = (string)$firstname;
+
         return $this;
     }
 
@@ -157,7 +167,8 @@ class FormObject
      */
     public function setSurname($surname)
     {
-        $this->surname = (string) $surname;
+        $this->surname = (string)$surname;
+
         return $this;
     }
 
@@ -174,6 +185,22 @@ class FormObject
      */
     public function getName()
     {
-        return isset($this->firstname) && isset($this->surname)? $this->firstname . " " . $this->surname : null;
+        return isset($this->firstname) && isset($this->surname) ? $this->firstname . " " . $this->surname : null;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getOptgroup()
+    {
+        return $this->optgroup;
+    }
+
+    /**
+     * @param null|string $optgroup
+     */
+    public function setOptgroup($optgroup)
+    {
+        $this->optgroup = $optgroup;
     }
 }

--- a/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
+++ b/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
@@ -75,7 +75,7 @@ class FormObject
      */
     public function setId($id)
     {
-        $this->id = (int)$id;
+        $this->id = (int) $id;
 
         return $this;
     }
@@ -87,7 +87,7 @@ class FormObject
      */
     public function setEmail($email)
     {
-        $this->email = (string)$email;
+        $this->email = (string) $email;
 
         return $this;
     }
@@ -107,7 +107,7 @@ class FormObject
      */
     public function setPassword($password)
     {
-        $this->password = (string)$password;
+        $this->password = (string) $password;
 
         return $this;
     }
@@ -127,7 +127,7 @@ class FormObject
      */
     public function setUsername($username)
     {
-        $this->username = (string)$username;
+        $this->username = (string) $username;
 
         return $this;
     }
@@ -147,7 +147,7 @@ class FormObject
      */
     public function setFirstname($firstname)
     {
-        $this->firstname = (string)$firstname;
+        $this->firstname = (string) $firstname;
 
         return $this;
     }
@@ -167,7 +167,7 @@ class FormObject
      */
     public function setSurname($surname)
     {
-        $this->surname = (string)$surname;
+        $this->surname = (string) $surname;
 
         return $this;
     }


### PR DESCRIPTION
References #370 

@gianarb this would be the first set of feature with which adding is not any danger at all I feel.

However there's still one thing that I wouldn't see as "that awesome".

When your data-structure "optgroup" is empty or null it will create an optgroup that has no title. While this is somewhat OK it would likely be more valid to put those empty optgroup entries within NO optgroup block at all.

A further alternative is to provide yet another option key `optgroup_default` where you could define what happens to empty optgroup elements. I.e. `'optgroup_default' => 'Others'` would name the empty group "Others".

The above functionality is already implemented in my branch. You can check it out here:
https://github.com/manuakasam/DoctrineModule/blob/feature/optgroup-default-container/src/DoctrineModule/Form/Element/Proxy.php#L617-L630

The downside to this is that this is quite a lot of custom code. While fully functional you may consider this too custom and not for a wide enough audience? Just gimme your thouhgt. If it's considered OK, ill write tests for those as well and hit up a follow up PR after this.