### PR TITLE
Changed isset for array_key_exists in context check

### DIFF
--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -161,7 +161,7 @@ class UniqueObject extends ObjectExists
 
         $result = array();
         foreach ($this->getIdentifiers() as $identifierField) {
-            if (!isset($context[$identifierField])) {
+            if (!array_key_exists($identifierField, $context)) {
                 throw new Exception\RuntimeException(\sprintf('Expected context to contain %s', $identifierField));
             }
 


### PR DESCRIPTION
**isset()** does not return TRUE for array keys that correspond to a NULL value, while **array_key_exists()** does.