### PR TITLE
bind Closure to null to allow the garbage collector do its work

### DIFF
--- a/src/DoctrineModule/Module.php
+++ b/src/DoctrineModule/Module.php
@@ -35,7 +35,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
     public function init(ModuleManagerInterface $moduleManager)
     {
         AnnotationRegistry::registerLoader(
-            function ($className) {
+            static function ($className) {
                 return class_exists($className);
             }
         );


### PR DESCRIPTION
The closure did bind to `$this` or `self` and therefore couldn't be garbage collected.