### PR TITLE
Added custom repository method feature

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -6,6 +6,7 @@ All three validators accept the following options :
 
 * `object_repository` : an instance of an object repository.
 * `fields` : an array that contains all the fields that are used to check if the entity exists (or does not).
+* `repository_method` (optional) : a string that points to a valid method in the provided object repository. If this value is not provided the default method `findOneBy` will be used.
 
 The `DoctrineModule\Validator\UniqueObject` also needs the following option:
 
@@ -24,7 +25,8 @@ You can directly instantiate a validator the following way:
 ```php
 $validator = new \DoctrineModule\Validator\ObjectExists(array(
     'object_repository' => $objectManager->getRepository('Application\Entity\User'),
-    'fields' => array('email')
+    'fields' => array('email'),
+    'repository_method' => 'findOneByCustomMethod' // Optional
 ));
 
 var_dump($validator->isValid('test@example.com')); // dumps 'true' if an entity matches
@@ -70,7 +72,8 @@ class User extends Form
 
        	$noObjectExistsValidator = new NoObjectExistsValidator(array(
             'object_repository' => $entityManager->getRepository('Application\Entity\User'),
-            'fields'            => 'email'
+            'fields'            => 'email',
+            'repository_method' => 'findOneByCustomMethod' // Optional
        	));
 
        	$emailInput->getValidatorChain()

--- a/src/DoctrineModule/Validator/NoObjectExists.php
+++ b/src/DoctrineModule/Validator/NoObjectExists.php
@@ -47,7 +47,8 @@ class NoObjectExists extends ObjectExists
     public function isValid($value)
     {
         $value = $this->cleanSearchValue($value);
-        $match = $this->objectRepository->findOneBy($value);
+        $method = $this->repositoryMethod;
+        $match = $this->objectRepository->$method($value);
 
         if (is_object($match)) {
             $this->error(self::ERROR_OBJECT_FOUND, $value);

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -98,15 +98,15 @@ class ObjectExists extends AbstractValidator
         $this->objectRepository = $options['object_repository'];
 
         if (isset($options['repository_method'])) {
-            if(!is_string($options['repository_method']) || !method_exists($this->objectRepository, $options['repository_method']))
-            throw new Exception\InvalidArgumentException(
-                'Invalid "repository_method" provided. The value must be a valid method in repository %s, %s given',
-                get_class($this->objectRepository);
-                is_string($options['repository_method']) ? $options['repository_method'] : gettype($options['repository_method'])
-            );
+            if(!is_string($options['repository_method']) || !method_exists($this->objectRepository, $options['repository_method'])){
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Invalid "repository_method" provided. The value must be a valid method in repository %s, %s given',
+                    get_class($this->objectRepository),
+                    is_string($options['repository_method']) ? $options['repository_method'] : gettype($options['repository_method'])
+                ));
+            }
+            $this->repositoryMethod = $options['repository_method'];
         }
-
-        $this->repositoryMethod = $options['repository_method'];
 
         if (!isset($options['fields'])) {
             throw new Exception\InvalidArgumentException(

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -59,6 +59,13 @@ class ObjectExists extends AbstractValidator
      * @var array
      */
     protected $fields;
+    
+    /**
+     * Repository method to use, defaults to findOneBy
+     *
+     * @var array
+     */
+    protected $repositoryMethod = 'findOneBy';
 
     /**
      * Constructor
@@ -89,6 +96,17 @@ class ObjectExists extends AbstractValidator
         }
 
         $this->objectRepository = $options['object_repository'];
+
+        if (isset($options['repository_method'])) {
+            if(!is_string($options['repository_method']) || !method_exists($this->objectRepository, $options['repository_method']))
+            throw new Exception\InvalidArgumentException(
+                'Invalid "repository_method" provided. The value must be a valid method in repository %s, %s given',
+                get_class($this->objectRepository);
+                is_string($options['repository_method']) ? $options['repository_method'] : gettype($options['repository_method'])
+            );
+        }
+
+        $this->repositoryMethod = $options['repository_method'];
 
         if (!isset($options['fields'])) {
             throw new Exception\InvalidArgumentException(
@@ -175,7 +193,8 @@ class ObjectExists extends AbstractValidator
     public function isValid($value)
     {
         $value = $this->cleanSearchValue($value);
-        $match = $this->objectRepository->findOneBy($value);
+        $method = $this->repositoryMethod;
+        $match = $this->objectRepository->$method($value);
 
         if (is_object($match)) {
             return true;

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -95,7 +95,8 @@ class UniqueObject extends ObjectExists
     public function isValid($value, $context = null)
     {
         $value = $this->cleanSearchValue($value);
-        $match = $this->objectRepository->findOneBy($value);
+        $method = $this->repositoryMethod;
+        $match = $this->objectRepository->$method($value);
 
         if (!is_object($match)) {
             return true;

--- a/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
@@ -74,6 +74,52 @@ class ObjectExistsTest extends BaseTestCase
         )));
         $this->assertTrue($validator->isValid(array('firstMatchValue', 'secondMatchValue')));
     }
+    
+    public function testCanValidateWithSingleFieldAndCustomMethod()
+    {
+        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository
+            ->expects($this->exactly(2))
+            ->method('findOneByCustomMethod')
+            ->with(array('matchKey' => 'matchValue'))
+            ->will($this->returnValue(new stdClass()));
+
+        $validator = new ObjectExists(array(
+            'object_repository' => $repository,
+            'fields'            => 'matchKey',
+            'repository_method' => 'findOneByCustomMethod'
+        ));
+        $this->assertTrue($validator->isValid('matchValue'));
+        $this->assertTrue($validator->isValid(array('matchKey' => 'matchValue')));
+    }
+
+    public function testCanValidateWithMultipleFieldsAndCustomMethod()
+    {
+        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository
+            ->expects($this->exactly(2))
+            ->method('findOneByCustomMethod')
+            ->with(array(
+                'firstMatchKey' => 'firstMatchValue',
+                'secondMatchKey' => 'secondMatchValue',
+            ))
+            ->will($this->returnValue(new stdClass()));
+
+        $validator = new ObjectExists(array(
+            'object_repository' => $repository,
+            'fields'            => array(
+                'firstMatchKey',
+                'secondMatchKey',
+            ),
+            'repository_method' => 'findOneByCustomMethod'
+        ));
+        $this->assertTrue($validator->isValid(array(
+            'firstMatchKey' => 'firstMatchValue',
+            'secondMatchKey' => 'secondMatchValue',
+        )));
+        $this->assertTrue($validator->isValid(array('firstMatchValue', 'secondMatchValue')));
+    }
+
 
     public function testCanValidateFalseOnNoResult()
     {
@@ -121,6 +167,26 @@ class ObjectExistsTest extends BaseTestCase
         $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException');
         new ObjectExists(array(
             'object_repository' => $this->getMock('Doctrine\Common\Persistence\ObjectRepository'),
+        ));
+    }
+    
+    public function testWillRefuseNonStringMethod()
+    {
+        $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException');
+        new ObjectExists(array(
+            'object_repository' => $this->getMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'fields'            => 'field',
+            'repository_method' => array()
+        ));
+    }
+    
+    public function testWillRefuseNonExistingMethod()
+    {
+        $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException');
+        new ObjectExists(array(
+            'object_repository' => $this->getMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'fields'            => 'field',
+            'repository_method' => 'findOneByNonExistingMethod'
         ));
     }
 

--- a/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
@@ -80,14 +80,14 @@ class ObjectExistsTest extends BaseTestCase
         $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
         $repository
             ->expects($this->exactly(2))
-            ->method('findOneByCustomMethod')
+            ->method('findOneBy')
             ->with(array('matchKey' => 'matchValue'))
             ->will($this->returnValue(new stdClass()));
 
         $validator = new ObjectExists(array(
             'object_repository' => $repository,
             'fields'            => 'matchKey',
-            'repository_method' => 'findOneByCustomMethod'
+            'repository_method' => 'findOneBy'
         ));
         $this->assertTrue($validator->isValid('matchValue'));
         $this->assertTrue($validator->isValid(array('matchKey' => 'matchValue')));
@@ -98,7 +98,7 @@ class ObjectExistsTest extends BaseTestCase
         $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
         $repository
             ->expects($this->exactly(2))
-            ->method('findOneByCustomMethod')
+            ->method('findOneBy')
             ->with(array(
                 'firstMatchKey' => 'firstMatchValue',
                 'secondMatchKey' => 'secondMatchValue',
@@ -111,7 +111,7 @@ class ObjectExistsTest extends BaseTestCase
                 'firstMatchKey',
                 'secondMatchKey',
             ),
-            'repository_method' => 'findOneByCustomMethod'
+            'repository_method' => 'findOneBy'
         ));
         $this->assertTrue($validator->isValid(array(
             'firstMatchKey' => 'firstMatchValue',


### PR DESCRIPTION
The code is updated to support a custom repository method. The repository method can be provided in the options array as follows:

```
'repository_method' => 'string'
```

In the constructor the provided value will be validated and if the variable is not a string or a non existing method an `InvalidArgumentException` will be thrown.

If no custom method is provided the class will fallback to the default `findOneBy` method.

Tests are provided
