### PR TITLE
Fixed php_codesniffer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "require-dev": {
         "phpunit/phpunit":             "~4.0",
-        "squizlabs/php_codesniffer":   "~2",
         "doctrine/coding-standard":    "dev-master",
         "zendframework/zendframework": "~2.3"
     },

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -302,7 +302,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
         $this->proxy->setOptions([
             'option_attributes' => [
                 'class' => 'foo',
-                'lang'  => 'en'
+                'lang' => 'en'
             ]
         ]);
 
@@ -310,7 +310,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
 
         $expectedAttributes = [
             'class' => 'foo',
-            'lang'  => 'en'
+            'lang' => 'en'
         ];
 
         $this->assertCount(2, $options);
@@ -437,26 +437,26 @@ class ProxyTest extends PHPUnit_Framework_TestCase
 
         $expectedOutput = [
             'Group One' => [
-                'label'   => 'Group One',
+                'label' => 'Group One',
                 'options' => [
                     0 => [
-                        'label'      => 'object one username',
-                        'value'      => 1,
+                        'label' => 'object one username',
+                        'value' => 1,
                         'attributes' => []
                     ],
                     1 => [
-                        'label'      => 'object two username',
-                        'value'      => 2,
+                        'label' => 'object two username',
+                        'value' => 2,
                         'attributes' => []
                     ]
                 ]
             ],
             'Group Two' => [
-                'label'   => 'Group Two',
+                'label' => 'Group Two',
                 'options' => [
                     0 => [
-                        'label'      => 'object three username',
-                        'value'      => 3,
+                        'label' => 'object three username',
+                        'value' => 3,
                         'attributes' => []
                     ]
                 ]
@@ -490,7 +490,7 @@ class ProxyTest extends PHPUnit_Framework_TestCase
 
         $expectedOutput = [
             'Others' => [
-                'label'   => 'Others',
+                'label' => 'Others',
                 'options' => [
                     0 => [
                         'label' => 'object one username',

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -67,8 +67,8 @@ class CacheFactoryTest extends BaseTestCase
                 'doctrine' => [
                     'cache' => [
                         'predis' => [
-                            'class'     => 'Doctrine\Common\Cache\PredisCache',
-                            'instance'  => 'my_predis_alias',
+                            'class' => 'Doctrine\Common\Cache\PredisCache',
+                            'instance' => 'my_predis_alias',
                             'namespace' => 'DoctrineModule',
                         ],
                     ],


### PR DESCRIPTION
After this commit
https://github.com/doctrine/coding-standard/pull/4/files#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R14
there are a problem of mismatch dependency.