### PR TITLE
Updated to PHPUnit 7.5 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "zendframework/zend-validator":      "^2.10"
     },
     "require-dev": {
-        "phpunit/phpunit":                  "^6.5 || ^7.0",
+        "phpunit/phpunit":                  "^7.5.2",
         "predis/predis":                    "^1.1",
         "squizlabs/php_codesniffer":        "^2.7",
         "zendframework/zend-i18n":          "^2.7",

--- a/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
+++ b/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
@@ -39,7 +39,7 @@ class DoctrineCacheStorageTest extends TestCase
      */
     protected $phpDatatypes = ['NULL', 'boolean', 'integer', 'double', 'string', 'array', 'object', 'resource'];
 
-    public function setUp()
+    protected function setUp()
     {
         $this->options = new AdapterOptions();
         // @todo fix constructor as it is messy
@@ -57,7 +57,7 @@ class DoctrineCacheStorageTest extends TestCase
         );
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // be sure the error handler has been stopped
         if (ErrorHandler::started()) {
@@ -138,7 +138,7 @@ class DoctrineCacheStorageTest extends TestCase
     {
         $capabilities = $this->storage->getCapabilities();
         $datatypes    = $capabilities->getSupportedDatatypes();
-        $this->assertInternalType('array', $datatypes);
+        $this->assertIsArray($datatypes);
 
         foreach ($datatypes as $sourceType => $targetType) {
             $this->assertContains($sourceType, $this->phpDatatypes, 'Unknown source type "' . $sourceType . '"');
@@ -146,7 +146,7 @@ class DoctrineCacheStorageTest extends TestCase
             if (is_string($targetType)) {
                 $this->assertContains($targetType, $this->phpDatatypes, 'Unknown source type "' . $sourceType . '"');
             } else {
-                $this->assertInternalType('bool', $targetType, 'Target type must be a string or boolean');
+                $this->assertIsBool($targetType, 'Target type must be a string or boolean');
             }
         }
     }
@@ -155,10 +155,10 @@ class DoctrineCacheStorageTest extends TestCase
     {
         $capabilities = $this->storage->getCapabilities();
         $metadata     = $capabilities->getSupportedMetadata();
-        $this->assertInternalType('array', $metadata);
+        $this->assertIsArray($metadata);
 
         foreach ($metadata as $property) {
-            $this->assertInternalType('string', $property);
+            $this->assertIsString($property);
         }
     }
 
@@ -166,27 +166,27 @@ class DoctrineCacheStorageTest extends TestCase
     {
         $capabilities = $this->storage->getCapabilities();
 
-        $this->assertInternalType('integer', $capabilities->getMaxTtl());
+        $this->assertIsInt($capabilities->getMaxTtl());
         $this->assertGreaterThanOrEqual(0, $capabilities->getMaxTtl());
 
-        $this->assertInternalType('bool', $capabilities->getStaticTtl());
+        $this->assertIsBool($capabilities->getStaticTtl());
 
-        $this->assertInternalType('numeric', $capabilities->getTtlPrecision());
+        $this->assertIsNumeric($capabilities->getTtlPrecision());
         $this->assertGreaterThan(0, $capabilities->getTtlPrecision());
 
-        $this->assertInternalType('bool', $capabilities->getStaticTtl());
+        $this->assertIsBool($capabilities->getStaticTtl());
     }
 
     public function testKeyCapabilities()
     {
         $capabilities = $this->storage->getCapabilities();
 
-        $this->assertInternalType('integer', $capabilities->getMaxKeyLength());
+        $this->assertIsInt($capabilities->getMaxKeyLength());
         $this->assertGreaterThanOrEqual(-1, $capabilities->getMaxKeyLength());
 
-        $this->assertInternalType('bool', $capabilities->getNamespaceIsPrefix());
+        $this->assertIsBool($capabilities->getNamespaceIsPrefix());
 
-        $this->assertInternalType('string', $capabilities->getNamespaceSeparator());
+        $this->assertIsString($capabilities->getNamespaceSeparator());
     }
 
     public function testHasItemReturnsTrueOnValidItem()
@@ -286,7 +286,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertTrue($this->storage->setItem('key', 'value'));
         $metadata = $this->storage->getMetadata('key');
 
-        $this->assertInternalType('array', $metadata);
+        $this->assertIsArray($metadata);
         foreach ($supportedMetadatas as $supportedMetadata) {
             $this->assertArrayHasKey($supportedMetadata, $metadata);
         }
@@ -317,10 +317,10 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertSame([], $this->storage->setItems($items));
 
         $metadatas = $this->storage->getMetadatas(array_keys($items));
-        $this->assertInternalType('array', $metadatas);
+        $this->assertIsArray($metadatas);
         $this->assertSame(count($items), count($metadatas));
         foreach ($metadatas as $metadata) {
-            $this->assertInternalType('array', $metadata);
+            $this->assertIsArray($metadata);
             foreach ($supportedMetadatas as $supportedMetadata) {
                 $this->assertArrayHasKey($supportedMetadata, $metadata);
             }
@@ -357,14 +357,14 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertSame([], $this->storage->setItems($items));
 
         $rs = $this->storage->getItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         foreach ($items as $key => $value) {
             $this->assertArrayHasKey($key, $rs);
             $this->assertEquals($value, $rs[$key]);
         }
 
         $rs = $this->storage->hasItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         $this->assertEquals(count($items), count($rs));
         foreach ($items as $key => $value) {
             $this->assertContains($key, $rs);
@@ -374,14 +374,14 @@ class DoctrineCacheStorageTest extends TestCase
         unset($items['key1'], $items['key3']);
 
         $rs = $this->storage->getItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         foreach ($items as $key => $value) {
             $this->assertArrayHasKey($key, $rs);
             $this->assertEquals($value, $rs[$key]);
         }
 
         $rs = $this->storage->hasItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         $this->assertEquals(count($items), count($rs));
         foreach ($items as $key => $value) {
             $this->assertContains($key, $rs);
@@ -434,14 +434,14 @@ class DoctrineCacheStorageTest extends TestCase
 
         $this->options->setNamespace('defaultns1');
         $rs = $this->storage->getItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         foreach ($items as $key => $value) {
             $this->assertArrayHasKey($key, $rs);
             $this->assertEquals($value, $rs[$key]);
         }
 
         $rs = $this->storage->hasItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         $this->assertEquals(count($items), count($rs));
         foreach ($items as $key => $value) {
             $this->assertContains($key, $rs);
@@ -452,14 +452,14 @@ class DoctrineCacheStorageTest extends TestCase
         unset($items['key1'], $items['key3']);
 
         $rs = $this->storage->getItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         foreach ($items as $key => $value) {
             $this->assertArrayHasKey($key, $rs);
             $this->assertEquals($value, $rs[$key]);
         }
 
         $rs = $this->storage->hasItems(array_keys($items));
-        $this->assertInternalType('array', $rs);
+        $this->assertIsArray($rs);
         $this->assertEquals(count($items), count($rs));
         foreach ($items as $key => $value) {
             $this->assertContains($key, $rs);

--- a/tests/DoctrineModuleTest/ConfigProviderTest.php
+++ b/tests/DoctrineModuleTest/ConfigProviderTest.php
@@ -18,7 +18,7 @@ class ConfigProviderTest extends TestCase
     {
         $config = (new ConfigProvider())->__invoke();
 
-        self::assertInternalType('array', $config);
+        self::assertIsArray($config);
 
         self::assertArrayHasKey('doctrine', $config, 'Expected config to have "doctrine" array key');
         self::assertArrayHasKey('doctrine_factories', $config, 'Expected config to have "doctrine_factories" array key');

--- a/tests/DoctrineModuleTest/Controller/CliControllerTest.php
+++ b/tests/DoctrineModuleTest/Controller/CliControllerTest.php
@@ -37,7 +37,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->setApplicationConfig(ServiceManagerFactory::getConfiguration());
         parent::setUp();

--- a/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
@@ -11,7 +11,7 @@ use DoctrineModule\Form\Element\ObjectMultiCheckbox;
  * @license MIT
  * @link    http://www.doctrine-project.org/
  * @author  Kyle Spraggs <theman@spiffyjr.me>
- * @covers  DoctrineModule\Form\Element\ObjectMultiCheckbox
+ * @covers  \DoctrineModule\Form\Element\ObjectMultiCheckbox
  */
 class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
 {

--- a/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
@@ -7,7 +7,7 @@ use DoctrineModule\Form\Element\ObjectRadio;
 /**
  * Tests for the ObjectRadio element
  *
- * @covers  DoctrineModule\Form\Element\ObjectRadio
+ * @covers \DoctrineModule\Form\Element\ObjectRadio
  */
 class ObjectRadioTest extends ProxyAwareElementTestCase
 {

--- a/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
@@ -11,7 +11,7 @@ use DoctrineModule\Form\Element\ObjectSelect;
  * @license MIT
  * @link    http://www.doctrine-project.org/
  * @author  Kyle Spraggs <theman@spiffyjr.me>
- * @covers  DoctrineModule\Form\Element\ObjectSelect
+ * @covers  \DoctrineModule\Form\Element\ObjectSelect
  */
 class ObjectSelectTest extends ProxyAwareElementTestCase
 {

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  * @license MIT
  * @link    http://www.doctrine-project.org/
  * @author  Kyle Spraggs <theman@spiffyjr.me>
- * @covers  DoctrineModule\Form\Element\Proxy
+ * @covers  \DoctrineModule\Form\Element\Proxy
  */
 class ProxyTest extends TestCase
 {

--- a/tests/DoctrineModuleTest/ModuleTest.php
+++ b/tests/DoctrineModuleTest/ModuleTest.php
@@ -35,7 +35,7 @@ class ModuleTest extends TestCase
      */
     private $cli;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->application    = $this->getMockBuilder('Zend\Mvc\Application')
             ->disableOriginalConstructor()
@@ -74,7 +74,7 @@ class ModuleTest extends TestCase
 
         $config = $module->getConfig();
 
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
         $this->assertArrayHasKey('doctrine', $config);
         $this->assertArrayHasKey('doctrine_factories', $config);
         $this->assertArrayHasKey('service_manager', $config);

--- a/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
+++ b/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
@@ -44,7 +44,7 @@ class SymfonyCliTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $symfonyCli = class_exists(V2RouteMatch::class) ? SymfonyCliV2::class : SymfonyCliV3::class;
 

--- a/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
@@ -22,7 +22,7 @@ class ModuleDefinedServicesTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->serviceManager = ServiceManagerFactory::getServiceManager();
     }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -40,7 +40,7 @@ class DoctrineObjectTest extends BaseTestCase
     /**
      * setUp
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -1318,7 +1318,7 @@ class DoctrineObjectTest extends BaseTestCase
         $data = $this->hydratorByValue->extract($entity);
 
         $this->assertEquals(4, $data['id']);
-        $this->assertInternalType('array', $data['entities']);
+        $this->assertIsArray($data['entities']);
 
         $this->assertEquals($toMany1->getId(), $data['entities'][0]->getId());
         $this->assertSame($toMany1, $data['entities'][0]);
@@ -1415,7 +1415,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1455,7 +1455,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1492,7 +1492,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertNotContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1532,7 +1532,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertNotContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1592,7 +1592,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1655,7 +1655,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1718,7 +1718,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertNotContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1777,7 +1777,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
             $this->assertNotContains('Modified from addEntities adder', $en->getField(false));
         }
 
@@ -1826,7 +1826,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
         }
 
         $this->assertEquals(2, $entities[0]->getId());
@@ -1877,7 +1877,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
 
             // Only the third element is new so the adder has not been called on it
             if ($en === $toMany3) {
@@ -1952,8 +1952,8 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
-            $this->assertInternalType('string', $en->getField());
+            $this->assertIsInt($en->getId());
+            $this->assertIsString($en->getField());
             $this->assertContains('Modified By Hydrate', $en->getField(false));
         }
 
@@ -2022,8 +2022,8 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
-            $this->assertInternalType('string', $en->getField());
+            $this->assertIsInt($en->getId());
+            $this->assertIsString($en->getField());
             $this->assertContains('Modified By Hydrate', $en->getField(false));
         }
 
@@ -2092,7 +2092,7 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
+            $this->assertIsInt($en->getId());
         }
 
         $this->assertEquals(2, $entities[0]->getId());
@@ -2177,8 +2177,8 @@ class DoctrineObjectTest extends BaseTestCase
 
         foreach ($entities as $en) {
             $this->assertInstanceOf('DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity', $en);
-            $this->assertInternalType('integer', $en->getId());
-            $this->assertInternalType('string', $en->getField());
+            $this->assertIsInt($en->getId());
+            $this->assertIsString($en->getField());
             $this->assertContains('Modified By Hydrate', $en->getField(false));
         }
 

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTypeConversionsTest.php
@@ -32,7 +32,7 @@ class DoctrineObjectTypeConversionsTest extends BaseTestCase
     /**
      * setUp
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
@@ -37,7 +37,7 @@ class NoObjectExistsFactoryTest extends TestCase
      */
     public function testCallable()
     {
-        $this->assertInternalType('callable', $this->object);
+        $this->assertIsCallable($this->object);
     }
 
     /**


### PR DESCRIPTION
We can drop PHPUnit 6 as we support only PHP 7.1+.