### PR TITLE
Change isNullIdentifier() accessibility to protected

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -543,7 +543,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @return bool
      */
-    private function isNullIdentifier($identifier)
+    protected function isNullIdentifier($identifier)
     {
         if (null === $identifier) {
             return true;


### PR DESCRIPTION
`isNullIdentifier()` is the only private method in this class, and I don't think it's very well justified, particularly since I require it in a derived class that implements support for embedded documents.