### PR TITLE
ZF3 Composer dependencies - hotfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "zendframework/zend-cache":          "^2.7.1",
         "zendframework/zend-form":           "^2.9",
         "zendframework/zend-hydrator":       "^1.1 || ^2.2.1",
-        "zendframework/zend-mvc":            "^2.7.10 || ^3.0.2",
+        "zendframework/zend-mvc":            "^2.7.10 || ^3.0.1",
         "zendframework/zend-paginator":      "^2.7",
-        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
+        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
         "zendframework/zend-stdlib":         "^2.7.7 || ^3.0.1",
         "zendframework/zend-validator":      "^2.8.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name":        "doctrine/doctrine-module",
-    "description": "Zend Framework 2 Module that provides Doctrine basic functionality required for ORM and ODM modules",
+    "description": "Zend Framework Module that provides Doctrine basic functionality required for ORM and ODM modules",
     "type":        "library",
     "license":     "MIT",
     "homepage":    "http://www.doctrine-project.org/",
     "keywords":    [
         "doctrine",
         "module",
-        "zf2"
+        "zf"
     ],
     "authors":     [
         {


### PR DESCRIPTION
Decreased composer dependencies of zend modules to match dependencies in ZendSkeletonApplication.
Currently if we build new project using composer `create-project` (from `ZendSkeletonApplication`) we have to run `composer update` because locked dependencies there are lower than required here.
We can safely decrees these dependencies in this library.