### PR TITLE
Update AbstractDoctrineServiceFactory.php

### DIFF
--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -79,7 +79,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
             return false;
         }
 
-        $config      = $serviceLocator->get('Config');
+        $config      = $serviceLocator->get('config');
         $mappingType = $matches['mappingType'];
         $serviceType = $matches['serviceType'];
         $serviceName = $matches['serviceName'];


### PR DESCRIPTION
Lower case ```'config'``` is the correct key to use. Service names are case-sensitive in v3 of the Service Manager and using ```'Config'``` may cause a fatal error. Fixes #645