### PR TITLE
2 Bugfixes regarding recursive hydration

### DIFF
--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -331,10 +331,10 @@ class DoctrineObject extends AbstractHydrator
                         $values = (array)$values;
                     }
 
-                    foreach ($values as $index => $value) {
+                    foreach ($values as $index => $collectionValue) {
                         $values[$index] = $this->addAdditionalIdentifiersToValue(
                             $metadata,
-                            $value,
+                            $collectionValue,
                             $additionalIdentifiers
                         );
                     }
@@ -772,6 +772,12 @@ class DoctrineObject extends AbstractHydrator
             foreach ($additionalIdentifiers as $identifier => $additionalIdentifier) {
                 $property = $reflection->getProperty($identifier);
                 $property->setAccessible(true);
+                $current = $property->getValue($value);
+
+                // Do not overwrite already provided information
+                if ($current !== null) {
+                    continue;
+                }
                 $property->setValue($value, $additionalIdentifier);
             }
 

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -521,8 +521,11 @@ class DoctrineObject extends AbstractHydrator
             }
         );
 
-        // Set the object so that the strategy can extract the Collection from it
 
+        // Restore metadata as the collection hydration caused the property to be set to the collections metdata instead
+        $this->prepare($object);
+
+        // Set the object so that the strategy can extract the Collection from it
         /** @var \DoctrineModule\Stdlib\Hydrator\Strategy\AbstractCollectionStrategy $collectionStrategy */
         $collectionStrategy = $this->getStrategy($collectionName);
         $collectionStrategy->setObject($object);

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntity.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntity.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class OneToManyReferencingIdentifierEntity
+{
+
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var Collection
+     */
+    public $toMany;
+
+    public function __construct()
+    {
+        $this->toMany = new ArrayCollection();
+    }
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntity.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntity.php
@@ -15,12 +15,39 @@ class OneToManyReferencingIdentifierEntity
     public $id;
 
     /**
-     * @var Collection
+     * @var Collection|OneToManyReferencingIdentifierEntityReferencingBack[]
      */
     public $toMany;
 
     public function __construct()
     {
         $this->toMany = new ArrayCollection();
+    }
+
+    public function addToMany(Collection $entities)
+    {
+        foreach ($entities as $toMany) {
+            if ($this->toMany->contains($toMany)) {
+                return;
+            }
+
+            $this->toMany->add($toMany);
+        }
+    }
+
+    public function removeToMany(Collection $entities)
+    {
+        foreach ($entities as $toMany) {
+            if (!$this->toMany->contains($toMany)) {
+                return;
+            }
+
+            $this->toMany->removeElement($toMany);
+        }
+    }
+
+    public function getToMany(): Collection
+    {
+        return $this->toMany;
     }
 }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntityReferencingBack.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntityReferencingBack.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
+
+use DateTimeInterface;
+
+class OneToManyReferencingIdentifierEntityReferencingBack
+{
+    /**
+     * @var OneToManyReferencingIdentifierEntity
+     */
+    public $toOneReferencingBack;
+
+    /**
+     * @var int
+     */
+    public $secondaryCompositePrimaryKey;
+
+    /**
+     * @var DateTimeInterface
+     */
+    public $createdAt;
+}

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntityReferencingBack.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/OneToManyReferencingIdentifierEntityReferencingBack.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 
 class OneToManyReferencingIdentifierEntityReferencingBack
 {
+
     /**
      * @var OneToManyReferencingIdentifierEntity
      */
@@ -21,4 +22,19 @@ class OneToManyReferencingIdentifierEntityReferencingBack
      * @var DateTimeInterface
      */
     public $createdAt;
+
+    public function setToOneReferencingBack(OneToManyReferencingIdentifierEntity $toOneReferencingBack): void
+    {
+        $this->toOneReferencingBack = $toOneReferencingBack;
+    }
+
+    public function setSecondaryCompositePrimaryKey(int $secondaryCompositePrimaryKey): void
+    {
+        $this->secondaryCompositePrimaryKey = $secondaryCompositePrimaryKey;
+    }
+
+    public function setCreatedAt(DateTimeInterface $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
 }

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -4,6 +4,7 @@ namespace DoctrineModuleTest\Stdlib\Hydrator;
 
 use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineObjectHydrator;
@@ -2802,6 +2803,8 @@ class DoctrineObjectTest extends BaseTestCase
         ];
 
         $hydrator->hydrate($data, $entity);
+        $this->assertInstanceOf(Collection::class, $entity->toMany);
+        $this->assertInstanceOf(OneToManyReferencingIdentifierEntityReferencingBack::class, $entity->toMany[0]);
     }
 
     private function getObjectManagerForNestedToManyHydration()

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2849,10 +2849,33 @@ class DoctrineObjectTest extends BaseTestCase
         return $objectManager->reveal();
     }
 
-    public function testNestedHydrationByReferencingHandlesInversedIdentifierInToOneReference()
+    public function testNestedHydrationByReferencingHandlesInversedIdentifierInToOneReferenceByUsingByReference()
     {
         $objectManager = $this->getObjectManagerForNestedHydrationWithReferencingBackIdentifier();
         $hydrator = new DoctrineObjectHydrator($objectManager, false);
+        $entity = new Asset\OneToManyReferencingIdentifierEntity();
+
+        $data = [
+            'toMany' => [
+                [
+                    'secondaryCompositePrimaryKey' => 42,
+                    'createdAt' => '2019-04-10 09:00:00',
+                ],
+            ],
+        ];
+
+        $hydrator->hydrate($data, $entity);
+        $this->assertInstanceOf(Collection::class, $entity->toMany);
+        /** @var OneToManyReferencingIdentifierEntityReferencingBack $referencingBack */
+        $referencingBack = $entity->toMany[0];
+        $this->assertInstanceOf(OneToManyReferencingIdentifierEntityReferencingBack::class, $referencingBack);
+        $this->assertEquals($entity, $referencingBack->toOneReferencingBack);
+    }
+
+    public function testNestedHydrationByReferencingHandlesInversedIdentifierInToOneReferenceByUsingByValue()
+    {
+        $objectManager = $this->getObjectManagerForNestedHydrationWithReferencingBackIdentifier();
+        $hydrator = new DoctrineObjectHydrator($objectManager, true);
         $entity = new Asset\OneToManyReferencingIdentifierEntity();
 
         $data = [

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -2718,7 +2718,7 @@ class DoctrineObjectTest extends BaseTestCase
         $oneToOneMetadata->getAssociationTargetClass('toOne')->willReturn(Asset\ByValueDifferentiatorEntity::class);
         $oneToOneMetadata->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToOneEntity::class));
         $oneToOneMetadata->getIdentifier()->willReturn(['id']);
-        $oneToOneMetadata->getIdentifierFieldNames(Argument::type(Asset\OneToOneEntity::class))->willReturn(['id']);
+        $oneToOneMetadata->getIdentifierFieldNames()->willReturn(['id']);
 
         $byValueDifferentiatorEntity = $this->prophesize(ClassMetadata::class);
         $byValueDifferentiatorEntity->getName()->willReturn(Asset\ByValueDifferentiatorEntity::class);
@@ -2728,7 +2728,7 @@ class DoctrineObjectTest extends BaseTestCase
         $byValueDifferentiatorEntity->getTypeOfField('field')->willReturn('string');
         $byValueDifferentiatorEntity->hasAssociation(Argument::any())->willReturn(false);
         $byValueDifferentiatorEntity->getIdentifier()->willReturn(['id']);
-        $byValueDifferentiatorEntity->getIdentifierFieldNames(Argument::type(Asset\ByValueDifferentiatorEntity::class))->willReturn(['id']);
+        $byValueDifferentiatorEntity->getIdentifierFieldNames()->willReturn(['id']);
         $byValueDifferentiatorEntity->getReflectionClass()->willReturn(new ReflectionClass(Asset\ByValueDifferentiatorEntity::class));
 
         $objectManager = $this->prophesize(ObjectManager::class);
@@ -2822,7 +2822,7 @@ class DoctrineObjectTest extends BaseTestCase
         $oneToOneMetadata->getAssociationTargetClass('toMany')->willReturn(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class);
         $oneToOneMetadata->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToManyReferencingIdentifierEntity::class));
         $oneToOneMetadata->getIdentifier()->willReturn(['id']);
-        $oneToOneMetadata->getIdentifierFieldNames(Argument::type(Asset\OneToManyReferencingIdentifierEntity::class))->willReturn(['id']);
+        $oneToOneMetadata->getIdentifierFieldNames()->willReturn(['id']);
 
         $oneToOneReferencingBackEntity = $this->prophesize(ClassMetadata::class);
         $oneToOneReferencingBackEntity->getName()->willReturn(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class);
@@ -2838,13 +2838,13 @@ class DoctrineObjectTest extends BaseTestCase
         $oneToOneReferencingBackEntity->isCollectionValuedAssociation('toOneReferencingBack')->willReturn(false);
         $oneToOneReferencingBackEntity->getAssociationTargetClass('toOneReferencingBack')->willReturn(Asset\OneToManyReferencingIdentifierEntity::class);
         $oneToOneReferencingBackEntity->getIdentifier()->willReturn(['toOneReferencingBack', 'secondaryCompositePrimaryKey']);
-        $oneToOneReferencingBackEntity->getIdentifierFieldNames(Argument::type(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class))->willReturn(['toOneReferencingBack']);
+        $oneToOneReferencingBackEntity->getIdentifierFieldNames()->willReturn(['toOneReferencingBack']);
         $oneToOneReferencingBackEntity->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class));
 
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata(Asset\OneToManyReferencingIdentifierEntity::class)->will([$oneToOneMetadata, 'reveal']);
         $objectManager->getClassMetadata(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class)->will([$oneToOneReferencingBackEntity, 'reveal']);
-        $objectManager->find(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class, ['secondaryCompositePrimaryKey' => 42])->willReturn(false);
+        $objectManager->find(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class, Argument::any())->willReturn(false);
 
         return $objectManager->reveal();
     }
@@ -2887,7 +2887,7 @@ class DoctrineObjectTest extends BaseTestCase
         $oneToOneMetadata->getAssociationTargetClass('toMany')->willReturn(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class);
         $oneToOneMetadata->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToManyReferencingIdentifierEntity::class));
         $oneToOneMetadata->getIdentifier()->willReturn(['id']);
-        $oneToOneMetadata->getIdentifierFieldNames(Argument::type(Asset\OneToManyReferencingIdentifierEntity::class))->willReturn(['id']);
+        $oneToOneMetadata->getIdentifierFieldNames()->willReturn(['id']);
 
         $oneToOneReferencingBackEntity = $this->prophesize(ClassMetadata::class);
         $oneToOneReferencingBackEntity->getName()->willReturn(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class);
@@ -2903,13 +2903,14 @@ class DoctrineObjectTest extends BaseTestCase
         $oneToOneReferencingBackEntity->isCollectionValuedAssociation('toOneReferencingBack')->willReturn(false);
         $oneToOneReferencingBackEntity->getAssociationTargetClass('toOneReferencingBack')->willReturn(Asset\OneToManyReferencingIdentifierEntity::class);
         $oneToOneReferencingBackEntity->getIdentifier()->willReturn(['toOneReferencingBack', 'secondaryCompositePrimaryKey']);
-        $oneToOneReferencingBackEntity->getIdentifierFieldNames(Argument::type(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class))->willReturn(['toOneReferencingBack']);
+        $oneToOneReferencingBackEntity->getIdentifierFieldNames()->willReturn(['toOneReferencingBack']);
         $oneToOneReferencingBackEntity->getReflectionClass()->willReturn(new ReflectionClass(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class));
 
         $objectManager = $this->prophesize(ObjectManager::class);
         $objectManager->getClassMetadata(Asset\OneToManyReferencingIdentifierEntity::class)->will([$oneToOneMetadata, 'reveal']);
         $objectManager->getClassMetadata(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class)->will([$oneToOneReferencingBackEntity, 'reveal']);
         $objectManager->find(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class, ['secondaryCompositePrimaryKey' => 42])->willReturn(false);
+        $objectManager->find(Asset\OneToManyReferencingIdentifierEntityReferencingBack::class, Argument::any())->willReturn(false);
 
         return $objectManager->reveal();
     }


### PR DESCRIPTION
Hey guys,

I've been using your module for about 3 years now.
We are recently experiencing some issues as we are trying to use the hydrator for recursive entity creations.

The first thing is: if one is using recursive hydration for `toMany` relations, the `toMany` method within the `DoctrineObject`-Hydrator is calling `DoctrineObject::hydrate` which overwrites the `metadata` property in its `prepare` method.

I've wrote a unit test for that and fixed the issue.


After this, I went to solve our current issue with the recursive hydration in `toMany` relations:
If there are relations having primary keys and one is providing just a partial set of the identifiers, `doctrine/orm` for example throws an `ORMException`:
```php
foreach ($class->identifier as $identifier) {
    if ( ! isset($id[$identifier])) {
        throw ORMException::missingIdentifierField($class->name, $identifier);
    }

    $sortedId[$identifier] = $id[$identifier];
    unset($id[$identifier]);
}
```

If the partial set of the identifiers contains all other identifiers but the missing identifier is, for example, the reference back to an entity, it should get properly created.

Here is an example:

```php
class EntityWithToMany
{
    public $id;
    /** @var EntityWithinToMany[]|Collection */
    public $toMany;

    public function __construct()
    {
        $this->toMany = new ArrayCollection();
    }
}

class EntityWithinToMany
{
    /** @var EntityWithToMany */
    public $toOne;

    /** @var integer */
    public $whateverOtherIdentifier;
}
```

If you now want to create an recursive entity like this, it would currently throw the exception:
```php
$entity = new EntityWithToMany();
$data = [
    'toMany' => [
        [
            // ofc I cannot provide the `toOne` identifier as we are going to create it
            'whateverOtherIdentifier' => 123,
        ],
    ],
];
$hydrator->hydrate($data, $entity); // in doctrine/orm this throws ORMException::missingIdentifierField
```

With this PR, the `$entity` information is being filled to the `value` information, if the information is missing.

- #663 fixed the `toOne` handling, this PR fixes the `toMany` handling.
- It introduces a feature of recursive hydration aswell.

If I have to strip the feature out into a different branch, please let me know.
I would love having that fix kinda asap as I am actually stucking in implementing a feature. Hopefully one gets time to review this.

Thanks in advance.

/cc @TomHAnderson 