### PR TITLE
Automatically append ConfigProvider in Expressive application

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     ],
     "extra": {
         "zf": {
+            "config-provider": "DoctrineModule\\ConfigProvider",
             "module": "DoctrineModule"
         },
         "branch-alias": {


### PR DESCRIPTION
Using full features of [`zendframework/zend-component-installer`](https://github.com/zendframework/zend-component-installer#writing-packages-that-utilize-the-installer)
