### PR TITLE
Drop PHP5.4 for 0.x releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7
     - php: hhvm
 
 before_script:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+ * Remove deprecated api call from test [#523](https://github.com/doctrine/DoctrineModule/pull/523)
+ * Allow for the use of Zend\Cache\Service\StorageCacheAbstractServiceFactory [#547](https://github.com/doctrine/DoctrineModule/pull/547)
+
 # 0.10.0
 
  * Fixed php_codesniffer dependency [#521](https://github.com/doctrine/DoctrineModule/pull/521)

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php":                                ">=5.5",
+        "php":                                "^5.5 || ^7.0",
         "doctrine/common":                    "~2.6",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php":                                ">=5.4",
-        "doctrine/common":                    ">=2.4,<2.6-dev",
+        "doctrine/common":                    ">=2.4,<2.7",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",
         "zendframework/zend-authentication":  "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php":                                ">=5.4",
-        "doctrine/common":                    ">=2.4,<2.7",
+        "doctrine/common":                    "~2.6",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",
         "zendframework/zend-authentication":  "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php":                                ">=5.4",
+        "php":                                ">=5.5",
         "doctrine/common":                    "~2.6",
         "doctrine/cache":                     "~1.5",
         "symfony/console":                    "~2.3|~3.0",

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -59,7 +59,6 @@ class ObjectRepository extends AbstractAdapter
 
     /**
      * @param  array|AuthenticationOptions $options
-     * @return ObjectRepository
      */
     public function setOptions($options)
     {
@@ -70,7 +69,7 @@ class ObjectRepository extends AbstractAdapter
         $this->options = $options;
         return $this;
     }
-    
+
     /**
      * @return AuthenticationOptions
      */
@@ -79,51 +78,7 @@ class ObjectRepository extends AbstractAdapter
         return $this->options;
     }
 
-    /**
-     * Set the value to be used as the identity
-     *
-     * @param  mixed $identityValue
-     * @return ObjectRepository
-     * @deprecated use setIdentity instead
-     */
-    public function setIdentityValue($identityValue)
-    {
-        $this->identity = $identityValue;
-        return $this;
-    }
-
-    /**
-     * @return string
-     * @deprecated use getIdentity instead
-     */
-    public function getIdentityValue()
-    {
-        return $this->identity;
-    }
-
-    /**
-     * Set the credential value to be used.
-     *
-     * @param  mixed $credentialValue
-     * @return ObjectRepository
-     * @deprecated use setCredential instead
-     */
-    public function setCredentialValue($credentialValue)
-    {
-        $this->credential = $credentialValue;
-        return $this;
-    }
-
-    /**
-     * @return string
-     * @deprecated use getCredential instead
-     */
-    public function getCredentialValue()
-    {
-        return $this->credential;
-    }
-
-    /**
+    /*
      * {@inheritDoc}
      */
     public function authenticate()

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -62,10 +62,12 @@ class CacheFactory extends AbstractFactory
             case 'Doctrine\Common\Cache\FilesystemCache':
                 $cache = new $class($options->getDirectory());
                 break;
+
             case 'DoctrineModule\Cache\ZendStorageCache':
             case 'Doctrine\Common\Cache\PredisCache':
                 $cache = new $class($instance);
                 break;
+
             default:
                 $cache = new $class;
         }

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -58,15 +58,14 @@ class CacheFactory extends AbstractFactory
             $instance = $serviceLocator->get($instance);
         }
 
-        switch ($this->name) {
-            case 'filesystem':
+        switch ($class) {
+            case 'Doctrine\Common\Cache\FilesystemCache':
                 $cache = new $class($options->getDirectory());
                 break;
-
-            case 'predis':
+            case 'DoctrineModule\Cache\ZendStorageCache':
+            case 'Doctrine\Common\Cache\PredisCache':
                 $cache = new $class($instance);
                 break;
-
             default:
                 $cache = new $class;
         }

--- a/src/DoctrineModule/Version.php
+++ b/src/DoctrineModule/Version.php
@@ -29,5 +29,5 @@ namespace DoctrineModule;
  */
 class Version
 {
-    const VERSION = '0.10.0';
+    const VERSION = '1.0.0';
 }

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -209,7 +209,7 @@ class ObjectRepositoryTest extends BaseTestCase
             )
         );
 
-        $adapter->setIdentityValue('a username');
+        $adapter->setIdentity('a username');
         $adapter->setCredential('a password');
         $adapter->authenticate();
     }

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -59,6 +59,7 @@ class CacheFactoryTest extends BaseTestCase
 
     /**
      * @covers \DoctrineModule\Service\CacheFactory::createService
+     * @group 547
      */
     public function testCreateZendCache()
     {
@@ -85,7 +86,8 @@ class CacheFactoryTest extends BaseTestCase
                     ]
                 ]
             ]
-        )->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
+        );
+        $serviceManager->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
 
         $cache = $factory->createService($serviceManager);
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -57,6 +57,41 @@ class CacheFactoryTest extends BaseTestCase
         $this->assertSame('bar', $service->getNamespace());
     }
 
+    /**
+     * @covers \DoctrineModule\Service\CacheFactory::createService
+     */
+    public function testCreateZendCache()
+    {
+        $factory        = new CacheFactory('phpunit');
+        $serviceManager = new ServiceManager();
+        $serviceManager->setAlias('Config', 'Configuration');
+        $serviceManager->setService(
+            'Configuration',
+            [
+                'doctrine' => [
+                    'cache' => [
+                        'phpunit' => [
+                            'class' => 'DoctrineModule\Cache\ZendStorageCache',
+                            'instance' => 'my-zend-cache',
+                            'namespace' => 'DoctrineModule',
+                        ],
+                    ],
+                ],
+                'caches' => [
+                    'my-zend-cache' => [
+                        'adapter' => [
+                            'name' => 'blackhole'
+                        ]
+                    ]
+                ]
+            ]
+        )->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
+
+        $cache = $factory->createService($serviceManager);
+
+        $this->assertInstanceOf('DoctrineModule\Cache\ZendStorageCache', $cache);
+    }
+
     public function testCreatePredisCache()
     {
         $factory        = new CacheFactory('predis');

--- a/tests/DoctrineModuleTest/ServiceManagerTestCase.php
+++ b/tests/DoctrineModuleTest/ServiceManagerTestCase.php
@@ -66,7 +66,9 @@ class ServiceManagerTestCase
         );
 
         $serviceManager->setService('ApplicationConfig', $configuration);
-        $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
+        if (!$serviceManager->has('ServiceListener')) {
+            $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
+        }
 
         /* @var $moduleManager \Zend\ModuleManager\ModuleManagerInterface */
         $moduleManager = $serviceManager->get('ModuleManager');


### PR DESCRIPTION
It is a security update for 0.x release

@Ocramius 