### PR TITLE
Bump phpunit version and remove minimum-stability flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
+  - 7
   - hhvm
 
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: 7
     - php: hhvm
 
 before_script:
@@ -17,12 +17,9 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/clover.xml
-  - '[[ $TRAVIS_PHP_VERSION = hhvm ]] || php build/coverage-checker.php build/clover.xml 70'
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ] && [ $TRAVIS_PHP_VERSION != '7' ]; then php build/coverage-checker.php build/clover.xml 70; fi
   - ./vendor/bin/phpcs --standard=vendor/doctrine/coding-standard/Doctrine ./src/ ./tests/
 
 after_script:
-  - |
-    [[ $TRAVIS_PHP_VERSION = hhvm ]] || {
-      wget https://scrutinizer-ci.com/ocular.phar
-      php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml
-    }
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ] && [ $TRAVIS_PHP_VERSION != '7' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ] && [ $TRAVIS_PHP_VERSION != '7' ]; then php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "zendframework/zend-validator":       "~2.3"
     },
     "require-dev": {
-        "phpunit/phpunit":             "~3.7",
+        "phpunit/phpunit":             "~4.0",
         "squizlabs/php_codesniffer":   "~2",
         "doctrine/coding-standard":    "dev-master",
         "zendframework/zendframework": "~2.3"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
             "homepage": "http://www.michaelgallego.fr"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php":                                ">=5.4",
         "doctrine/common":                    ">=2.4,<2.6-dev",


### PR DESCRIPTION
The minimum-stability flag seems useless now, please correct me if it's not the case.
phpunit has been bumped to allow ZF 2.5 compliance.