### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
+<<<<<<< HEAD
         - CS_CHECK=true
+=======
+        - TEST_COVERAGE=true
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
     - php: 7.1
       env:
         - DEPS=latest
@@ -32,7 +36,14 @@ matrix:
       env:
         - DEPS=locked
         - CS_CHECK=true
+<<<<<<< HEAD
     - php: 7.1
+=======
+    - php: 7.2
+      env:
+        - DEPS=latest
+    - php: nightly
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
       env:
         - DEPS=lowest
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -43,28 +43,39 @@
     },
     "require": {
         "php":                               "^7.1",
+<<<<<<< HEAD
         "doctrine/common":                   "^2.6.1",
         "doctrine/cache":                    "^1.6",
         "symfony/console":                   "^2.3 || ^3.0 || ^4.0",
+=======
+        "doctrine/common":                   "^2.8",
+        "doctrine/cache":                    "^1.7",
+        "symfony/console":                   "^3.3",
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
         "zendframework/zend-authentication": "^2.5.3",
         "zendframework/zend-cache":          "^2.7.1",
-        "zendframework/zend-form":           "^2.9",
-        "zendframework/zend-hydrator":       "^1.1 || ^2.2.1",
-        "zendframework/zend-mvc":            "^2.7.10 || ^3.0.1",
-        "zendframework/zend-paginator":      "^2.7",
-        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
-        "zendframework/zend-stdlib":         "^2.7.7 || ^3.0.1",
-        "zendframework/zend-validator":      "^2.8.1"
+        "zendframework/zend-form":           "^2.10",
+        "zendframework/zend-hydrator":       "^2.3",
+        "zendframework/zend-mvc":            "^3.1",
+        "zendframework/zend-paginator":      "^2.8",
+        "zendframework/zend-servicemanager": "^3.3",
+        "zendframework/zend-stdlib":         "^3.1",
+        "zendframework/zend-validator":      "^2.10"
     },
     "require-dev": {
+<<<<<<< HEAD
         "phpunit/phpunit":                  "^4.8",
         "squizlabs/php_codesniffer":        "^2.7",
         "zendframework/zend-i18n":          "^2.7.3",
+=======
+        "phpunit/phpunit":                  "^6.4",
+        "zendframework/zend-i18n":          "^2.7",
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
         "zendframework/zend-log":           "^2.9",
-        "zendframework/zend-modulemanager": "^2.7.2",
+        "zendframework/zend-modulemanager": "^2.8",
         "zendframework/zend-serializer":    "^2.8",
-        "zendframework/zend-session":       "^2.7.3",
-        "zendframework/zend-test":          "^2.6.1 || ^3.0.1",
+        "zendframework/zend-session":       "^2.8",
+        "zendframework/zend-test":          "^3.1.1",
         "zendframework/zend-version":       "^2.5.1"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+<<<<<<< HEAD
     "content-hash": "35d0a6d8eee09a5c8f2bea20ed4833ec",
+=======
+    "content-hash": "b8838b4ffb92d8c869d9700b632f82f9",
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2694,6 +2698,7 @@
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
+<<<<<<< HEAD
             "name": "squizlabs/php_codesniffer",
             "version": "2.7.0",
             "source": {
@@ -2774,6 +2779,10 @@
         {
             "name": "symfony/yaml",
             "version": "v3.1.2",
+=======
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+>>>>>>> Update to PHPUnit 6.4 and PHP 7.1
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.