### PR TITLE
Throw exception for null objects in DoctrineObject hydrator.

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -145,6 +145,14 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function prepare($object)
     {
+        if(!is_object($object)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Object to be prepared must be an object, %s given',
+                    gettype($object)
+                )
+            );
+        }
         $this->metadata = $this->objectManager->getClassMetadata(get_class($object));
         $this->prepareStrategies();
     }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2628,4 +2628,37 @@ class DoctrineObjectTest extends BaseTestCase
             $this->hydratorByReference->getStrategy('entities')
         );
     }
+
+    public function testNullEntityThrowsUsefulException()
+    {
+        $this->configureObjectManagerForSimpleEntity();
+
+        try {
+            $this->hydratorByValue->extract(null);
+        }
+        catch(\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+
+        try {
+            $this->hydratorByValue->hydrate([], null);
+        }
+        catch(\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+
+        try {
+            $this->hydratorByReference->extract(null);
+        }
+        catch(\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+
+        try {
+            $this->hydratorByReference->hydrate([], null);
+        }
+        catch(\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+    }
 }


### PR DESCRIPTION
When calling $hydrator->extract(null) or $hydrator->hydrate(null), errors thrown are very unhelpful, as the ObjectManager tries to get the metadata for the hydrator class itself (as get_class(NULL) returns the name of the class it is called in).
I've just added a check that we are trying to prepare an object.