### PR TITLE
Configuration is an alias to config

### DIFF
--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -90,7 +90,7 @@ abstract class AbstractFactory implements FactoryInterface
             $name = $this->getName();
         }
 
-        $options = $container->get('Configuration');
+        $options = $container->get('config');
         $options = $options['doctrine'];
         if ($mappingType = $this->getMappingType()) {
             $options = $options[$mappingType];

--- a/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
@@ -33,7 +33,7 @@ class AdapterFactoryTest extends BaseTestCase
         $objectManager  = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'authentication' => [

--- a/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -37,7 +37,7 @@ class AuthenticationServiceFactoryTest extends BaseTestCase
 
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'authentication' => [

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -38,7 +38,7 @@ class StorageFactoryTest extends BaseTestCase
             'Zend\Authentication\Storage\Session'
         );
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'authentication' => [
@@ -73,7 +73,7 @@ class StorageFactoryTest extends BaseTestCase
         $serviceManager
             ->expects($this->at(0))
             ->method('get')
-            ->with('Configuration')
+            ->with('config')
             ->will($this->returnValue($config));
         $serviceManager
             ->expects($this->at(1))

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -39,7 +39,7 @@ class CacheFactoryTest extends BaseTestCase
         $factory        = new CacheFactory('foo');
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                  'doctrine' => [
                      'cache' => [
@@ -66,9 +66,8 @@ class CacheFactoryTest extends BaseTestCase
     {
         $factory        = new CacheFactory('phpunit');
         $serviceManager = new ServiceManager();
-        $serviceManager->setAlias('config', 'Configuration');
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'cache' => [
@@ -100,7 +99,7 @@ class CacheFactoryTest extends BaseTestCase
         $factory        = new CacheFactory('predis');
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'cache' => [
@@ -127,7 +126,7 @@ class CacheFactoryTest extends BaseTestCase
         $factory        = new CacheFactory('chain');
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'cache' => [

--- a/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
@@ -32,7 +32,7 @@ class DriverFactoryTest extends BaseTestCase
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'driver' => [
@@ -53,7 +53,7 @@ class DriverFactoryTest extends BaseTestCase
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'driver' => [

--- a/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
@@ -35,7 +35,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $factory        = new EventManagerFactory($name);
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'eventmanager' => [
@@ -64,7 +64,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $subscriber     = new DummyEventSubscriber();
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'eventmanager' => [
@@ -96,7 +96,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $serviceManager = new ServiceManager();
         $serviceManager->setService('dummy-subscriber', $subscriber);
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'eventmanager' => [
@@ -126,7 +126,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $factory        = new EventManagerFactory($name);
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
-            'Configuration',
+            'config',
             [
                 'doctrine' => [
                     'eventmanager' => [


### PR DESCRIPTION
see https://github.com/zendframework/zend-mvc/blob/master/src/Service/ServiceListenerFactory.php#L41-L43

so it would be better to use `config` directly.

see also https://github.com/doctrine/DoctrineORMModule/issues/545