### PR TITLE
Update composer.json to allow for doctrine/common 2.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php":                                ">=5.4",
-        "doctrine/common":                    ">=2.4,<2.6-dev",
+        "doctrine/common":                    ">=2.4,<2.7",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",
         "zendframework/zend-authentication":  "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php":                                ">=5.4",
-        "doctrine/common":                    ">=2.4,<2.7",
+        "doctrine/common":                    "~2.6",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",
         "zendframework/zend-authentication":  "~2.3",


### PR DESCRIPTION
I'm not sure if this makes sense or is dangerous. But I think it would solve this

https://github.com/zf-fr/zfr-oauth2-server-doctrine/issues/5

I currently do this in my project composer.json which can't be recommended either... :-)

"doctrine/common": "2.6.1 as 2.5.4"
