### PR TITLE
Improve Selectable adapter

### DIFF
--- a/src/DoctrineModule/Paginator/Adapter/Selectable.php
+++ b/src/DoctrineModule/Paginator/Adapter/Selectable.php
@@ -72,6 +72,14 @@ class Selectable implements AdapterInterface
     public function count()
     {
         $criteria = clone $this->criteria;
+        
+        // If selectable is an entity repository, we can perform a more optimized query
+        if ($this->selectable instanceof \Doctrine\ORM\EntityRepository) {
+            return (int) $this->selectable->getEntityManager()->createQueryBuilder()
+                ->select('COUNT(e) AS nb')
+                ->from($this->selectable->getEntityName(), 'e')
+                ->addCriteria($oCriteria)->getQuery()->getSingleScalarResult();
+        }
 
         $criteria->setFirstResult(null);
         $criteria->setMaxResults(null);


### PR DESCRIPTION
Use Query builder to perform a more optimized query if selectable is a "\Doctrine\ORM\EntityRepository". This improvement don't need to fetch all the available entities