### PR TITLE
Adds additional processing for DoctrineObject::toMany

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -432,6 +432,7 @@ class DoctrineObject extends AbstractHydrator
                 continue;
             }
 
+            $find = array();
             if (is_array($identifier)) {
                 foreach ($identifier as $field) {
                     switch (gettype($value)) {

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -413,8 +413,8 @@ class DoctrineObject extends AbstractHydrator
         $metadata   = $this->objectManager->getClassMetadata(ltrim($target, '\\'));
         $identifier = $metadata->getIdentifier();
 
-        if (!is_array($values) && $values instanceof Traversable) {
-            $values = iterator_to_array($values, true);
+        if (!is_array($values) && !$values instanceof Traversable) {
+            $values = (array)$values;
         }
 
         $collection = array();

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -414,7 +414,7 @@ class DoctrineObject extends AbstractHydrator
         $identifier = $metadata->getIdentifier();
 
         if (!is_array($values) && $values instanceof Traversable) {
-            $values = (array) $values;
+            $values = iterator_to_array($values, true);
         }
 
         $collection = array();

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -410,7 +410,7 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function toMany($object, $collectionName, $target, $values)
     {
-        $metadata = $this->objectManager->getClassMetadata(ltrim($target, '\\'));
+        $metadata   = $this->objectManager->getClassMetadata(ltrim($target, '\\'));
         $identifier = $metadata->getIdentifier();
 
         if (!is_array($values) && !$values instanceof Traversable) {
@@ -426,7 +426,7 @@ class DoctrineObject extends AbstractHydrator
                 // assumes modifications have already taken place in object
                 $collection[] = $value;
                 continue;
-            } else if (empty($value)) {
+            } elseif (empty($value)) {
                 // assumes no id and retrieves new $target
                 $collection[] = $this->find($value, $target);
                 continue;
@@ -439,7 +439,7 @@ class DoctrineObject extends AbstractHydrator
                             $getter = 'get' . ucfirst($field);
                             if (method_exists($value, $getter)) {
                                 $find[$field] = $value->$getter();
-                            } else if (property_exists($value, $field)) {
+                            } elseif (property_exists($value, $field)) {
                                 $find[$field] = $value->$field;
                             }
                             break;
@@ -456,7 +456,7 @@ class DoctrineObject extends AbstractHydrator
                 }
             }
 
-            if (!empty($find) && $found = $this->find($find, $target)){
+            if (!empty($find) && $found = $this->find($find, $target)) {
                 $collection[] = (is_array($value)) ? $this->hydrate($value, $found) : $found;
             } else {
                 $collection[] = (is_array($value)) ? $this->hydrate($value, new $target) : new $target;

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -413,7 +413,7 @@ class DoctrineObject extends AbstractHydrator
         $metadata   = $this->objectManager->getClassMetadata(ltrim($target, '\\'));
         $identifier = $metadata->getIdentifier();
 
-        if (!is_array($values) && !$values instanceof Traversable) {
+        if (!is_array($values) && $values instanceof Traversable) {
             $values = (array) $values;
         }
 

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyEntityWithEntities.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyEntityWithEntities.php
@@ -7,9 +7,6 @@ use Doctrine\Common\Collections\Collection;
 
 class OneToManyEntityWithEntities extends OneToManyEntity
 {
-
-
-
     public function __construct(ArrayCollection $entities = null)
     {
         $this->entities = $entities;
@@ -19,5 +16,4 @@ class OneToManyEntityWithEntities extends OneToManyEntity
     {
         return $this->entities;
     }
-
 }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyEntityWithEntities.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyEntityWithEntities.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class OneToManyEntityWithEntities extends OneToManyEntity
+{
+
+
+
+    public function __construct(ArrayCollection $entities = null)
+    {
+        $this->entities = $entities;
+    }
+
+    public function getEntities($modifyValue = true)
+    {
+        return $this->entities;
+    }
+
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2042,10 +2042,10 @@ class DoctrineObjectTest extends BaseTestCase
     public function testHydrateOneToManyAssociationByValueWithStdClass()
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
-        $stdClass1 = new \StdClass();
+        $stdClass1     = new \StdClass();
         $stdClass1->id = 2;
 
-        $stdClass2 = new \StdClass();
+        $stdClass2     = new \StdClass();
         $stdClass2->id = 3;
 
         $data = array('entities' => array($stdClass1, $stdClass2));

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2021,7 +2021,6 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $en);
-            var_dump($en);
             $this->assertInternalType('integer', $en->getId());
             $this->assertInternalType('string', $en->getField());
             $this->assertContains('Modified By Hydrate', $en->getField(false));

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -648,7 +648,7 @@ class DoctrineObjectTest extends BaseTestCase
                     $this->equalTo('entities'),
                     $this->equalTo('field')
                 )
-            );
+            )
             ->will(
                 $this->returnCallback(
                     function ($arg) {

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -642,12 +642,18 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getTypeOfField')
-            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities')))
+            ->with($this->logicalOr(
+                $this->equalTo('id'),
+                $this->equalTo('entities'),
+                $this->equalTo('field'))
+            )
             ->will(
                 $this->returnCallback(
                     function ($arg) {
                         if ($arg === 'id') {
                             return 'integer';
+                        } elseif ($arg === 'field') {
+                            return 'string';
                         } elseif ($arg === 'entities') {
                             return 'Doctrine\Common\Collections\ArrayCollection';
                         }
@@ -661,11 +667,13 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('hasAssociation')
-            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities')))
+            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities'), $this->equalTo('field')))
             ->will(
                 $this->returnCallback(
                     function ($arg) {
                         if ($arg === 'id') {
+                            return false;
+                        } elseif ($arg === 'field') {
                             return false;
                         } elseif ($arg === 'entities') {
                             return true;
@@ -703,6 +711,11 @@ class DoctrineObjectTest extends BaseTestCase
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
 
+        $this->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array("id")));
+
         $this->hydratorByValue     = new DoctrineObjectHydrator(
             $this->objectManager,
             true
@@ -711,6 +724,7 @@ class DoctrineObjectTest extends BaseTestCase
             $this->objectManager,
             false
         );
+
     }
 
     public function configureObjectManagerForOneToManyArrayEntity()
@@ -739,6 +753,8 @@ class DoctrineObjectTest extends BaseTestCase
                     function ($arg) {
                         if ($arg === 'id') {
                             return 'integer';
+                        } elseif ($arg === 'field') {
+                            return 'string';
                         } elseif ($arg === 'entities') {
                             return 'Doctrine\Common\Collections\ArrayCollection';
                         }
@@ -758,6 +774,8 @@ class DoctrineObjectTest extends BaseTestCase
                     function ($arg) {
                         if ($arg === 'id') {
                             return false;
+                        } elseif ($arg === 'field') {
+                            return 'string';
                         } elseif ($arg === 'entities') {
                             return true;
                         }
@@ -793,6 +811,11 @@ class DoctrineObjectTest extends BaseTestCase
             ->expects($this->any())
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
+
+        $this->metadata
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue(array("id")));
 
         $this->hydratorByValue     = new DoctrineObjectHydrator(
             $this->objectManager,
@@ -1533,14 +1556,14 @@ class DoctrineObjectTest extends BaseTestCase
             ->method('find')
             ->with(
                 'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
-                $this->logicalOr($this->equalTo(2), $this->equalTo(3))
+                $this->logicalOr($this->equalTo(array('id' => 2)), $this->equalTo(array('id' => 3)))
             )
             ->will(
                 $this->returnCallback(
                     function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg === 2) {
+                        if ($arg['id'] === 2) {
                             return $entityInDatabaseWithIdOfTwo;
-                        } elseif ($arg === 3) {
+                        } elseif ($arg['id'] === 3) {
                             return $entityInDatabaseWithIdOfThree;
                         }
 
@@ -1634,6 +1657,7 @@ class DoctrineObjectTest extends BaseTestCase
 
     public function testHydrateOneToManyAssociationByReferenceUsingIdentifiersArrayForRelations()
     {
+
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Asset\OneToManyEntity();
         $this->configureObjectManagerForOneToManyEntity();
@@ -1720,14 +1744,14 @@ class DoctrineObjectTest extends BaseTestCase
             ->method('find')
             ->with(
                 'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
-                $this->logicalOr($this->equalTo(2), $this->equalTo(3))
+                $this->logicalOr($this->equalTo(array('id' => 2)), $this->equalTo(array('id' => 3)))
             )
             ->will(
                 $this->returnCallback(
                     function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg === 2) {
+                        if ($arg['id'] === 2) {
                             return $entityInDatabaseWithIdOfTwo;
-                        } elseif ($arg === 3) {
+                        } elseif ($arg['id'] === 3) {
                             return $entityInDatabaseWithIdOfThree;
                         }
 
@@ -1810,7 +1834,7 @@ class DoctrineObjectTest extends BaseTestCase
 
     public function testHydrateOneToManyAssociationByReferenceUsingDisallowRemoveStrategy()
     {
-        // When using hydration by reference, it won't use the public API of the entity to set values (setters)
+       // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $toMany1 = new Asset\SimpleEntity();
         $toMany1->setId(2);
         $toMany1->setField('foo', false);
@@ -1864,6 +1888,164 @@ class DoctrineObjectTest extends BaseTestCase
 
         $this->assertEquals(8, $entities[2]->getId());
         $this->assertSame($toMany3, $entities[2]);
+    }
+
+    public function testHydrateOneToManyAssociationByValueWithArrayCausingDataModifications()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $data = array(
+            'entities' => array(
+                array('id' => 2, 'field' => 'Modified By Hydrate'),
+                array('id' => 3, 'field' => 'Modified By Hydrate')
+            )
+        );
+
+        $entityInDatabaseWithIdOfTwo = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfTwo->setId(2);
+        $entityInDatabaseWithIdOfTwo->setField('foo', false);
+
+        $entityInDatabaseWithIdOfThree = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfThree->setId(3);
+        $entityInDatabaseWithIdOfThree->setField('bar', false);
+
+        $entity = new Asset\OneToManyEntityWithEntities(
+            new ArrayCollection(array(
+                $entityInDatabaseWithIdOfTwo,
+                $entityInDatabaseWithIdOfThree
+            ))
+        );
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this
+            ->objectManager
+            ->expects($this->exactly(2))
+            ->method('find')
+            ->with(
+                'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
+                $this->logicalOr($this->equalTo(array('id' => 2)), $this->equalTo(array('id' => 3)))
+            )
+            ->will(
+                $this->returnCallback(
+                    function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                        if ($arg['id'] === 2) {
+                            return $entityInDatabaseWithIdOfTwo;
+                        } elseif ($arg['id'] === 3) {
+                            return $entityInDatabaseWithIdOfThree;
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntityWithEntities', $entity);
+
+        /* @var $entity \DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntity */
+        $entities = $entity->getEntities(false);
+
+        foreach ($entities as $en) {
+            $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $en);
+            $this->assertInternalType('integer', $en->getId());
+            $this->assertInternalType('string', $en->getField());
+            $this->assertContains('Modified By Hydrate', $en->getField(false));
+        }
+
+        $this->assertEquals(2, $entities[0]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfTwo, $entities[0]);
+
+        $this->assertEquals(3, $entities[1]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
+    }
+
+    public function testHydrateOneToManyAssociationByReferenceWithArrayCausingDataModifications()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $data = array(
+            'entities' => array(
+                array('id' => 2, 'field' => 'Modified By Hydrate'),
+                array('id' => 3, 'field' => 'Modified By Hydrate')
+            )
+        );
+
+        $entityInDatabaseWithIdOfTwo = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfTwo->setId(2);
+        $entityInDatabaseWithIdOfTwo->setField('Unmodified Value', false);
+
+        $entityInDatabaseWithIdOfThree = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfThree->setId(3);
+        $entityInDatabaseWithIdOfThree->setField('Unmodified Value', false);
+
+        $entity = new Asset\OneToManyEntityWithEntities(
+            new ArrayCollection(array(
+                $entityInDatabaseWithIdOfTwo,
+                $entityInDatabaseWithIdOfThree
+            ))
+        );
+
+        $reflSteps = array(
+            new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntityWithEntities'),
+            new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity'),
+            new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity'),
+            new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntityWithEntities'),
+        );
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnCallback(
+                function () use (&$reflSteps) {
+                    $refl = array_shift($reflSteps);
+                    return $refl;
+                }
+            ));
+
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this
+            ->objectManager
+            ->expects($this->exactly(2))
+            ->method('find')
+            ->with(
+                'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
+                $this->logicalOr($this->equalTo(array('id' => 2)), $this->equalTo(array('id' => 3)))
+            )
+            ->will(
+                $this->returnCallback(
+                    function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                        if ($arg['id'] === 2) {
+                            return $entityInDatabaseWithIdOfTwo;
+                        } elseif ($arg['id'] === 3) {
+                            return $entityInDatabaseWithIdOfThree;
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntityWithEntities', $entity);
+
+        /* @var $entity \DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntity */
+        $entities = $entity->getEntities(false);
+
+        foreach ($entities as $en) {
+            $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $en);
+            $this->assertInternalType('integer', $en->getId());
+            $this->assertInternalType('string', $en->getField());
+            $this->assertContains('Modified By Hydrate', $en->getField(false));
+        }
+
+        $this->assertEquals(2, $entities[0]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfTwo, $entities[0]);
+
+        $this->assertEquals(3, $entities[1]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
+
+
     }
 
     public function testAssertCollectionsAreNotSwappedDuringHydration()
@@ -1926,12 +2108,12 @@ class DoctrineObjectTest extends BaseTestCase
             ->method('find')
             ->with(
                 'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
-                $this->logicalOr($this->equalTo(2), $this->equalTo(3))
+                $this->logicalOr($this->equalTo(array('id' =>2)), $this->equalTo(array('id' => 3)))
             )
             ->will(
                 $this->returnCallback(
-                    function ($arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg === 2) {
+                    function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                        if ($arg['id'] === 2) {
                             return $entityInDatabaseWithIdOfTwo;
                         }
 

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -642,11 +642,13 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getTypeOfField')
-            ->with($this->logicalOr(
-                $this->equalTo('id'),
-                $this->equalTo('entities'),
-                $this->equalTo('field'))
-            )
+            ->with(
+                $this->logicalOr(
+                    $this->equalTo('id'),
+                    $this->equalTo('entities'),
+                    $this->equalTo('field')
+                )
+            );
             ->will(
                 $this->returnCallback(
                     function ($arg) {

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -749,7 +749,13 @@ class DoctrineObjectTest extends BaseTestCase
             ->metadata
             ->expects($this->any())
             ->method('getTypeOfField')
-            ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities')))
+            ->with(
+                $this->logicalOr(
+                    $this->equalTo('id'),
+                    $this->equalTo('entities'),
+                    $this->equalTo('field')
+                )
+            )
             ->will(
                 $this->returnCallback(
                     function ($arg) {
@@ -2024,6 +2030,74 @@ class DoctrineObjectTest extends BaseTestCase
             $this->assertInternalType('integer', $en->getId());
             $this->assertInternalType('string', $en->getField());
             $this->assertContains('Modified By Hydrate', $en->getField(false));
+        }
+
+        $this->assertEquals(2, $entities[0]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfTwo, $entities[0]);
+
+        $this->assertEquals(3, $entities[1]->getId());
+        $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
+    }
+
+    public function testHydrateOneToManyAssociationByValueWithStdClass()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $stdClass1 = new \StdClass();
+        $stdClass1->id = 2;
+
+        $stdClass2 = new \StdClass();
+        $stdClass2->id = 3;
+
+        $data = array('entities' => array($stdClass1, $stdClass2));
+
+        $entityInDatabaseWithIdOfTwo = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfTwo->setId(2);
+        $entityInDatabaseWithIdOfTwo->setField('foo', false);
+
+        $entityInDatabaseWithIdOfThree = new Asset\SimpleEntity();
+        $entityInDatabaseWithIdOfThree->setId(3);
+        $entityInDatabaseWithIdOfThree->setField('bar', false);
+
+        $entity = new Asset\OneToManyEntityWithEntities(
+            new ArrayCollection(array(
+                $entityInDatabaseWithIdOfTwo,
+                $entityInDatabaseWithIdOfThree
+            ))
+        );
+        $this->configureObjectManagerForOneToManyEntity();
+
+        $this
+            ->objectManager
+            ->expects($this->exactly(2))
+            ->method('find')
+            ->with(
+                'DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity',
+                $this->logicalOr($this->equalTo(array('id' => 2)), $this->equalTo(array('id' => 3)))
+            )
+            ->will(
+                $this->returnCallback(
+                    function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                        if ($arg['id'] === 2) {
+                            return $entityInDatabaseWithIdOfTwo;
+                        } elseif ($arg['id'] === 3) {
+                            return $entityInDatabaseWithIdOfThree;
+                        }
+
+                        throw new \InvalidArgumentException();
+                    }
+                )
+            );
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntityWithEntities', $entity);
+
+        /* @var $entity \DoctrineModuleTest\Stdlib\Hydrator\Asset\OneToManyEntity */
+        $entities = $entity->getEntities(false);
+
+        foreach ($entities as $en) {
+            $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity', $en);
+            $this->assertInternalType('integer', $en->getId());
         }
 
         $this->assertEquals(2, $entities[0]->getId());


### PR DESCRIPTION
While working with DoctrineModule in a current Apigility project we needed to be able to hydrate the data in ToMany relationships from an array structure on POST,PUT & PATCH requests. However the current implementation would result in a ORMException::unrecognizedIdentifierFields being thrown. (see https://github.com/zfcampus/zf-apigility-doctrine/issues/183 for additional details)

I've now refactored the toMany function to evaluate data coming in and hydrate objects accordingly. All tests and been checked and where required corrected as well as introducing two new tests to validate hydration from an Array 
