### PR TITLE
Make Hydrator\DoctrineObject::handleTypeConversions handle all (simple) defaults 

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -466,7 +466,9 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Handle various type conversions that should be supported natively by Doctrine (like DateTime)
-     *
+     * See Documentation of Doctrine Mapping Types for defaults
+     * 
+     * @link http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#doctrine-mapping-types
      * @param  mixed  $value
      * @param  string $typeOfField
      * @return DateTime
@@ -474,6 +476,23 @@ class DoctrineObject extends AbstractHydrator
     protected function handleTypeConversions($value, $typeOfField)
     {
         switch ($typeOfField) {
+            case 'boolean':
+                $value = (bool)$value;
+                break;
+            case 'string':
+            case 'text':
+            case 'bigint':
+            case 'decimal':
+            case 'decimal':
+                $value = (string)$value;
+                break;
+            case 'integer':
+            case 'smallint':
+                $value = (int)$value;
+                break;
+            case 'float':
+                $value = (double)$value;
+                break;
             case 'datetimetz':
             case 'datetime':
             case 'time':


### PR DESCRIPTION
Extend DoctrineModule\Stdlib\Hydrator\DoctrineObject::handleTypeConversions() to handle all basic conversions according to documentation instead of just DateTime object related values


Stumbled across this, because I hadn't typecast some bools in an Entity setter method. That caused the UoW to detect changes e.g ` true === 1` and always updated the Entity although nothing changed (logically).

There are default type mappings from Doctrine to PHP via the hydrator, but not vice versa.
(see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#doctrine-mapping-types)

Now there are (at least the simple ones).

Before:
> Column definition is **boolean**
> $value in DB is **1** (TINYINT)
> $value extracted from hydrator is **true** _<== this should be the same in both directions_
> $value used in Form becomes **1**
> $value given to hydrator is **1**
> $value hydrated is **1** _<== but it isn't_

Now:
> Column definition is **boolean**
> $value in DB is **1** (TINYINT)
> $value extracted from hydrator is **true** _<== this should be the same in both directions_
> $value used in Form becomes **1**
> $value given to hydrator is **1**
> $value hydrated is **true** _<== now it is_

