### PR TITLE
fix when options is null

### DIFF
--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -32,7 +32,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      * @return \Doctrine\Common\Persistence\ObjectRepository
      * @throws ServiceCreationException
      */
-    protected function getRepository(ContainerInterface $container, array $options)
+    protected function getRepository(ContainerInterface $container, array $options = null)
     {
         if (empty($options['target_class'])) {
             throw new ServiceCreationException(sprintf(
@@ -53,7 +53,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      * @param array $options
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    protected function getObjectManager(ContainerInterface $container, array $options)
+    protected function getObjectManager(ContainerInterface $container, array $options = null)
     {
         $objectManager = ($options['object_manager']) ?? self::DEFAULT_OBJECTMANAGER_KEY;
 


### PR DESCRIPTION
If options are not set type error is thrown 
```
TypeError: Argument 2 passed to DoctrineModule\Validator\Service\AbstractValidatorFactory::getObjectManager() must be of the type array, null given
```