### PR TITLE
Allow for the use of Zend\Cache\Service\StorageCacheAbstractServiceFactory

### DIFF
--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -62,10 +62,12 @@ class CacheFactory extends AbstractFactory
             case 'Doctrine\Common\Cache\FilesystemCache':
                 $cache = new $class($options->getDirectory());
                 break;
+
             case 'DoctrineModule\Cache\ZendStorageCache':
             case 'Doctrine\Common\Cache\PredisCache':
                 $cache = new $class($instance);
                 break;
+
             default:
                 $cache = new $class;
         }

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -58,15 +58,14 @@ class CacheFactory extends AbstractFactory
             $instance = $serviceLocator->get($instance);
         }
 
-        switch ($this->name) {
-            case 'filesystem':
+        switch ($class) {
+            case 'Doctrine\Common\Cache\FilesystemCache':
                 $cache = new $class($options->getDirectory());
                 break;
-
-            case 'predis':
+            case 'DoctrineModule\Cache\ZendStorageCache':
+            case 'Doctrine\Common\Cache\PredisCache':
                 $cache = new $class($instance);
                 break;
-
             default:
                 $cache = new $class;
         }

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -59,6 +59,7 @@ class CacheFactoryTest extends BaseTestCase
 
     /**
      * @covers \DoctrineModule\Service\CacheFactory::createService
+     * @group 547
      */
     public function testCreateZendCache()
     {
@@ -85,7 +86,8 @@ class CacheFactoryTest extends BaseTestCase
                     ]
                 ]
             ]
-        )->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
+        );
+        $serviceManager->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
 
         $cache = $factory->createService($serviceManager);
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -57,6 +57,41 @@ class CacheFactoryTest extends BaseTestCase
         $this->assertSame('bar', $service->getNamespace());
     }
 
+    /**
+     * @covers \DoctrineModule\Service\CacheFactory::createService
+     */
+    public function testCreateZendCache()
+    {
+        $factory        = new CacheFactory('phpunit');
+        $serviceManager = new ServiceManager();
+        $serviceManager->setAlias('Config', 'Configuration');
+        $serviceManager->setService(
+            'Configuration',
+            [
+                'doctrine' => [
+                    'cache' => [
+                        'phpunit' => [
+                            'class' => 'DoctrineModule\Cache\ZendStorageCache',
+                            'instance' => 'my-zend-cache',
+                            'namespace' => 'DoctrineModule',
+                        ],
+                    ],
+                ],
+                'caches' => [
+                    'my-zend-cache' => [
+                        'adapter' => [
+                            'name' => 'blackhole'
+                        ]
+                    ]
+                ]
+            ]
+        )->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
+
+        $cache = $factory->createService($serviceManager);
+
+        $this->assertInstanceOf('DoctrineModule\Cache\ZendStorageCache', $cache);
+    }
+
     public function testCreatePredisCache()
     {
         $factory        = new CacheFactory('predis');


### PR DESCRIPTION
## Motivation

ZF2 contains an abstract factory to create caches we want to use. We also want to use the `DoctrineModule\Cache\ZendStorageCache` adapter to use the zend cache storages created from the abstract factory without having to write a new factory just to use the zend cache storages / bridge between zend and doctrine caches.

## Issues

1. The `DoctrineModule\Cache\ZendStorageCache` requires the zend cache storages as constructor argument. The `DoctrineModule\Service\CacheFactory` is hardwired to only pass the zend cache storage as constructor argument if the doctrine-adapter (with the name) `predis` is used.

## Workaround

A workaround is to use `predis` as config-key for the cache and rely that the CacheFactory of DoctrineModule then does the right thing and pass the storage as constructor argument. Obvious drawbacks are:
- only 1 cache storage created from the abstract factory is useable (the one under the key `predis`) and
- it is semantically wrong to - for example - have a memcache instance under the config-key `predis`

### config
```yaml
service_manager:
    abstract_factories:
        - "Zend\\Cache\\Service\\StorageCacheAbstractServiceFactory"
doctrine:
    configuration:
        metadata_cache: "predis"
    cache:
        predis: # notice how we overwrite the pre-configured predis doctrine cache to use a memcache
            class: "DoctrineModule\\Cache\\ZendStorageCache"
            instance: memcache
caches:
    memcache:
        adapter:
            name: "memcache"
            options:
                servers:
                ...
```
## Fix

The `DoctrineModule\Service\CacheFactory` is not hardwired to the name of the cache, but to the class-name which is instantiated. The drawbacks listed above disappear and the config is semantically correct. It also should be more future proof, as relying on name is not robust.

### config
```yaml
service_manager:
    abstract_factories:
        - "Zend\\Cache\\Service\\StorageCacheAbstractServiceFactory"
doctrine:
    configuration:
        metadata_cache: "memcache"
    cache:
        memcache:
            class: "DoctrineModule\\Cache\\ZendStorageCache"
            instance: memcache
caches:
    memcache:
        adapter:
            name: "memcache"
            options:
                servers:
                ...
```

Thank you in advance for considering my pull request. If you have any questions or improvements please let me know and i will update the PR.