### PR TITLE
Hydrator ignores private/protected getter/setter

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -258,7 +258,7 @@ class DoctrineObject extends AbstractHydrator
                 $target = $metadata->getAssociationTargetClass($field);
 
                 if ($metadata->isSingleValuedAssociation($field)) {
-                    if (! method_exists($object, $setter)) {
+                    if (! is_callable([$object, $setter])) {
                         continue;
                     }
 
@@ -275,7 +275,7 @@ class DoctrineObject extends AbstractHydrator
                     $this->toMany($object, $field, $target, $value);
                 }
             } else {
-                if (! method_exists($object, $setter)) {
+                if (! is_callable([$object, $setter])) {
                     continue;
                 }
 
@@ -438,7 +438,7 @@ class DoctrineObject extends AbstractHydrator
                     switch (gettype($value)) {
                         case 'object':
                             $getter = 'get' . ucfirst($field);
-                            if (method_exists($value, $getter)) {
+                            if (is_callable([$value, $getter])) {
                                 $find[$field] = $value->$getter();
                             } elseif (property_exists($value, $field)) {
                                 $find[$field] = $value->$field;

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimplePrivateEntity.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimplePrivateEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+class SimplePrivateEntity
+{
+    private function setPrivate($value)
+    {
+        throw new \Exception('Should never be called');
+    }
+
+    private function getPrivate()
+    {
+        throw new \Exception('Should never be called');
+    }
+
+    protected function setProtected($value)
+    {
+        throw new \Exception('Should never be called');
+    }
+
+    protected function getProtected()
+    {
+        throw new \Exception('Should never be called');
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2518,4 +2518,71 @@ class DoctrineObjectTest extends BaseTestCase
         $entity = $this->hydratorByValue->hydrate(array('camel_case' => $name), new NamingStrategyEntity());
         $this->assertEquals($name, $entity->getCamelCase());
     }
+
+    public function configureObjectManagerForSimplePrivateEntity()
+    {
+        $refl = new ReflectionClass('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimplePrivateEntity');
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimplePrivateEntity'));
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue(array()));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(array('private', 'protected')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr($this->equalTo('private'), $this->equalTo('protected')))
+            ->will($this->returnValue('integer'));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->will($this->returnValue(false));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->will($this->returnValue(array('private')));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this->hydratorByValue     = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
+    public function testCannotHydratePrivateByValue()
+    {
+        $entity = new Asset\SimplePrivateEntity();
+        $this->configureObjectManagerForSimplePrivateEntity();
+        $data = array('private' => 123, 'protected' => 456);
+
+        $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\SimplePrivateEntity', $entity);
+    }
 }


### PR DESCRIPTION
If the entity had a getter/setter which was private or protected the hydrator tried to call it anyway 
and thus threw an exception. We now silently ignore them if there are not callable.

This allow for entities that have "read-only" fields which are set internally (such as timestamp).