### PR TITLE
Add APCu cache to configuration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -24,6 +24,10 @@ return [
                 'class'     => 'Doctrine\Common\Cache\ApcCache',
                 'namespace' => 'DoctrineModule',
             ],
+            'apcu' => [
+                'class'     => 'Doctrine\Common\Cache\ApcuCache',
+                'namespace' => 'DoctrineModule',
+            ],
             'array' => [
                 'class' => 'Doctrine\Common\Cache\ArrayCache',
                 'namespace' => 'DoctrineModule',


### PR DESCRIPTION
Same as #569, because apparently it was deleted in the [next commit](6706e63) (probably by mistake? since it looks like it's just a PSR-2 appliance commit). 

You can check the file history [here](https://github.com/doctrine/DoctrineModule/commits/master/config/module.config.php).