### PR TITLE
Fixed hydration with nested entities

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -328,6 +328,8 @@ class DoctrineObject extends AbstractHydrator
 
                 $object->$setter($this->hydrateValue($field, $value, $data));
             }
+
+            $this->metadata = $metadata;
         }
 
         return $object;
@@ -375,6 +377,8 @@ class DoctrineObject extends AbstractHydrator
             } else {
                 $reflProperty->setValue($object, $this->hydrateValue($field, $value, $data));
             }
+
+            $this->metadata = $metadata;
         }
 
         return $object;

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToOneEntity.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToOneEntity.php
@@ -2,6 +2,8 @@
 
 namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
 
+use DateTime;
+
 class OneToOneEntity
 {
     /**
@@ -13,6 +15,11 @@ class OneToOneEntity
      * @var ByValueDifferentiatorEntity
      */
     protected $toOne;
+
+    /**
+     * @var DateTime
+     */
+    protected $createdAt;
 
 
     public function setId($id)
@@ -44,5 +51,15 @@ class OneToOneEntity
         }
 
         return $this->toOne;
+    }
+
+    public function setCreatedAt(DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2,10 +2,14 @@
 
 namespace DoctrineModuleTest\Stdlib\Hydrator;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModuleTest\Stdlib\Hydrator\Asset\ByValueDifferentiatorEntity;
 use DoctrineModuleTest\Stdlib\Hydrator\Asset\ContextStrategy;
 use DoctrineModuleTest\Stdlib\Hydrator\Asset\SimpleEntity;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineObjectHydrator;
@@ -2646,7 +2650,8 @@ class DoctrineObjectTest extends BaseTestCase
     /**
      * https://github.com/doctrine/DoctrineModule/issues/639
      */
-    public function testStrategyWithArray() {
+    public function testStrategyWithArrayByValue()
+    {
         $entity = new Asset\SimpleEntity();
 
         $data = ['field' => ['complex', 'value']];
@@ -2667,5 +2672,116 @@ class DoctrineObjectTest extends BaseTestCase
         $this->hydratorByValue->hydrate($data, $entity);
 
         $this->assertEquals('complex,value', $entity->getField());
+    }
+
+    public function testStrategyWithArrayByReference()
+    {
+        $entity = new Asset\SimpleEntity();
+
+        $data = ['field' => ['complex', 'value']];
+        $this->configureObjectManagerForSimpleEntity();
+        $this->hydratorByReference->addStrategy('field', new class implements StrategyInterface {
+            public function extract($value) : array
+            {
+                return explode(',', $value);
+            }
+
+            public function hydrate($value) : string
+            {
+                return implode(',', $value);
+            }
+
+        });
+
+        $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertSame('complex,value', $entity->getField());
+    }
+
+    private function getObjectManagerForNestedHydration()
+    {
+        $oneToOneMetadata = $this->prophesize(ClassMetadata::class);
+        $oneToOneMetadata->getName()->willReturn(Asset\OneToOneEntity::class);
+        $oneToOneMetadata->getFieldNames()->willReturn(['id', 'toOne', 'createdAt']);
+        $oneToOneMetadata->getAssociationNames()->willReturn(['toOne']);
+        $oneToOneMetadata->getTypeOfField('id')->willReturn('integer');
+        $oneToOneMetadata->getTypeOfField('toOne')->willReturn(Asset\ByValueDifferentiatorEntity::class);
+        $oneToOneMetadata->getTypeOfField('createdAt')->willReturn('datetime');
+        $oneToOneMetadata->hasAssociation('id')->willReturn(false);
+        $oneToOneMetadata->hasAssociation('toOne')->willReturn(true);
+        $oneToOneMetadata->hasAssociation('createdAt')->willReturn(false);
+        $oneToOneMetadata->isSingleValuedAssociation('toOne')->willReturn(true);
+        $oneToOneMetadata->isCollectionValuedAssociation('toOne')->willReturn(false);
+        $oneToOneMetadata->getAssociationTargetClass('toOne')->willReturn(Asset\ByValueDifferentiatorEntity::class);
+        $oneToOneMetadata->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToOneEntity::class));
+        $oneToOneMetadata->getIdentifier()->willReturn(['id']);
+        $oneToOneMetadata->getIdentifierFieldNames(Argument::type(Asset\OneToOneEntity::class))->willReturn(['id']);
+
+        $byValueDifferentiatorEntity = $this->prophesize(ClassMetadata::class);
+        $byValueDifferentiatorEntity->getName()->willReturn(Asset\ByValueDifferentiatorEntity::class);
+        $byValueDifferentiatorEntity->getAssociationNames()->willReturn([]);
+        $byValueDifferentiatorEntity->getFieldNames()->willReturn(['id', 'field']);
+        $byValueDifferentiatorEntity->getTypeOfField('id')->willReturn('integer');
+        $byValueDifferentiatorEntity->getTypeOfField('field')->willReturn('string');
+        $byValueDifferentiatorEntity->hasAssociation(Argument::any())->willReturn(false);
+        $byValueDifferentiatorEntity->getIdentifier()->willReturn(['id']);
+        $byValueDifferentiatorEntity->getIdentifierFieldNames(Argument::type(Asset\ByValueDifferentiatorEntity::class))->willReturn(['id']);
+        $byValueDifferentiatorEntity->getReflectionClass()->willReturn(new ReflectionClass(Asset\ByValueDifferentiatorEntity::class));
+
+        $objectManager = $this->prophesize(ObjectManager::class);
+        $objectManager->getClassMetadata(Asset\OneToOneEntity::class)->will([$oneToOneMetadata, 'reveal']);
+        $objectManager->getClassMetadata(Asset\ByValueDifferentiatorEntity::class)->will([$byValueDifferentiatorEntity, 'reveal']);
+        $objectManager->find(Asset\OneToOneEntity::class, ['id' => 12])->willReturn(false);
+        $objectManager->find(Asset\ByValueDifferentiatorEntity::class, ['id' => 13])->willReturn(false);
+
+        return $objectManager->reveal();
+    }
+
+    public function testNestedHydrationByValue()
+    {
+        $objectManager = $this->getObjectManagerForNestedHydration();
+        $hydrator = new DoctrineObjectHydrator($objectManager, true);
+        $entity = new Asset\OneToOneEntity();
+
+        $data = [
+            'id' => 12,
+            'toOne' => [
+                'id' => 13,
+                'field' => 'value',
+            ],
+            'createdAt' => '2019-01-24 12:00:00',
+        ];
+
+        $hydrator->hydrate($data, $entity);
+
+        $this->assertSame(12, $entity->getId());
+        $this->assertInstanceOf(Asset\ByValueDifferentiatorEntity::class, $entity->getToOne(false));
+        $this->assertSame(13, $entity->getToOne(false)->getId());
+        $this->assertSame('Modified from setToOne setter', $entity->getToOne(false)->getField(false));
+        $this->assertSame('2019-01-24 12:00:00', $entity->getCreatedAt()->format('Y-m-d H:i:s'));
+    }
+
+    public function testNestedHydrationByReference()
+    {
+        $objectManager = $this->getObjectManagerForNestedHydration();
+        $hydrator = new DoctrineObjectHydrator($objectManager, false);
+        $entity = new Asset\OneToOneEntity();
+
+        $data = [
+            'id' => 12,
+            'toOne' => [
+                'id' => 13,
+                'field' => 'value',
+            ],
+            'createdAt' => '2019-01-24 12:00:00',
+        ];
+
+        $hydrator->hydrate($data, $entity);
+
+        $this->assertSame(12, $entity->getId());
+        $this->assertInstanceOf(Asset\ByValueDifferentiatorEntity::class, $entity->getToOne(false));
+        $this->assertSame(13, $entity->getToOne(false)->getId());
+        $this->assertSame('value', $entity->getToOne(false)->getField(false));
+        $this->assertSame('2019-01-24 12:00:00', $entity->getCreatedAt()->format('Y-m-d H:i:s'));
     }
 }


### PR DESCRIPTION
In case we try hydrate entity with nested entities metadata was overridden in the hydrator and invalid metadata was used to hydrate rest of the fields after hydrating nested entity.

The issue was introduced in [version 2.1.4](https://github.com/doctrine/DoctrineModule/releases/tag/2.1.4) in commit: 336b33ffdbddc9431f776646e5353ce0a5a6bcfb
PR: https://github.com/doctrine/DoctrineModule/pull/646

The tests are not the best in the library. I hope we will be able to improve them when we extract hydrators to separate repository. I would like to get class metadata for the entity instead of mocking it.
See: #644 

/cc @Erikvv @alextech @TomHAnderson