### PR TITLE
Use service manager factory for cache when possible

### DIFF
--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -22,9 +22,8 @@ namespace DoctrineModule\Service;
 use Doctrine\Common\Cache\CacheProvider;
 use Interop\Container\ContainerInterface;
 use RuntimeException;
-use Doctrine\Common\Cache\MemcacheCache;
-use Doctrine\Common\Cache\MemcachedCache;
-use Doctrine\Common\Cache\RedisCache;
+use Doctrine\Common\Cache;
+use DoctrineModule\Cache\ZendStorageCache;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
@@ -63,12 +62,12 @@ class CacheFactory extends AbstractFactory
             $cache = $container->get($class);
         } else {
             switch ($class) {
-                case \Doctrine\Common\Cache\FilesystemCache::class:
+                case Cache\FilesystemCache::class:
                     $cache = new $class($options->getDirectory());
                     break;
 
-                case \DoctrineModule\Cache\ZendStorageCache::class:
-                case \Doctrine\Common\Cache\PredisCache::class:
+                case ZendStorageCache::class:
+                case Cache\PredisCache::class:
                     $cache = new $class($instance);
                     break;
 
@@ -78,13 +77,13 @@ class CacheFactory extends AbstractFactory
             }
         }
 
-        if ($cache instanceof MemcacheCache) {
+        if ($cache instanceof Cache\MemcacheCache) {
             /* @var $cache MemcacheCache */
             $cache->setMemcache($instance);
-        } elseif ($cache instanceof MemcachedCache) {
+        } elseif ($cache instanceof Cache\MemcachedCache) {
             /* @var $cache MemcachedCache */
             $cache->setMemcached($instance);
-        } elseif ($cache instanceof RedisCache) {
+        } elseif ($cache instanceof Cache\RedisCache) {
             /* @var $cache RedisCache */
             $cache->setRedis($instance);
         }

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -59,18 +59,22 @@ class CacheFactory extends AbstractFactory
             $instance = $container->get($instance);
         }
 
-        switch ($class) {
-            case 'Doctrine\Common\Cache\FilesystemCache':
-                $cache = new $class($options->getDirectory());
-                break;
+        if ($container->has($class)) {
+            $cache = $container->get($class);
+        } else {
+            switch ($class) {
+                case 'Doctrine\Common\Cache\FilesystemCache':
+                    $cache = new $class($options->getDirectory());
+                    break;
 
-            case 'DoctrineModule\Cache\ZendStorageCache':
-            case 'Doctrine\Common\Cache\PredisCache':
-                $cache = new $class($instance);
-                break;
+                case 'DoctrineModule\Cache\ZendStorageCache':
+                case 'Doctrine\Common\Cache\PredisCache':
+                    $cache = new $class($instance);
+                    break;
 
-            default:
-                $cache = new $class;
+                default:
+                    $cache = new $class;
+            }
         }
 
         if ($cache instanceof MemcacheCache) {

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -63,17 +63,18 @@ class CacheFactory extends AbstractFactory
             $cache = $container->get($class);
         } else {
             switch ($class) {
-                case 'Doctrine\Common\Cache\FilesystemCache':
+                case \Doctrine\Common\Cache\FilesystemCache::class:
                     $cache = new $class($options->getDirectory());
                     break;
 
-                case 'DoctrineModule\Cache\ZendStorageCache':
-                case 'Doctrine\Common\Cache\PredisCache':
+                case \DoctrineModule\Cache\ZendStorageCache::class:
+                case \Doctrine\Common\Cache\PredisCache::class:
                     $cache = new $class($instance);
                     break;
 
                 default:
                     $cache = new $class;
+                    break;
             }
         }
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -131,16 +131,16 @@ class CacheFactoryTest extends BaseTestCase
                 'doctrine' => [
                     'cache' => [
                         'chain' => [
-                            'class' => 'Doctrine\Common\Cache\ChainCache',
+                            'class' => Doctrine\Common\Cache\ChainCache::class,
                         ],
                     ],
                 ],
             ]
         );
 
-        $mock = $this->getMock('Doctrine\Common\Cache\ChainCache');
+        $mock = $this->getMock(Doctrine\Common\Cache\ChainCache::class);
 
-        $serviceManager->setFactory('Doctrine\Common\Cache\ChainCache', function () use ($mock) {
+        $serviceManager->setFactory(Doctrine\Common\Cache\ChainCache::class, function () use ($mock) {
             return $mock;
         });
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineModuleTest\Service;
 
+use Doctrine\Common\Cache\ChainCache;
 use DoctrineModule\Service\CacheFactory;
 use PHPUnit_Framework_TestCase as BaseTestCase;
 use Zend\ServiceManager\ServiceManager;
@@ -131,16 +132,16 @@ class CacheFactoryTest extends BaseTestCase
                 'doctrine' => [
                     'cache' => [
                         'chain' => [
-                            'class' => Doctrine\Common\Cache\ChainCache::class,
+                            'class' => ChainCache::class,
                         ],
                     ],
                 ],
             ]
         );
 
-        $mock = $this->getMock(Doctrine\Common\Cache\ChainCache::class);
+        $mock = $this->getMock(ChainCache::class);
 
-        $serviceManager->setFactory(Doctrine\Common\Cache\ChainCache::class, function () use ($mock) {
+        $serviceManager->setFactory(ChainCache::class, function () use ($mock) {
             return $mock;
         });
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -120,4 +120,32 @@ class CacheFactoryTest extends BaseTestCase
 
         $this->assertInstanceOf('Doctrine\Common\Cache\PredisCache', $cache);
     }
+
+    public function testUseServiceFactory()
+    {
+        $factory        = new CacheFactory('chain');
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'Configuration',
+            [
+                'doctrine' => [
+                    'cache' => [
+                        'chain' => [
+                            'class' => 'Doctrine\Common\Cache\ChainCache',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $mock = $this->getMock('Doctrine\Common\Cache\ChainCache');
+
+        $serviceManager->setFactory('Doctrine\Common\Cache\ChainCache', function () use ($mock) {
+            return $mock;
+        });
+
+        $cache = $factory->createService($serviceManager);
+
+        $this->assertSame($mock, $cache);
+    }
 }


### PR DESCRIPTION
If a user has defined a factory for a given cache, we should use that factory to instantiate it. This will allow the user to define the logic and dependencies for their caches and give them greater flexibility when instantiating them.