### PR TITLE
Expose to `zend-component-installer` as module `DoctrineModule`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
             "homepage": "http://www.michaelgallego.fr"
         }
     ],
+    "extra": {
+        "zf": {
+            "module": "DoctrineModule"
+        }
+    },
     "require": {
         "php":                               "^5.6 || ^7.0",
         "doctrine/common":                   "^2.6.1",


### PR DESCRIPTION
There is new library used with zend application skeleton and apigility skeleton to simplify installation of new modules: [`zend-component-installer`](https://github.com/zendframework/zend-component-installer).