### PR TITLE
Migrate from Zend to Laminas

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is placed here for compatibility with Zend Framework's ModuleManager.
+ * This file is placed here for compatibility with Laminas's ModuleManager.
  * It allows usage of this module even without composer.
  * The original Module.php is in 'src/DoctrineModule' in order to respect PSR-0
  */

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DoctrineModule for Zend Framework
+# DoctrineModule for Laminas Framework
 
 [![Master Branch Build Status](https://secure.travis-ci.org/doctrine/DoctrineModule.png?branch=master)](http://travis-ci.org/doctrine/DoctrineModule) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/badges/quality-score.png?s=9772884307bfc08a7eae862fd553e9d5df251729)](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/) [![Code Coverage](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/badges/coverage.png?s=3a35b83cbfdb95b54fd01fd1aef6b0c65a09a43b)](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DoctrineModule for Laminas Framework
+# DoctrineModule for Laminas
 
 [![Master Branch Build Status](https://secure.travis-ci.org/doctrine/DoctrineModule.png?branch=master)](http://travis-ci.org/doctrine/DoctrineModule) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/badges/quality-score.png?s=9772884307bfc08a7eae862fd553e9d5df251729)](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/) [![Code Coverage](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/badges/coverage.png?s=3a35b83cbfdb95b54fd01fd1aef6b0c65a09a43b)](https://scrutinizer-ci.com/g/doctrine/DoctrineModule/)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,7 +54,7 @@ with current practices and a slew of updates and fixes.
 # 1.0.0
 
  * Remove deprecated api call from test [#523](https://github.com/doctrine/DoctrineModule/pull/523)
- * Allow for the use of Laminas\Cache\Service\StorageCacheAbstractServiceFactory [#547](https://github.com/doctrine/DoctrineModule/pull/547)
+ * Allow for the use of Zend\Cache\Service\StorageCacheAbstractServiceFactory [#547](https://github.com/doctrine/DoctrineModule/pull/547)
 
 # 0.10.1
 
@@ -102,7 +102,7 @@ with current practices and a slew of updates and fixes.
  * It is now possible to define a callable for option `label_generator` in `DoctrineModule\Form\Element\Proxy`
    as of [#219](https://github.com/doctrine/DoctrineModule/pull/219)
  * `DoctrineModule\Authentication\Adapter\ObjectRepository` now inherits logic from
-   `Laminas\Authentication\Adapter\AbstractAdapter` as of [#156](https://github.com/doctrine/DoctrineModule/pull/156).
+   `Zend\Authentication\Adapter\AbstractAdapter` as of [#156](https://github.com/doctrine/DoctrineModule/pull/156).
    Methods `setIdentityValue`, `getIdentityValue`, `setCredentialValue`, `getCredentialValue` are now deprecated.
  * It is now possible to set the cache namespace in the cache configuration as
    of [#164](https://github.com/doctrine/DoctrineModule/pull/164)
@@ -117,9 +117,9 @@ with current practices and a slew of updates and fixes.
    [#137](https://github.com/doctrine/DoctrineModule/pull/137). From now on, you can simply run
    `php ./public/index.php` in a standard zf2 skeleton application and the tools will be available
    in there. The console in `./vendor/bin/doctrine-module` is now deprecated.
- * The module does not implement `Laminas\ModuleManager\Feature\AutoloaderProviderInterface` anymore.
+ * The module does not implement `Zend\ModuleManager\Feature\AutoloaderProviderInterface` anymore.
    Please use [composer](http://getcomposer.org/) autoloading or setup autoloading yourself.
- * Service `doctrine.cache.laminascachestorage` was removed from the pre-configured services as of
+ * Service `doctrine.cache.zendcachestorage` was removed from the pre-configured services as of
    [#226](https://github.com/doctrine/DoctrineModule/pull/226).
  * Instantiating a `DoctrineModule\Stdlib\Hydrator\DoctrineObject` does not require a
    `targetClass` anymore. This means you have to modify the way you create hydrator

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,7 +54,7 @@ with current practices and a slew of updates and fixes.
 # 1.0.0
 
  * Remove deprecated api call from test [#523](https://github.com/doctrine/DoctrineModule/pull/523)
- * Allow for the use of Zend\Cache\Service\StorageCacheAbstractServiceFactory [#547](https://github.com/doctrine/DoctrineModule/pull/547)
+ * Allow for the use of Laminas\Cache\Service\StorageCacheAbstractServiceFactory [#547](https://github.com/doctrine/DoctrineModule/pull/547)
 
 # 0.10.1
 
@@ -102,7 +102,7 @@ with current practices and a slew of updates and fixes.
  * It is now possible to define a callable for option `label_generator` in `DoctrineModule\Form\Element\Proxy`
    as of [#219](https://github.com/doctrine/DoctrineModule/pull/219)
  * `DoctrineModule\Authentication\Adapter\ObjectRepository` now inherits logic from
-   `Zend\Authentication\Adapter\AbstractAdapter` as of [#156](https://github.com/doctrine/DoctrineModule/pull/156).
+   `Laminas\Authentication\Adapter\AbstractAdapter` as of [#156](https://github.com/doctrine/DoctrineModule/pull/156).
    Methods `setIdentityValue`, `getIdentityValue`, `setCredentialValue`, `getCredentialValue` are now deprecated.
  * It is now possible to set the cache namespace in the cache configuration as
    of [#164](https://github.com/doctrine/DoctrineModule/pull/164)
@@ -117,9 +117,9 @@ with current practices and a slew of updates and fixes.
    [#137](https://github.com/doctrine/DoctrineModule/pull/137). From now on, you can simply run
    `php ./public/index.php` in a standard zf2 skeleton application and the tools will be available
    in there. The console in `./vendor/bin/doctrine-module` is now deprecated.
- * The module does not implement `Zend\ModuleManager\Feature\AutoloaderProviderInterface` anymore.
+ * The module does not implement `Laminas\ModuleManager\Feature\AutoloaderProviderInterface` anymore.
    Please use [composer](http://getcomposer.org/) autoloading or setup autoloading yourself.
- * Service `doctrine.cache.zendcachestorage` was removed from the pre-configured services as of
+ * Service `doctrine.cache.laminascachestorage` was removed from the pre-configured services as of
    [#226](https://github.com/doctrine/DoctrineModule/pull/226).
  * Instantiating a `DoctrineModule\Stdlib\Hydrator\DoctrineObject` does not require a
    `targetClass` anymore. This means you have to modify the way you create hydrator

--- a/bin/doctrine-module.php
+++ b/bin/doctrine-module.php
@@ -1,7 +1,7 @@
 <?php
 
-use Zend\Mvc\Application;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Mvc\Application;
+use Laminas\Stdlib\ArrayUtils;
 
 ini_set('display_errors', true);
 chdir(__DIR__);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name":        "doctrine/doctrine-module",
-    "description": "Zend Framework Module that provides Doctrine basic functionality required for ORM and ODM modules",
+    "description": "Laminas Module that provides Doctrine basic functionality required for ORM and ODM modules",
     "type":        "library",
     "license":     "MIT",
     "homepage":    "http://www.doctrine-project.org/",

--- a/composer.json
+++ b/composer.json
@@ -47,32 +47,31 @@
         "doctrine/common":                   "^2.8",
         "doctrine/cache":                    "^1.7",
         "symfony/console":                   "^3.3 || ^4.0 || ^5.0",
-        "zendframework/zend-authentication": "^2.5.3",
-        "zendframework/zend-cache":          "^2.7.1",
-        "zendframework/zend-form":           "^2.11",
-        "zendframework/zend-hydrator":       "^2.3",
-        "zendframework/zend-mvc":            "^3.1",
-        "zendframework/zend-paginator":      "^2.8",
-        "zendframework/zend-servicemanager": "^3.3",
-        "zendframework/zend-stdlib":         "^3.1",
-        "zendframework/zend-validator":      "^2.10"
+        "laminas/laminas-authentication":    "^2.5.3",
+        "laminas/laminas-cache":             "^2.7.1",
+        "laminas/laminas-form":              "^2.11",
+        "laminas/laminas-hydrator":          "^2.3",
+        "laminas/laminas-mvc":               "^3.1",
+        "laminas/laminas-paginator":         "^2.8",
+        "laminas/laminas-servicemanager":    "^3.3",
+        "laminas/laminas-stdlib":            "^3.1",
+        "laminas/laminas-validator":         "^2.10"
     },
     "require-dev": {
         "phpunit/phpunit":                  "^7.5.2",
         "predis/predis":                    "^1.1",
         "squizlabs/php_codesniffer":        "^2.7",
-        "zendframework/zend-i18n":          "^2.7",
-        "zendframework/zend-log":           "^2.9",
-        "zendframework/zend-modulemanager": "^2.8",
-        "zendframework/zend-mvc-console":   "^1.1.11",
-        "zendframework/zend-serializer":    "^2.8",
-        "zendframework/zend-session":       "^2.8",
-        "zendframework/zend-test":          "^3.1.1",
-        "zendframework/zend-version":       "^2.5.1"
+        "laminas/laminas-i18n":             "^2.7",
+        "laminas/laminas-log":              "^2.9",
+        "laminas/laminas-modulemanager":    "^2.8",
+        "laminas/laminas-mvc-console":      "^1.1.11",
+        "laminas/laminas-serializer":       "^2.8",
+        "laminas/laminas-session":          "^2.8",
+        "laminas/laminas-test":             "^3.1.1"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",
-        "zendframework/zend-mvc-console": "^1.1.11 if you want to use the ZF3 console libraries"
+        "laminas/laminas-mvc-console":    "^1.1.11 if you want to use the ZF3 console libraries"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "php":                               "^7.1",
         "doctrine/common":                   "^2.8",
         "doctrine/cache":                    "^1.7",
-        "symfony/console":                   "^3.3 || ^4.0 || ^5.0",
         "laminas/laminas-authentication":    "^2.5.3",
         "laminas/laminas-cache":             "^2.7.1",
         "laminas/laminas-form":              "^2.11",
@@ -55,19 +54,20 @@
         "laminas/laminas-paginator":         "^2.8",
         "laminas/laminas-servicemanager":    "^3.3",
         "laminas/laminas-stdlib":            "^3.1",
-        "laminas/laminas-validator":         "^2.10"
+        "laminas/laminas-validator":         "^2.10",
+        "symfony/console":                   "^3.3 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit":                  "^7.5.2",
-        "predis/predis":                    "^1.1",
-        "squizlabs/php_codesniffer":        "^2.7",
         "laminas/laminas-i18n":             "^2.7",
         "laminas/laminas-log":              "^2.9",
         "laminas/laminas-modulemanager":    "^2.8",
         "laminas/laminas-mvc-console":      "^1.1.11",
         "laminas/laminas-serializer":       "^2.8",
         "laminas/laminas-session":          "^2.8",
-        "laminas/laminas-test":             "^3.1.1"
+        "laminas/laminas-test":             "^3.1.1",
+        "phpunit/phpunit":                  "^7.5.2",
+        "predis/predis":                    "^1.1",
+        "squizlabs/php_codesniffer":        "^2.7"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Authentication through Doctrine is fully supported by DoctrineModule through an authentication adapter, and a specific storage implementation that relies on the database. Most of the time, those classes will be used in conjunction with `Zend\Authentication\AuthenticationService` class.
+Authentication through Doctrine is fully supported by DoctrineModule through an authentication adapter, and a specific storage implementation that relies on the database. Most of the time, those classes will be used in conjunction with `Laminas\Authentication\AuthenticationService` class.
 
 ### Simple example
 
@@ -8,7 +8,7 @@ In order to authenticate a user (or anything else) against Doctrine, the followi
 
 1. Set configuration that contains options about the entity that is authenticated (credential property, identity property…). It is not necessary to create a separate authentication adapter, this will be automatically created by the DoctrineModule based on the defined configuration.
 2. Create a storage adapter. If the authentication succeeds, the identifier of the entity will be automatically stored in session.
-3. Create a `Zend\Authentication\AuthenticationService`instance that contains both the authentication adapter and the storage adapter.
+3. Create a `Laminas\Authentication\AuthenticationService`instance that contains both the authentication adapter and the storage adapter.
 
 #### Authentication factory
 
@@ -97,12 +97,12 @@ public static function verifyCredential(User $user, $inputPassword)
 
 #### Creating the AuthenticationService
 
-Now that we have configured the authentication, we still need to tell Zend Framework how to construct a correct ``Zend\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
+Now that we have configured the authentication, we still need to tell Zend Framework how to construct a correct ``Laminas\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
 
 ```php
 namespace Application;
 
-use Zend\Authentication\AuthenticationService;
+use Laminas\Authentication\AuthenticationService;
 
 class Module
 {
@@ -110,7 +110,7 @@ class Module
     {
         return [
             'factories' => [
-                'Zend\Authentication\AuthenticationService' => function ($serviceManager) {
+                'Laminas\Authentication\AuthenticationService' => function ($serviceManager) {
                     // If you are using DoctrineORMModule:
                     return $serviceManager->get('doctrine.authenticationservice.orm_default');
 
@@ -123,16 +123,16 @@ class Module
 }
 ```
 
-Please note that I am using here a ``Zend\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Zend\Authentication\AuthenticationService`` will allow it to be recognised by the ZF2 [Identity view helper](https://framework.zend.com/manual/2.4/en/modules/zend.view.helpers.identity.html).
+Please note that I am using here a ``Laminas\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Laminas\Authentication\AuthenticationService`` will allow it to be recognised by the ZF2 [Identity view helper](https://framework.zend.com/manual/2.4/en/modules/zend.view.helpers.identity.html).
 
-In ZF3, you can inject the ``Zend\Authentication\AuthenticationService`` into your controller factories as in the example below:
+In ZF3, you can inject the ``Laminas\Authentication\AuthenticationService`` into your controller factories as in the example below:
 
 ```php
 <?php
 namespace Application\Factory\Controller;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class ApplicationControllerFactory implements FactoryInterface
 {
@@ -146,7 +146,7 @@ class ApplicationControllerFactory implements FactoryInterface
 
 #### Using the AuthenticationService
 
-Now that we have defined how to create a `Zend\Authentication\AuthenticationService` object we can use it in our code. For more information about Zend authentication mechanisms please read [the ZF 2 Authentication's documentation](http://framework.zend.com/manual/2.4/en/modules/zend.authentication.intro.html).
+Now that we have defined how to create a `Laminas\Authentication\AuthenticationService` object we can use it in our code. For more information about Zend authentication mechanisms please read [the ZF 2 Authentication's documentation](http://framework.zend.com/manual/2.4/en/modules/zend.authentication.intro.html).
 
 Here is an example of how we could use it from a controller action (we stripped any Form things for simplicity):
 
@@ -156,7 +156,7 @@ public function loginAction()
     $data = $this->getRequest()->getPost();
 
     // If you used another name for the authentication service, change it here
-    $authService = $this->getServiceLocator()->get('Zend\Authentication\AuthenticationService');
+    $authService = $this->getServiceLocator()->get('Laminas\Authentication\AuthenticationService');
 
     $adapter = $authService->getAdapter();
     $adapter->setIdentityValue($data['login']);
@@ -219,7 +219,7 @@ $authService->getStorage()->write($identity);
 The storage automatically extracts ONLY the identifier values and only store this in session (this avoid to store in session a serialized entity, which is a bad practice). Later, when you want to retrieve the logged user :
 
 ```php
-$authenticationService = $services->get('Zend\Authentication\AuthenticationService');
+$authenticationService = $services->get('Laminas\Authentication\AuthenticationService');
 $authenticatedUser = $authenticationService->getIdentity();
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -97,7 +97,7 @@ public static function verifyCredential(User $user, $inputPassword)
 
 #### Creating the AuthenticationService
 
-Now that we have configured the authentication, we still need to tell Zend Framework how to construct a correct ``Laminas\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
+Now that we have configured the authentication, we still need to tell Laminas Framework how to construct a correct ``Laminas\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
 
 ```php
 namespace Application;
@@ -123,7 +123,7 @@ class Module
 }
 ```
 
-Please note that I am using here a ``Laminas\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Laminas\Authentication\AuthenticationService`` will allow it to be recognised by the ZF2 [Identity view helper](https://framework.zend.com/manual/2.4/en/modules/zend.view.helpers.identity.html).
+Please note that I am using here a ``Laminas\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Laminas\Authentication\AuthenticationService`` will allow it to be recognised by the Laminas [Identity view helper](https://framework.zend.com/manual/2.4/en/modules/zend.view.helpers.identity.html).
 
 In ZF3, you can inject the ``Laminas\Authentication\AuthenticationService`` into your controller factories as in the example below:
 
@@ -146,7 +146,7 @@ class ApplicationControllerFactory implements FactoryInterface
 
 #### Using the AuthenticationService
 
-Now that we have defined how to create a `Laminas\Authentication\AuthenticationService` object we can use it in our code. For more information about Zend authentication mechanisms please read [the ZF 2 Authentication's documentation](http://framework.zend.com/manual/2.4/en/modules/zend.authentication.intro.html).
+Now that we have defined how to create a `Laminas\Authentication\AuthenticationService` object we can use it in our code. For more information about Laminas authentication mechanisms please read [the ZF 2 Authentication's documentation](http://framework.zend.com/manual/2.4/en/modules/zend.authentication.intro.html).
 
 Here is an example of how we could use it from a controller action (we stripped any Form things for simplicity):
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -97,7 +97,7 @@ public static function verifyCredential(User $user, $inputPassword)
 
 #### Creating the AuthenticationService
 
-Now that we have configured the authentication, we still need to tell Laminas Framework how to construct a correct ``Laminas\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
+Now that we have configured the authentication, we still need to tell Laminas how to construct a correct ``Laminas\Authentication\AuthenticationService`` instance. For this, add the following code in your Module.php class:
 
 ```php
 namespace Application;

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -10,7 +10,7 @@ You may use `Laminas\Cache` within your doctrine-related projects as following:
 
 ```php
 $laminasCache = new \Laminas\Cache\Storage\Adapter\Memory(); // any storage adapter is OK here
-$doctrineCache = new \DoctrineModule\Cache\ZendStorageCache($laminasCache);
+$doctrineCache = new \DoctrineModule\Cache\LaminasStorageCache($laminasCache);
 // now use $doctrineCache as a normal Doctrine\Common\Cache\Cache instance
 ```
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -4,7 +4,7 @@ DoctrineModule provides bridging between
 [`Laminas\Cache`](https://github.com/laminas/laminas-cache)
 and [`Doctrine\Common\Cache`](https://github.com/doctrine/common/tree/master/lib/Doctrine/Common/Cache).
 This may be useful in case you want to share configured cache instances across doctrine, symfony
-and zendframework projects.
+and laminas projects.
 
 You may use `Laminas\Cache` within your doctrine-related projects as following:
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,7 +1,7 @@
 # Caching
 
 DoctrineModule provides bridging between
-[`Laminas\Cache`](https://github.com/zendframework/zf2/tree/master/library/Zend/Cache)
+[`Laminas\Cache`](https://github.com/laminas/laminas-cache)
 and [`Doctrine\Common\Cache`](https://github.com/doctrine/common/tree/master/lib/Doctrine/Common/Cache).
 This may be useful in case you want to share configured cache instances across doctrine, symfony
 and zendframework projects.
@@ -9,16 +9,16 @@ and zendframework projects.
 You may use `Laminas\Cache` within your doctrine-related projects as following:
 
 ```php
-$zendCache = new \Laminas\Cache\Storage\Adapter\Memory(); // any storage adapter is OK here
-$doctrineCache = new \DoctrineModule\Cache\ZendStorageCache($zendCache);
+$laminasCache = new \Laminas\Cache\Storage\Adapter\Memory(); // any storage adapter is OK here
+$doctrineCache = new \DoctrineModule\Cache\ZendStorageCache($laminasCache);
 // now use $doctrineCache as a normal Doctrine\Common\Cache\Cache instance
 ```
 
-You may use `Doctrine\Common\Cache` within your zendframework projects as following:
+You may use `Doctrine\Common\Cache` within your Laminas projects as following:
 
 ```php
 $doctrineCache = new \Doctrine\Common\Cache\ArrayCache(); // any doctrine cache is OK here
 $adapterOptions = new \Laminas\Cache\Storage\Adapter\AdapterOptions();
-$zendCacheStorage = new \DoctrineModule\Cache\DoctrineCacheStorage($adapterOptions, $doctrineCache);
-// now use $zendCacheStorage as a normal Laminas\Cache\Storage\StorageInterface instance.
+$laminasCacheStorage = new \DoctrineModule\Cache\DoctrineCacheStorage($adapterOptions, $doctrineCache);
+// now use $laminasCacheStorage as a normal Laminas\Cache\Storage\StorageInterface instance.
 ```

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,15 +1,15 @@
 # Caching
 
 DoctrineModule provides bridging between
-[`Zend\Cache`](https://github.com/zendframework/zf2/tree/master/library/Zend/Cache)
+[`Laminas\Cache`](https://github.com/zendframework/zf2/tree/master/library/Zend/Cache)
 and [`Doctrine\Common\Cache`](https://github.com/doctrine/common/tree/master/lib/Doctrine/Common/Cache).
 This may be useful in case you want to share configured cache instances across doctrine, symfony
 and zendframework projects.
 
-You may use `Zend\Cache` within your doctrine-related projects as following:
+You may use `Laminas\Cache` within your doctrine-related projects as following:
 
 ```php
-$zendCache = new \Zend\Cache\Storage\Adapter\Memory(); // any storage adapter is OK here
+$zendCache = new \Laminas\Cache\Storage\Adapter\Memory(); // any storage adapter is OK here
 $doctrineCache = new \DoctrineModule\Cache\ZendStorageCache($zendCache);
 // now use $doctrineCache as a normal Doctrine\Common\Cache\Cache instance
 ```
@@ -18,7 +18,7 @@ You may use `Doctrine\Common\Cache` within your zendframework projects as follow
 
 ```php
 $doctrineCache = new \Doctrine\Common\Cache\ArrayCache(); // any doctrine cache is OK here
-$adapterOptions = new \Zend\Cache\Storage\Adapter\AdapterOptions();
+$adapterOptions = new \Laminas\Cache\Storage\Adapter\AdapterOptions();
 $zendCacheStorage = new \DoctrineModule\Cache\DoctrineCacheStorage($adapterOptions, $doctrineCache);
-// now use $zendCacheStorage as a normal Zend\Cache\Storage\StorageInterface instance.
+// now use $zendCacheStorage as a normal Laminas\Cache\Storage\StorageInterface instance.
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,8 +21,8 @@ and attaching them to the provided CLI application as following:
 ```php
 namespace My;
 
-use Zend\EventManager\EventInterface;
-use Zend\ModuleManager\ModuleManagerInterface;
+use Laminas\EventManager\EventInterface;
+use Laminas\ModuleManager\ModuleManagerInterface;
 
 class Module
 {

--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -18,7 +18,7 @@ use and a `property` of the class to use as the Label.
 ```php
 namespace Module\Form;
 
-use Zend\Form\Form;
+use Laminas\Form\Form;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 

--- a/docs/hydrator.md
+++ b/docs/hydrator.md
@@ -4,7 +4,7 @@ Hydrators convert an array of data to an object (this is called "hydrating") and
 convert an object back to an array (this is called "extracting"). Hydrators are mainly used in the context of Forms,
 with the binding functionality of Laminas, but can also be used in any hydrating/extracting context (for
 instance, it can be used in RESTful context). If you are not really comfortable with hydrators, please first
-read [Laminas Framework hydrator's documentation](http://framework.zend.com/manual/current/en/modules/zend.stdlib.hydrator.html).
+read [Laminas hydrator's documentation](http://framework.zend.com/manual/current/en/modules/zend.stdlib.hydrator.html).
 
 
 ### Basic usage

--- a/docs/hydrator.md
+++ b/docs/hydrator.md
@@ -937,7 +937,7 @@ class Tag
 
 #### The fieldsets
 
-We now need to create two fieldsets that will map those entities. With Zend Framework, it's a good practice to create
+We now need to create two fieldsets that will map those entities. With Laminas, it's a good practice to create
 one fieldset per entity in order to reuse them across many forms.
 
 Here is the fieldset for the Tag. Notice that in this example, I added a hidden input whose name is "id". This is
@@ -1224,7 +1224,7 @@ This simple entity contains an id, a string property, and a OneToOne relationshi
 forms the correct way, you will likely have a fieldset for every entity, so that you have a perfect mapping between
 entities and fieldsets. Here are fieldsets for User and and City entities.
 
-> If you are not comfortable with Fieldsets and how they should work, please refer to [this part of Zend Framework 2
+> If you are not comfortable with Fieldsets and how they should work, please refer to [this part of Laminas
 documentation](http://framework.zend.com/manual/2.0/en/modules/zend.form.collections.html).
 
 First the User fieldset :

--- a/docs/hydrator.md
+++ b/docs/hydrator.md
@@ -399,7 +399,7 @@ echo $blogPost->getUser()->getPassword(); // prints 2BorN0t2B
 
 #### Example 3 : OneToMany association
 
-DoctrineModule hydrator also handles OneToMany relationships (when use `Zend\Form\Element\Collection` element). Please
+DoctrineModule hydrator also handles OneToMany relationships (when use `Laminas\Form\Element\Collection` element). Please
 refer to the official [Zend Framework 2 documentation](http://framework.zend.com/manual/2.0/en/modules/zend.form.collections.html) to learn more about Collection.
 
 > Note: internally, for a given collection, if an array contains identifiers, the hydrator automatically fetches the
@@ -779,7 +779,7 @@ echo $data['foo']; // prints 'bar'
 It now only prints "bar", which shows clearly that the getter has not been called.
 
 
-### A complete example using Zend\Form
+### A complete example using Laminas\Form
 
 Now that we understand how the hydrator works, let's see how it integrates into the Zend Framework's Form component.
 We are going to use a simple example with, once again, a BlogPost and a Tag entities. We will see how we can create the
@@ -952,8 +952,8 @@ namespace Application\Form;
 use Application\Entity\Tag;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Fieldset;
-use Zend\InputFilter\InputFilterProviderInterface;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
 
 class TagFieldset extends Fieldset implements InputFilterProviderInterface
 {
@@ -965,12 +965,12 @@ class TagFieldset extends Fieldset implements InputFilterProviderInterface
              ->setObject(new Tag());
 
         $this->add([
-            'type' => 'Zend\Form\Element\Hidden',
+            'type' => 'Laminas\Form\Element\Hidden',
             'name' => 'id',
         ]);
 
         $this->add([
-            'type'    => 'Zend\Form\Element\Text',
+            'type'    => 'Laminas\Form\Element\Text',
             'name'    => 'name',
             'options' => [
                 'label' => 'Tag',
@@ -1000,8 +1000,8 @@ namespace Application\Form;
 use Application\Entity\BlogPost;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Fieldset;
-use Zend\InputFilter\InputFilterProviderInterface;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
 
 class BlogPostFieldset extends Fieldset implements InputFilterProviderInterface
 {
@@ -1013,13 +1013,13 @@ class BlogPostFieldset extends Fieldset implements InputFilterProviderInterface
              ->setObject(new BlogPost());
 
         $this->add([
-            'type' => 'Zend\Form\Element\Text',
+            'type' => 'Laminas\Form\Element\Text',
             'name' => 'title',
         ]);
 
         $tagFieldset = new TagFieldset($objectManager);
         $this->add([
-            'type'    => 'Zend\Form\Element\Collection',
+            'type'    => 'Laminas\Form\Element\Collection',
             'name'    => 'tags',
             'options' => [
                 'count'          => 2,
@@ -1039,7 +1039,7 @@ class BlogPostFieldset extends Fieldset implements InputFilterProviderInterface
 }
 ```
 
-Plain and easy. The blog post is just a simple fieldset with an element type of ``Zend\Form\Element\Collection``
+Plain and easy. The blog post is just a simple fieldset with an element type of ``Laminas\Form\Element\Collection``
 that represents the ManyToOne association.
 
 #### The form
@@ -1056,7 +1056,7 @@ namespace Application\Form;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Form;
+use Laminas\Form\Form;
 
 class CreateBlogPostForm extends Form
 {
@@ -1086,7 +1086,7 @@ namespace Application\Form;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Form;
+use Laminas\Form\Form;
 
 class UpdateBlogPostForm extends Form
 {
@@ -1235,8 +1235,8 @@ namespace Application\Form;
 use Application\Entity\User;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Fieldset;
-use Zend\InputFilter\InputFilterProviderInterface;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
 
 class UserFieldset extends Fieldset implements InputFilterProviderInterface
 {
@@ -1248,7 +1248,7 @@ class UserFieldset extends Fieldset implements InputFilterProviderInterface
              ->setObject(new User());
 
         $this->add([
-            'type'    => 'Zend\Form\Element\Text',
+            'type'    => 'Laminas\Form\Element\Text',
             'name'    => 'name',
             'options' => [
                 'label' => 'Your name',
@@ -1283,8 +1283,8 @@ namespace Application\Form;
 use Application\Entity\City;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Fieldset;
-use Zend\InputFilter\InputFilterProviderInterface;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
 
 class CityFieldset extends Fieldset implements InputFilterProviderInterface
 {
@@ -1296,7 +1296,7 @@ class CityFieldset extends Fieldset implements InputFilterProviderInterface
              ->setObject(new City());
 
         $this->add([
-            'type'    => 'Zend\Form\Element\Text',
+            'type'    => 'Laminas\Form\Element\Text',
             'name'    => 'name',
             'options' => [
                 'label' => 'Name of your city',
@@ -1307,7 +1307,7 @@ class CityFieldset extends Fieldset implements InputFilterProviderInterface
         ]);
 
         $this->add([
-            'type'    => 'Zend\Form\Element\Text',
+            'type'    => 'Laminas\Form\Element\Text',
             'name'    => 'postCode',
             'options' => [
                 'label' => 'Postcode of your city',
@@ -1341,7 +1341,7 @@ namespace Application\Form;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Form;
+use Laminas\Form\Form;
 
 class EditNameForm extends Form
 {
@@ -1404,7 +1404,7 @@ public function editNameAction()
 ```
 
 This looks good, doesn't it? However, if we check the queries that are made (for instance using the awesome
-[ZendDeveloperTools module](https://github.com/zendframework/zend-developer-tools), we will see that a request is
+[Laminas\DeveloperTools module](https://github.com/laminas/laminas-developer-tools), we will see that a request is
 made to fetch data for the City relationship of the user, and we hence have a completely useless database call,
 as this information is not rendered by the form.
 
@@ -1428,7 +1428,7 @@ namespace Application\Form;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineHydrator;
-use Zend\Form\Form;
+use Laminas\Form\Form;
 
 class EditNameForm extends Form
 {

--- a/docs/hydrator.md
+++ b/docs/hydrator.md
@@ -2,9 +2,9 @@
 
 Hydrators convert an array of data to an object (this is called "hydrating") and
 convert an object back to an array (this is called "extracting"). Hydrators are mainly used in the context of Forms,
-with the binding functionality of Zend Framework, but can also be used in any hydrating/extracting context (for
+with the binding functionality of Laminas, but can also be used in any hydrating/extracting context (for
 instance, it can be used in RESTful context). If you are not really comfortable with hydrators, please first
-read [Zend Framework hydrator's documentation](http://framework.zend.com/manual/current/en/modules/zend.stdlib.hydrator.html).
+read [Laminas Framework hydrator's documentation](http://framework.zend.com/manual/current/en/modules/zend.stdlib.hydrator.html).
 
 
 ### Basic usage
@@ -400,7 +400,7 @@ echo $blogPost->getUser()->getPassword(); // prints 2BorN0t2B
 #### Example 3 : OneToMany association
 
 DoctrineModule hydrator also handles OneToMany relationships (when use `Laminas\Form\Element\Collection` element). Please
-refer to the official [Zend Framework 2 documentation](http://framework.zend.com/manual/2.0/en/modules/zend.form.collections.html) to learn more about Collection.
+refer to the official [Laminas documentation](http://framework.zend.com/manual/2.0/en/modules/zend.form.collections.html) to learn more about Collection.
 
 > Note: internally, for a given collection, if an array contains identifiers, the hydrator automatically fetches the
 objects through the Doctrine `find` function. However, this may cause problems if one of the values of the collection
@@ -781,7 +781,7 @@ It now only prints "bar", which shows clearly that the getter has not been calle
 
 ### A complete example using Laminas\Form
 
-Now that we understand how the hydrator works, let's see how it integrates into the Zend Framework's Form component.
+Now that we understand how the hydrator works, let's see how it integrates into the Laminas's Form component.
 We are going to use a simple example with, once again, a BlogPost and a Tag entities. We will see how we can create the
 blog post, and being able to edit it.
 
@@ -1220,7 +1220,7 @@ class User
 }
 ```
 
-This simple entity contains an id, a string property, and a OneToOne relationship. If you are using Zend Framework
+This simple entity contains an id, a string property, and a OneToOne relationship. If you are using Laminas
 forms the correct way, you will likely have a fieldset for every entity, so that you have a perfect mapping between
 entities and fieldsets. Here are fieldsets for User and and City entities.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # DoctrineModule
 
-DoctrineModule provides a bridge between Zend Framework and Doctrine 2.
+DoctrineModule provides a bridge between Laminas and Doctrine 2.
 It gives you access to features that can be used across Doctrine 2 ORM as well as Doctrine 2 ODM.
 It provides an abstraction layer on top of [`Doctrine\Common`](https://github.com/doctrine/common)
 which allows the end user to build functionality being completely unaware if he's currently working
@@ -14,6 +14,6 @@ You can find more details about the features offered by DoctrineModule:
 * [Authentication documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/authentication.md): this explains how you can use the DoctrineModule authentication adapter and authentication storage adapter to provide a simple way to authenticate users using Doctrine.
 * [Caching documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/caching.md): DoctrineModule provides simple classes to allow easier caching using Doctrine.
 * [CLI documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/cli.md): learn how to use the Doctrine 2 command line tool, and how to add your own command.
-* [Hydrator documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/hydrator.md): if you are using Zend Framework 2 Forms (and I hope you are !), DoctrineModule hydrator provides a powerful hydrator that allow you to easily deal with OneToOne, OneToMany and ManyToOne relationships when using forms.
+* [Hydrator documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/hydrator.md): if you are using Laminas Forms (and I hope you are !), DoctrineModule hydrator provides a powerful hydrator that allow you to easily deal with OneToOne, OneToMany and ManyToOne relationships when using forms.
 * [Paginator documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/paginator.md): discover how to use the DoctrineModule Paginator adapter.
 * [Validator documentation](https://github.com/doctrine/DoctrineModule/blob/master/docs/validator.md): this chapter explains how to use ObjectExists and NoObjectExists validator, that allow you to easily validate if a given entity exists or not.

--- a/docs/paginator.md
+++ b/docs/paginator.md
@@ -13,7 +13,7 @@ Here is how you can use the DoctrineModule paginator adapter :
 ```php
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Paginator\Adapter\Collection as CollectionAdapter;
-use Zend\Paginator\Paginator;
+use Laminas\Paginator\Paginator;
 
 // Create a Doctrine 2 Collection
 $doctrineCollection = new ArrayCollection(range(1, 101));
@@ -42,7 +42,7 @@ You can use it without any existing Criteria object:
 
 ```php
 use DoctrineModule\Paginator\Adapter\Selectable as SelectableAdapter;
-use Zend\Paginator\Paginator;
+use Laminas\Paginator\Paginator;
 
 // Create the adapter
 $adapter = new SelectableAdapter($objectRepository); // An object repository implements Selectable
@@ -60,7 +60,7 @@ If you want to further filter the results, you can optionally pass an existing C
 ```php
 use Doctrine\Common\Collections\Criteria as DoctrineCriteria;
 use DoctrineModule\Paginator\Adapter\Selectable as SelectableAdapter;
-use Zend\Paginator\Paginator;
+use Laminas\Paginator\Paginator;
 
 // Create the criteria
 $expr     = DoctrineCriteria::expr()->eq('foo', 'bar');

--- a/docs/paginator.md
+++ b/docs/paginator.md
@@ -26,10 +26,10 @@ $paginator = new Paginator($adapter);
 $paginator->setCurrentPageNumber(1)
           ->setItemCountPerPage(5);
 
-// Pass it to the view, and use it like a "standard" Zend paginator
+// Pass it to the view, and use it like a "standard" Laminas paginator
 ```
 
-For more information about Zend Paginator, please read the [Zend Paginator documentation](http://framework.zend.com/manual/2.0/en/modules/zend.paginator.introduction.html).
+For more information about Laminas Paginator, please read the [Laminas Paginator documentation](http://framework.zend.com/manual/2.0/en/modules/zend.paginator.introduction.html).
 
 ### Selectable adapter
 
@@ -52,7 +52,7 @@ $paginator = new Paginator($adapter);
 $paginator->setCurrentPageNumber(1)
           ->setItemCountPerPage(5);
 
-// Pass it to the view, and use it like a "standard" Zend paginator
+// Pass it to the view, and use it like a "standard" Laminas paginator
 ```
 
 If you want to further filter the results, you can optionally pass an existing Criteria object:
@@ -74,7 +74,7 @@ $paginator = new Paginator($adapter);
 $paginator->setCurrentPageNumber(1)
           ->setItemCountPerPage(5);
 
-// Pass it to the view, and use it like a "standard" Zend paginator
+// Pass it to the view, and use it like a "standard" Laminas paginator
 ```
 
-For more information about Zend Paginator, please read the [Zend Paginator documentation](http://framework.zend.com/manual/2.3/en/modules/zend.paginator.introduction.html).
+For more information about Laminas Paginator, please read the [Laminas Paginator documentation](http://framework.zend.com/manual/2.3/en/modules/zend.paginator.introduction.html).

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -43,8 +43,8 @@ Of course, validators are especially useful when paired with forms.  To add a `N
 namespace Application\Form;
 
 use DoctrineModule\Validator\NoObjectExists as NoObjectExistsValidator;
-use Zend\Form\Form;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Form\Form;
+use Laminas\ServiceManager\ServiceManager;
 use Application\Entity;
 
 class User extends Form
@@ -55,7 +55,7 @@ class User extends Form
 
         // Add an element
         $this->add([
-            'type'    => 'Zend\Form\Element\Email',
+            'type'    => 'Laminas\Form\Element\Email',
             'name'    => 'email',
             'options' => [
                 'label' => 'Email',
@@ -90,9 +90,9 @@ If you are using fieldsets you can directly add the validator using the array no
 ```php
 namespace Application\Form;
 
-use Zend\Form\Fieldset;
-use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
+use Laminas\ServiceManager\ServiceManager;
 use Application\Entity;
 
 class UserFieldset extends Fieldset implements InputFilterProviderInterface
@@ -107,7 +107,7 @@ class UserFieldset extends Fieldset implements InputFilterProviderInterface
 
         // Add an element
         $this->add([
-            'type'    => 'Zend\Form\Element\Email',
+            'type'    => 'Laminas\Form\Element\Email',
             'name'    => 'email',
             'options' => [
                 'label' => 'Email',
@@ -170,7 +170,7 @@ $objectExistsValidator = new \DoctrineModule\Validator\ObjectExists([
 
 There are two things you have to think about when using `DoctrineModule\Validator\UniqueObject`;  As mentioned above you have to pass an ObjectManager as `object_manager` option and second you have to pass a value for every identifier your entity has.
 
-* If you leave out the `use_context` option or set it to `false` you have to pass an array containing the `fields`- and `identifier`-values into `isValid()`. When using `Zend\Form` this behaviour is needed if you're using fieldsets.
-* If you set the `use_context` option to `true` you have to pass the `fields`-values as first argument and an array containing the `identifier`-values as second argument into `isValid()`. When using `Zend\Form` without fieldsets, this behaviour would be needed.
+* If you leave out the `use_context` option or set it to `false` you have to pass an array containing the `fields`- and `identifier`-values into `isValid()`. When using `Laminas\Form` this behaviour is needed if you're using fieldsets.
+* If you set the `use_context` option to `true` you have to pass the `fields`-values as first argument and an array containing the `identifier`-values as second argument into `isValid()`. When using `Laminas\Form` without fieldsets, this behaviour would be needed.
 
 __Important:__ Whatever you choose, please ensure that the `identifier`-values are named by the field-names, not by the database-column.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -1,7 +1,7 @@
 Validator
 =========
 
-DoctrineModule provides three validators that work out the box: `DoctrineModule\Validator\ObjectExists` and `DoctrineModule\Validator\NoObjectExists` which implements a check if an entity exists or does not exists in the database, respectively, and `DoctrineModule\Validator\UniqueObject` which implements a check if a value is only used in one object.  They behave like any other standard Zend validator.
+DoctrineModule provides three validators that work out the box: `DoctrineModule\Validator\ObjectExists` and `DoctrineModule\Validator\NoObjectExists` which implements a check if an entity exists or does not exists in the database, respectively, and `DoctrineModule\Validator\UniqueObject` which implements a check if a value is only used in one object.  They behave like any other standard Laminas validator.
 
 All three validators accept the following options :
 
@@ -35,9 +35,9 @@ var_dump($validator->isValid(['email' => 'test@example.com'])); // dumps 'true' 
 ```
 
 
-### Use together with Zend Framework 2 forms
+### Use together with Laminas forms
 
-Of course, validators are especially useful when paired with forms.  To add a `NoObjectExists` validator to a Zend Framework form element:
+Of course, validators are especially useful when paired with forms.  To add a `NoObjectExists` validator to a Laminas form element:
 
 ```php
 namespace Application\Form;

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -3,9 +3,9 @@
 namespace DoctrineModule\Authentication\Adapter;
 
 use DoctrineModule\Options\Authentication as AuthenticationOptions;
-use Zend\Authentication\Adapter\AbstractAdapter;
-use Zend\Authentication\Adapter\Exception;
-use Zend\Authentication\Result as AuthenticationResult;
+use Laminas\Authentication\Adapter\AbstractAdapter;
+use Laminas\Authentication\Adapter\Exception;
+use Laminas\Authentication\Result as AuthenticationResult;
 use Doctrine\Common\Inflector\Inflector;
 
 /**
@@ -166,10 +166,10 @@ class ObjectRepository extends AbstractAdapter
     }
 
     /**
-     * Creates a Zend\Authentication\Result object from the information that has been collected
+     * Creates a Laminas\Authentication\Result object from the information that has been collected
      * during the authenticate() attempt.
      *
-     * @return \Zend\Authentication\Result
+     * @return \Laminas\Authentication\Result
      */
     protected function createAuthenticationResult()
     {

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -169,7 +169,7 @@ class ObjectRepository extends AbstractAdapter
      * Creates a Laminas\Authentication\Result object from the information that has been collected
      * during the authenticate() attempt.
      *
-     * @return \Laminas\Authentication\Result
+     * @return AuthenticationResult
      */
     protected function createAuthenticationResult()
     {

--- a/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
@@ -3,7 +3,7 @@
 namespace DoctrineModule\Authentication\Storage;
 
 use DoctrineModule\Options\Authentication as AuthenticationOptions;
-use Zend\Authentication\Storage\StorageInterface;
+use Laminas\Authentication\Storage\StorageInterface;
 
 /**
  * This class implements StorageInterface and allow to save the result of an authentication against an object repository

--- a/src/DoctrineModule/Cache/DoctrineCacheStorage.php
+++ b/src/DoctrineModule/Cache/DoctrineCacheStorage.php
@@ -3,7 +3,7 @@
 namespace DoctrineModule\Cache;
 
 use Doctrine\Common\Cache\Cache;
-use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 
 /**
  * Bridge class that allows usage of a Doctrine Cache Storage as a Zend Cache Storage

--- a/src/DoctrineModule/Cache/DoctrineCacheStorage.php
+++ b/src/DoctrineModule/Cache/DoctrineCacheStorage.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Cache\Cache;
 use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 
 /**
- * Bridge class that allows usage of a Doctrine Cache Storage as a Zend Cache Storage
+ * Bridge class that allows usage of a Doctrine Cache Storage as a Laminas Cache Storage
  *
  * @license MIT
  * @link    http://www.doctrine-project.org/

--- a/src/DoctrineModule/Cache/LaminasStorageCache.php
+++ b/src/DoctrineModule/Cache/LaminasStorageCache.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace DoctrineModule\Cache;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
+use Laminas\Cache\Storage\StorageInterface;
+use Laminas\Cache\Storage\FlushableInterface;
+use Laminas\Cache\Storage\TotalSpaceCapableInterface;
+use Laminas\Cache\Storage\AvailableSpaceCapableInterface;
+
+/**
+ * Bridge class that allows usage of a Zend Cache Storage as a Doctrine Cache
+ *
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Marco Pivetta <ocramius@gmail.com>
+ */
+class LaminasStorageCache extends CacheProvider
+{
+
+    /**
+     * @var StorageInterface
+     */
+    protected $storage;
+
+    /**
+     * @param StorageInterface $storage
+     */
+    public function __construct(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doFetch($id)
+    {
+        $hit = $this->storage->getItem($id);
+
+        return null === $hit ? false : $hit;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doContains($id)
+    {
+        return $this->storage->hasItem($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doSave($id, $data, $lifeTime = false)
+    {
+        // @todo check if lifetime can be set
+        return $this->storage->setItem($id, $data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doDelete($id)
+    {
+        return $this->storage->removeItem($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doFlush()
+    {
+        if ($this->storage instanceof FlushableInterface) {
+            /* @var $storage FlushableInterface */
+            $storage = $this->storage;
+
+            return $storage->flush();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doGetStats()
+    {
+        /* @var $storage TotalSpaceCapableInterface */
+        /* @var $storage AvailableSpaceCapableInterface */
+        $storage = $this->storage;
+
+        return [
+            Cache::STATS_HITS              => $this->storage->getMetadata(Cache::STATS_HITS),
+            Cache::STATS_MISSES            => $this->storage->getMetadata(Cache::STATS_MISSES),
+            Cache::STATS_UPTIME            => $this->storage->getMetadata(Cache::STATS_UPTIME),
+            Cache::STATS_MEMORY_USAGE      => $storage instanceof TotalSpaceCapableInterface
+                ? $storage->getTotalSpace()
+                : null,
+            Cache::STATS_MEMORY_AVAILIABLE => $storage instanceof AvailableSpaceCapableInterface
+                ? $storage->getAvailableSpace()
+                : null,
+        ];
+    }
+}

--- a/src/DoctrineModule/Cache/LaminasStorageCache.php
+++ b/src/DoctrineModule/Cache/LaminasStorageCache.php
@@ -10,7 +10,7 @@ use Laminas\Cache\Storage\TotalSpaceCapableInterface;
 use Laminas\Cache\Storage\AvailableSpaceCapableInterface;
 
 /**
- * Bridge class that allows usage of a Zend Cache Storage as a Doctrine Cache
+ * Bridge class that allows usage of a Laminas Cache Storage as a Doctrine Cache
  *
  * @license MIT
  * @link    http://www.doctrine-project.org/

--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -4,10 +4,10 @@ namespace DoctrineModule\Cache;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
-use Zend\Cache\Storage\StorageInterface;
-use Zend\Cache\Storage\FlushableInterface;
-use Zend\Cache\Storage\TotalSpaceCapableInterface;
-use Zend\Cache\Storage\AvailableSpaceCapableInterface;
+use Laminas\Cache\Storage\StorageInterface;
+use Laminas\Cache\Storage\FlushableInterface;
+use Laminas\Cache\Storage\TotalSpaceCapableInterface;
+use Laminas\Cache\Storage\AvailableSpaceCapableInterface;
 
 /**
  * Bridge class that allows usage of a Zend Cache Storage as a Doctrine Cache

--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -2,105 +2,14 @@
 
 namespace DoctrineModule\Cache;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\CacheProvider;
-use Laminas\Cache\Storage\StorageInterface;
-use Laminas\Cache\Storage\FlushableInterface;
-use Laminas\Cache\Storage\TotalSpaceCapableInterface;
-use Laminas\Cache\Storage\AvailableSpaceCapableInterface;
-
 /**
  * Bridge class that allows usage of a Zend Cache Storage as a Doctrine Cache
  *
  * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
+ *
+ * @deprecated use \DoctrineModule\Cache\LaminasStorageCache
  */
-class ZendStorageCache extends CacheProvider
+class ZendStorageCache extends LaminasStorageCache
 {
-
-    /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
-     * @param StorageInterface $storage
-     */
-    public function __construct(StorageInterface $storage)
-    {
-        $this->storage = $storage;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doFetch($id)
-    {
-        $hit = $this->storage->getItem($id);
-
-        return null === $hit ? false : $hit;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doContains($id)
-    {
-        return $this->storage->hasItem($id);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doSave($id, $data, $lifeTime = false)
-    {
-        // @todo check if lifetime can be set
-        return $this->storage->setItem($id, $data);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doDelete($id)
-    {
-        return $this->storage->removeItem($id);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doFlush()
-    {
-        if ($this->storage instanceof FlushableInterface) {
-            /* @var $storage FlushableInterface */
-            $storage = $this->storage;
-
-            return $storage->flush();
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doGetStats()
-    {
-        /* @var $storage TotalSpaceCapableInterface */
-        /* @var $storage AvailableSpaceCapableInterface */
-        $storage = $this->storage;
-
-        return [
-            Cache::STATS_HITS              => $this->storage->getMetadata(Cache::STATS_HITS),
-            Cache::STATS_MISSES            => $this->storage->getMetadata(Cache::STATS_MISSES),
-            Cache::STATS_UPTIME            => $this->storage->getMetadata(Cache::STATS_UPTIME),
-            Cache::STATS_MEMORY_USAGE      => $storage instanceof TotalSpaceCapableInterface
-                ? $storage->getTotalSpace()
-                : null,
-            Cache::STATS_MEMORY_AVAILIABLE => $storage instanceof AvailableSpaceCapableInterface
-                ? $storage->getAvailableSpace()
-                : null,
-        ];
-    }
 }

--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -3,8 +3,6 @@
 namespace DoctrineModule\Cache;
 
 /**
- * Bridge class that allows usage of a Zend Cache Storage as a Doctrine Cache
- *
  * @license MIT
  * @link    http://www.doctrine-project.org/
  *

--- a/src/DoctrineModule/Component/Console/Input/RequestInput.php
+++ b/src/DoctrineModule/Component/Console/Input/RequestInput.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Component\Console\Input;
 
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
-use Zend\Console\Request;
+use Laminas\Console\Request;
 
 /**
  * RequestInput represents an input provided as an console request.
@@ -17,7 +17,7 @@ class RequestInput extends ArgvInput
     /**
      * Constructor
      *
-     * @param \Zend\Console\Request $request
+     * @param \Laminas\Console\Request $request
      * @param \Symfony\Component\Console\Input\InputDefinition $definition
      */
     public function __construct(Request $request, InputDefinition $definition = null)

--- a/src/DoctrineModule/Component/Console/Input/RequestInput.php
+++ b/src/DoctrineModule/Component/Console/Input/RequestInput.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineModule\Component\Console\Input;
 
+use Laminas\Console\Request;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
-use Laminas\Console\Request;
 
 /**
  * RequestInput represents an input provided as an console request.
@@ -17,7 +17,7 @@ class RequestInput extends ArgvInput
     /**
      * Constructor
      *
-     * @param \Laminas\Console\Request $request
+     * @param Request $request
      * @param \Symfony\Component\Console\Input\InputDefinition $definition
      */
     public function __construct(Request $request, InputDefinition $definition = null)

--- a/src/DoctrineModule/ConfigProvider.php
+++ b/src/DoctrineModule/ConfigProvider.php
@@ -36,7 +36,7 @@ class ConfigProvider
     {
         return [
             'invokables' => [
-                'DoctrineModule\Authentication\Storage\Session' => 'Zend\Authentication\Storage\Session',
+                'DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session',
             ],
             'factories' => [
                 'doctrine.cli' => 'DoctrineModule\Service\CliFactory',

--- a/src/DoctrineModule/Controller/CliController.php
+++ b/src/DoctrineModule/Controller/CliController.php
@@ -4,8 +4,8 @@ namespace DoctrineModule\Controller;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
-use Zend\Mvc\Console\View\ViewModel;
-use Zend\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\Console\View\ViewModel;
+use Laminas\Mvc\Controller\AbstractActionController;
 use DoctrineModule\Component\Console\Input\RequestInput;
 
 /**

--- a/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
+++ b/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
@@ -3,9 +3,9 @@
 namespace DoctrineModule\Form\Element;
 
 use DoctrineModule\Form\Element\Proxy;
-use Zend\Form\Element\MultiCheckbox;
-use Zend\Form\Form;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Form\Element\MultiCheckbox;
+use Laminas\Form\Form;
+use Laminas\Stdlib\ArrayUtils;
 
 class ObjectMultiCheckbox extends MultiCheckbox
 {

--- a/src/DoctrineModule/Form/Element/ObjectRadio.php
+++ b/src/DoctrineModule/Form/Element/ObjectRadio.php
@@ -3,8 +3,8 @@
 namespace DoctrineModule\Form\Element;
 
 use DoctrineModule\Form\Element\Proxy;
-use Zend\Form\Element\Radio as RadioElement;
-use Zend\Form\Form;
+use Laminas\Form\Element\Radio as RadioElement;
+use Laminas\Form\Form;
 
 class ObjectRadio extends RadioElement
 {

--- a/src/DoctrineModule/Form/Element/ObjectSelect.php
+++ b/src/DoctrineModule/Form/Element/ObjectSelect.php
@@ -3,9 +3,9 @@
 namespace DoctrineModule\Form\Element;
 
 use DoctrineModule\Form\Element\Proxy;
-use Zend\Form\Element\Select as SelectElement;
-use Zend\Form\Form;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Form\Element\Select as SelectElement;
+use Laminas\Form\Form;
+use Laminas\Stdlib\ArrayUtils;
 
 class ObjectSelect extends SelectElement
 {

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -6,7 +6,7 @@ use Traversable;
 use ReflectionMethod;
 use RuntimeException;
 use InvalidArgumentException;
-use Zend\Stdlib\Guard\ArrayOrTraversableGuardTrait;
+use Laminas\Stdlib\Guard\ArrayOrTraversableGuardTrait;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Inflector\Inflector;

--- a/src/DoctrineModule/Module.php
+++ b/src/DoctrineModule/Module.php
@@ -3,12 +3,12 @@
 namespace DoctrineModule;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Zend\ModuleManager\Feature\InitProviderInterface;
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\ModuleManager\ModuleManagerInterface;
-use Zend\EventManager\EventInterface;
-use Zend\Console\Adapter\AdapterInterface as Console;
+use Laminas\ModuleManager\Feature\InitProviderInterface;
+use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
+use Laminas\ModuleManager\Feature\ConfigProviderInterface;
+use Laminas\ModuleManager\ModuleManagerInterface;
+use Laminas\EventManager\EventInterface;
+use Laminas\Console\Adapter\AdapterInterface as Console;
 
 use Symfony\Component\Console\Input\StringInput;
 use DoctrineModule\Component\Console\Output\PropertyOutput;
@@ -25,7 +25,7 @@ use DoctrineModule\Component\Console\Output\PropertyOutput;
 class Module implements ConfigProviderInterface, InitProviderInterface, BootstrapListenerInterface
 {
     /**
-     * @var \Zend\ServiceManager\ServiceLocatorInterface
+     * @var \Laminas\ServiceManager\ServiceLocatorInterface
      */
     private $serviceManager;
 

--- a/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
+++ b/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
@@ -3,10 +3,10 @@
 namespace DoctrineModule\Mvc\Router\Console;
 
 use Symfony\Component\Console\Application;
-use Zend\Mvc\Console\Router\RouteInterface;
-use Zend\Stdlib\RequestInterface as Request;
-use Zend\Router\RouteMatch;
-use Zend\Console\Request as ConsoleRequest;
+use Laminas\Mvc\Console\Router\RouteInterface;
+use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Router\RouteMatch;
+use Laminas\Console\Request as ConsoleRequest;
 
 /**
  * Route matching commands in Symfony CLI

--- a/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
+++ b/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
@@ -2,11 +2,11 @@
 
 namespace DoctrineModule\Mvc\Router\Console;
 
-use Symfony\Component\Console\Application;
 use Laminas\Mvc\Console\Router\RouteInterface;
 use Laminas\Stdlib\RequestInterface as Request;
 use Laminas\Router\RouteMatch;
 use Laminas\Console\Request as ConsoleRequest;
+use Symfony\Component\Console\Application;
 
 /**
  * Route matching commands in Symfony CLI

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -5,10 +5,10 @@ namespace DoctrineModule\Options;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
-use Zend\Authentication\Adapter\Exception;
-use Zend\Authentication\Storage\Session as SessionStorage;
-use Zend\Authentication\Storage\StorageInterface;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Authentication\Adapter\Exception;
+use Laminas\Authentication\Storage\Session as SessionStorage;
+use Laminas\Authentication\Storage\StorageInterface;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * This options class can be consumed by five different classes:
@@ -107,7 +107,7 @@ class Authentication extends AbstractOptions
      * the option storeOnlyKeys == false, this is the storage instance that the whole
      * object will be stored in.
      *
-     * @var \Zend\Authentication\Storage\StorageInterface|string;
+     * @var \Laminas\Authentication\Storage\StorageInterface|string;
      */
     protected $storage = 'DoctrineModule\Authentication\Storage\Session';
 
@@ -272,7 +272,7 @@ class Authentication extends AbstractOptions
     }
 
     /**
-     * @return \Zend\Authentication\Storage\StorageInterface|string
+     * @return \Laminas\Authentication\Storage\StorageInterface|string
      */
     public function getStorage()
     {
@@ -280,7 +280,7 @@ class Authentication extends AbstractOptions
     }
 
     /**
-     * @param \Zend\Authentication\Storage\StorageInterface|string $storage
+     * @param \Laminas\Authentication\Storage\StorageInterface|string $storage
      */
     public function setStorage($storage)
     {

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -107,7 +107,7 @@ class Authentication extends AbstractOptions
      * the option storeOnlyKeys == false, this is the storage instance that the whole
      * object will be stored in.
      *
-     * @var \Laminas\Authentication\Storage\StorageInterface|string;
+     * @var StorageInterface|string;
      */
     protected $storage = 'DoctrineModule\Authentication\Storage\Session';
 
@@ -272,7 +272,7 @@ class Authentication extends AbstractOptions
     }
 
     /**
-     * @return \Laminas\Authentication\Storage\StorageInterface|string
+     * @return StorageInterface|string
      */
     public function getStorage()
     {
@@ -280,7 +280,7 @@ class Authentication extends AbstractOptions
     }
 
     /**
-     * @param \Laminas\Authentication\Storage\StorageInterface|string $storage
+     * @param StorageInterface|string $storage
      */
     public function setStorage($storage)
     {

--- a/src/DoctrineModule/Options/Cache.php
+++ b/src/DoctrineModule/Options/Cache.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Cache options

--- a/src/DoctrineModule/Options/Driver.php
+++ b/src/DoctrineModule/Options/Driver.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * MappingDriver options

--- a/src/DoctrineModule/Options/EventManager.php
+++ b/src/DoctrineModule/Options/EventManager.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * EventManager options

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -3,7 +3,7 @@
 namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
-use Zend\Paginator\Adapter\AdapterInterface;
+use Laminas\Paginator\Adapter\AdapterInterface;
 
 /**
  * Base module for Doctrine ORM.

--- a/src/DoctrineModule/Paginator/Adapter/Selectable.php
+++ b/src/DoctrineModule/Paginator/Adapter/Selectable.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
 use Doctrine\Common\Collections\Criteria;
-use Zend\Paginator\Adapter\AdapterInterface;
+use Laminas\Paginator\Adapter\AdapterInterface;
 
 /**
  * Provides a wrapper around a Selectable object

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
 use RuntimeException;
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\FactoryInterface;
 
 /**
  * Base ServiceManager factory to be extended
@@ -28,7 +28,7 @@ abstract class AbstractFactory implements FactoryInterface
     protected $name;
 
     /**
-     * @var \Zend\Stdlib\AbstractOptions
+     * @var \Laminas\Stdlib\AbstractOptions
      */
     protected $options;
 
@@ -64,7 +64,7 @@ abstract class AbstractFactory implements FactoryInterface
      * @param  ContainerInterface $container
      * @param  string             $key
      * @param  null|string        $name
-     * @return \Zend\Stdlib\AbstractOptions
+     * @return \Laminas\Stdlib\AbstractOptions
      * @throws \RuntimeException
      */
     public function getOptions(ContainerInterface $container, $key, $name = null)

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Service\Authentication;
 use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory to create authentication adapter object.

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -3,8 +3,8 @@ namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Zend\Authentication\AuthenticationService;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory to create authentication service object.
@@ -29,8 +29,8 @@ class AuthenticationServiceFactory extends AbstractFactory
 
     /**
      *
-     * @param \Zend\ServiceManager\ServiceLocatorInterface $container
-     * @return \Zend\Authentication\AuthenticationService
+     * @param \Laminas\ServiceManager\ServiceLocatorInterface $container
+     * @return \Laminas\Authentication\AuthenticationService
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -29,8 +29,8 @@ class AuthenticationServiceFactory extends AbstractFactory
 
     /**
      *
-     * @param \Laminas\ServiceManager\ServiceLocatorInterface $container
-     * @return \Laminas\Authentication\AuthenticationService
+     * @param ServiceLocatorInterface $container
+     * @return AuthenticationService
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Service\Authentication;
 use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory to create authentication storage object.

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -7,7 +7,7 @@ use Interop\Container\ContainerInterface;
 use RuntimeException;
 use Doctrine\Common\Cache;
 use DoctrineModule\Cache\ZendStorageCache;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Cache ServiceManager factory

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Cache\CacheProvider;
 use Interop\Container\ContainerInterface;
 use RuntimeException;
 use Doctrine\Common\Cache;
-use DoctrineModule\Cache\ZendStorageCache;
+use DoctrineModule\Cache\LaminasStorageCache;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
@@ -49,7 +49,7 @@ class CacheFactory extends AbstractFactory
                     $cache = new $class($options->getDirectory());
                     break;
 
-                case ZendStorageCache::class:
+                case LaminasStorageCache::class:
                 case Cache\PredisCache::class:
                     $cache = new $class($instance);
                     break;

--- a/src/DoctrineModule/Service/CliControllerFactory.php
+++ b/src/DoctrineModule/Service/CliControllerFactory.php
@@ -5,10 +5,10 @@ namespace DoctrineModule\Service;
 use DoctrineModule\Controller\CliController;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory responsible of instantiating an {@see \DoctrineModule\Controller\CliController}

--- a/src/DoctrineModule/Service/CliFactory.php
+++ b/src/DoctrineModule/Service/CliFactory.php
@@ -5,8 +5,8 @@ namespace DoctrineModule\Service;
 use Interop\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * CLI Application ServiceManager factory responsible for instantiating a Symfony CLI application
@@ -18,7 +18,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 class CliFactory implements FactoryInterface
 {
     /**
-     * @var \Zend\EventManager\EventManagerInterface
+     * @var \Laminas\EventManager\EventManagerInterface
      */
     protected $events;
 
@@ -34,12 +34,12 @@ class CliFactory implements FactoryInterface
 
     /**
      * @param  ContainerInterface $container
-     * @return \Zend\EventManager\EventManagerInterface
+     * @return \Laminas\EventManager\EventManagerInterface
      */
     public function getEventManager(ContainerInterface $container)
     {
         if (null === $this->events) {
-            /* @var $events \Zend\EventManager\EventManagerInterface */
+            /* @var $events \Laminas\EventManager\EventManagerInterface */
             $events = $container->get('EventManager');
 
             $events->addIdentifiers([__CLASS__, 'doctrine']);

--- a/src/DoctrineModule/Service/CliFactory.php
+++ b/src/DoctrineModule/Service/CliFactory.php
@@ -3,10 +3,10 @@
 namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Helper\HelperSet;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
 
 /**
  * CLI Application ServiceManager factory responsible for instantiating a Symfony CLI application

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use DoctrineModule\Options\Driver as DriverOptions;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * MappingDriver ServiceManager factory

--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -6,7 +6,7 @@ use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\EventSubscriber;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory responsible for creating EventManager instances

--- a/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
+++ b/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
@@ -4,8 +4,8 @@ namespace DoctrineModule\Service;
 
 use DoctrineModule\Mvc\Router\Console\SymfonyCli;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory responsible of instantiating {@see \DoctrineModule\Mvc\Router\Console\SymfonyCli}

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -3,9 +3,9 @@
 namespace DoctrineModule\ServiceFactory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\AbstractFactoryInterface;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\AbstractFactoryInterface;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Abstract service factory capable of instantiating services whose names match the

--- a/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/DoctrineObject.php
@@ -9,9 +9,9 @@ use Doctrine\Common\Inflector\Inflector;
 use InvalidArgumentException;
 use RuntimeException;
 use Traversable;
-use Zend\Stdlib\ArrayUtils;
-use Zend\Hydrator\AbstractHydrator;
-use Zend\Hydrator\Filter\FilterProviderInterface;
+use Laminas\Stdlib\ArrayUtils;
+use Laminas\Hydrator\AbstractHydrator;
+use Laminas\Hydrator\Filter\FilterProviderInterface;
 
 /**
  * This hydrator has been completely refactored for DoctrineModule 0.7.0. It provides an easy and powerful way

--- a/src/DoctrineModule/Stdlib/Hydrator/Filter/PropertyName.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Filter/PropertyName.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModule\Stdlib\Hydrator\Filter;
 
-use Zend\Hydrator\Filter\FilterInterface;
+use Laminas\Hydrator\Filter\FilterInterface;
 
 /**
  * Provides a filter to restrict returned fields by whitelisting or

--- a/src/DoctrineModule/Stdlib/Hydrator/Strategy/AbstractCollectionStrategy.php
+++ b/src/DoctrineModule/Stdlib/Hydrator/Strategy/AbstractCollectionStrategy.php
@@ -3,7 +3,7 @@
 namespace DoctrineModule\Stdlib\Hydrator\Strategy;
 
 use InvalidArgumentException;
-use Zend\Hydrator\Strategy\StrategyInterface;
+use Laminas\Hydrator\Strategy\StrategyInterface;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Inflector\Inflector;

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -2,10 +2,10 @@
 
 namespace DoctrineModule\Validator;
 
-use Zend\Validator\AbstractValidator;
-use Zend\Validator\Exception;
+use Laminas\Validator\AbstractValidator;
+use Laminas\Validator\Exception;
 use Doctrine\Common\Persistence\ObjectRepository;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Stdlib\ArrayUtils;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields
@@ -49,7 +49,7 @@ class ObjectExists extends AbstractValidator
      * @param array $options required keys are `object_repository`, which must be an instance of
      *                       Doctrine\Common\Persistence\ObjectRepository, and `fields`, with either
      *                       a string or an array of strings representing the fields to be matched by the validator.
-     * @throws \Zend\Validator\Exception\InvalidArgumentException
+     * @throws \Laminas\Validator\Exception\InvalidArgumentException
      */
     public function __construct(array $options)
     {
@@ -91,7 +91,7 @@ class ObjectExists extends AbstractValidator
     /**
      * Filters and validates the fields passed to the constructor
      *
-     * @throws \Zend\Validator\Exception\InvalidArgumentException
+     * @throws \Laminas\Validator\Exception\InvalidArgumentException
      * @return array
      */
     private function validateFields()
@@ -117,7 +117,7 @@ class ObjectExists extends AbstractValidator
      * @param string|array $value a field value or an array of field values if more fields have been configured to be
      *                      matched
      * @return array
-     * @throws \Zend\Validator\Exception\RuntimeException
+     * @throws \Laminas\Validator\Exception\RuntimeException
      */
     protected function cleanSearchValue($value)
     {

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -2,10 +2,10 @@
 
 namespace DoctrineModule\Validator;
 
-use Laminas\Validator\AbstractValidator;
-use Laminas\Validator\Exception;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\Validator\AbstractValidator;
+use Laminas\Validator\Exception;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields
@@ -49,7 +49,7 @@ class ObjectExists extends AbstractValidator
      * @param array $options required keys are `object_repository`, which must be an instance of
      *                       Doctrine\Common\Persistence\ObjectRepository, and `fields`, with either
      *                       a string or an array of strings representing the fields to be matched by the validator.
-     * @throws \Laminas\Validator\Exception\InvalidArgumentException
+     * @throws Exception\InvalidArgumentException
      */
     public function __construct(array $options)
     {
@@ -91,7 +91,7 @@ class ObjectExists extends AbstractValidator
     /**
      * Filters and validates the fields passed to the constructor
      *
-     * @throws \Laminas\Validator\Exception\InvalidArgumentException
+     * @throws Exception\InvalidArgumentException
      * @return array
      */
     private function validateFields()
@@ -117,7 +117,7 @@ class ObjectExists extends AbstractValidator
      * @param string|array $value a field value or an array of field values if more fields have been configured to be
      *                      matched
      * @return array
-     * @throws \Laminas\Validator\Exception\RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function cleanSearchValue($value)
     {

--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -3,12 +3,12 @@
 
 namespace DoctrineModule\Validator\Service;
 
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\FactoryInterface;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use DoctrineModule\Validator\Service\Exception\ServiceCreationException;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Stdlib\ArrayUtils;
 
 /**
  * Factory for creating NoObjectExists instances

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -3,7 +3,7 @@
 namespace DoctrineModule\Validator;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Zend\Validator\Exception;
+use Laminas\Validator\Exception;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields only once.

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -19,7 +19,7 @@ class ObjectRepositoryTest extends BaseTestCase
     public function testWillRejectInvalidIdentityProperty()
     {
         $this->expectException(
-            'Zend\Authentication\Adapter\Exception\InvalidArgumentException'
+            'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
         );
         $this->expectExceptionMessage(
             'Provided $identityProperty is invalid, boolean given'
@@ -31,7 +31,7 @@ class ObjectRepositoryTest extends BaseTestCase
     public function testWillRejectInvalidCredentialProperty()
     {
         $this->expectException(
-            'Zend\Authentication\Adapter\Exception\InvalidArgumentException'
+            'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
         );
         $this->expectExceptionMessage(
             'Provided $credentialProperty is invalid, boolean given'
@@ -42,7 +42,7 @@ class ObjectRepositoryTest extends BaseTestCase
     public function testWillRequireIdentityValue()
     {
         $this->expectException(
-            'Zend\Authentication\Adapter\Exception\RuntimeException'
+            'Laminas\Authentication\Adapter\Exception\RuntimeException'
         );
         $this->expectExceptionMessage(
             'A value for the identity was not provided prior to authentication with ObjectRepository authentication '
@@ -60,7 +60,7 @@ class ObjectRepositoryTest extends BaseTestCase
     public function testWillRequireCredentialValue()
     {
         $this->expectException(
-            'Zend\Authentication\Adapter\Exception\RuntimeException'
+            'Laminas\Authentication\Adapter\Exception\RuntimeException'
         );
         $this->expectExceptionMessage(
             'A credential value was not provided prior to authentication with ObjectRepository authentication adapter'
@@ -78,7 +78,7 @@ class ObjectRepositoryTest extends BaseTestCase
     public function testWillRejectInvalidCredentialCallable()
     {
         $this->expectException(
-            'Zend\Authentication\Adapter\Exception\InvalidArgumentException'
+            'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
         );
         $this->expectExceptionMessage(
             '"array" is not a callable'
@@ -174,7 +174,7 @@ class ObjectRepositoryTest extends BaseTestCase
 
     public function testWillRefuseToAuthenticateWithoutGettersOrPublicMethods()
     {
-        $this->expectException('Zend\Authentication\Adapter\Exception\UnexpectedValueException');
+        $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
         $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
         $objectRepository
@@ -236,7 +236,7 @@ class ObjectRepositoryTest extends BaseTestCase
 
     public function testWillRefuseToAuthenticateWhenInvalidInstanceIsFound()
     {
-        $this->expectException('Zend\Authentication\Adapter\Exception\UnexpectedValueException');
+        $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
         $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
         $objectRepository

--- a/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
@@ -5,7 +5,7 @@ namespace DoctrineModuleTest\Authentication\Storage;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use DoctrineModule\Authentication\Storage\ObjectRepository as ObjectRepositoryStorage;
 use DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject;
-use Zend\Authentication\Storage\NonPersistent as NonPersistentStorage;
+use Laminas\Authentication\Storage\NonPersistent as NonPersistentStorage;
 
 /**
  * Tests for the ObjectRepository based authentication adapter

--- a/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
+++ b/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
@@ -4,9 +4,9 @@ namespace DoctrineModuleTest\Cache;
 
 use DoctrineModule\Cache\DoctrineCacheStorage;
 use Doctrine\Common\Cache\ArrayCache;
-use Zend\Cache\Storage\Adapter\AdapterOptions;
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use PHPUnit\Framework\TestCase;
-use Zend\Stdlib\ErrorHandler;
+use Laminas\Stdlib\ErrorHandler;
 
 /**
  * Tests for the cache bridge
@@ -28,7 +28,7 @@ class DoctrineCacheStorageTest extends TestCase
     /**
      * The storage adapter
      *
-     * @var \Zend\Cache\Storage\StorageInterface
+     * @var \Laminas\Cache\Storage\StorageInterface
      */
     protected $storage;
 
@@ -46,12 +46,12 @@ class DoctrineCacheStorageTest extends TestCase
         $this->storage = new DoctrineCacheStorage($this->options, new ArrayCache());
 
         $this->assertInstanceOf(
-            'Zend\Cache\Storage\StorageInterface',
+            'Laminas\Cache\Storage\StorageInterface',
             $this->storage,
             'Storage adapter instance is needed for tests'
         );
         $this->assertInstanceOf(
-            'Zend\Cache\Storage\Adapter\AdapterOptions',
+            'Laminas\Cache\Storage\Adapter\AdapterOptions',
             $this->options,
             'Options instance is needed for tests'
         );
@@ -131,7 +131,7 @@ class DoctrineCacheStorageTest extends TestCase
     public function testGetCapabilities()
     {
         $capabilities = $this->storage->getCapabilities();
-        $this->assertInstanceOf('Zend\Cache\Storage\Capabilities', $capabilities);
+        $this->assertInstanceOf('Laminas\Cache\Storage\Capabilities', $capabilities);
     }
 
     public function testDatatypesCapability()

--- a/tests/DoctrineModuleTest/Cache/LaminasStorageCacheTest.php
+++ b/tests/DoctrineModuleTest/Cache/LaminasStorageCacheTest.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModuleTest\Cache;
 
-use DoctrineModule\Cache\ZendStorageCache;
+use DoctrineModule\Cache\LaminasStorageCache;
 use Doctrine\Common\Cache\Cache;
 use Laminas\Cache\Storage\Adapter\Memory;
 use PHPUnit\Framework\TestCase;
@@ -14,14 +14,14 @@ use PHPUnit\Framework\TestCase;
  * @link    http://www.doctrine-project.org/
  * @author  Marco Pivetta <ocramius@gmail.com>
  */
-class ZendStorageCacheTest extends TestCase
+class LaminasStorageCacheTest extends TestCase
 {
     /**
-     * @return ZendStorageCache
+     * @return LaminasStorageCache
      */
     protected function getCacheDriver()
     {
-        return new ZendStorageCache(new Memory());
+        return new LaminasStorageCache(new Memory());
     }
 
     public function testBasics()

--- a/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
+++ b/tests/DoctrineModuleTest/Cache/ZendStorageCacheTest.php
@@ -4,7 +4,7 @@ namespace DoctrineModuleTest\Cache;
 
 use DoctrineModule\Cache\ZendStorageCache;
 use Doctrine\Common\Cache\Cache;
-use Zend\Cache\Storage\Adapter\Memory;
+use Laminas\Cache\Storage\Adapter\Memory;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/DoctrineModuleTest/Component/Console/Input/RequestInputTest.php
+++ b/tests/DoctrineModuleTest/Component/Console/Input/RequestInputTest.php
@@ -3,7 +3,7 @@
 namespace DoctrineModuleTest\Component\Console\Input;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Console\Request;
+use Laminas\Console\Request;
 use DoctrineModule\Component\Console\Input\RequestInput;
 
 /**

--- a/tests/DoctrineModuleTest/Controller/CliControllerTest.php
+++ b/tests/DoctrineModuleTest/Controller/CliControllerTest.php
@@ -4,8 +4,8 @@ namespace DoctrineModuleTest\Controller;
 
 use DoctrineModuleTest\ServiceManagerFactory;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Zend\Console\Request;
-use Zend\Test\PHPUnit\Controller\AbstractConsoleControllerTestCase;
+use Laminas\Console\Request;
+use Laminas\Test\PHPUnit\Controller\AbstractConsoleControllerTestCase;
 use DoctrineModuleTest\Controller\Mock\FailingCommand;
 
 /**

--- a/tests/DoctrineModuleTest/ModuleTest.php
+++ b/tests/DoctrineModuleTest/ModuleTest.php
@@ -15,18 +15,18 @@ class ModuleTest extends TestCase
 {
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|\Zend\Mvc\Application
+     * @var PHPUnit_Framework_MockObject_MockObject|\Laminas\Mvc\Application
      */
     private $application;
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|\Zend\Mvc\MvcEvent
+     * @var PHPUnit_Framework_MockObject_MockObject|\Laminas\Mvc\MvcEvent
      */
     private $event;
 
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|\Zend\ServiceManager\ServiceManager
+     * @var PHPUnit_Framework_MockObject_MockObject|\Laminas\ServiceManager\ServiceManager
      */
     private $serviceManager;
 
@@ -37,12 +37,12 @@ class ModuleTest extends TestCase
 
     protected function setUp()
     {
-        $this->application    = $this->getMockBuilder('Zend\Mvc\Application')
+        $this->application    = $this->getMockBuilder('Laminas\Mvc\Application')
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $this->event          = $this->createMock('Zend\Mvc\MvcEvent');
-        $this->serviceManager = $this->createMock('Zend\ServiceManager\ServiceManager');
+        $this->event          = $this->createMock('Laminas\Mvc\MvcEvent');
+        $this->serviceManager = $this->createMock('Laminas\ServiceManager\ServiceManager');
         $this->cli            = $this->createPartialMock('Symfony\Component\Console\Application', ['run']);
 
         $this
@@ -111,7 +111,7 @@ class ModuleTest extends TestCase
 
         $this->assertSame(
             'list - TEST - More output',
-            $module->getConsoleUsage($this->createMock('Zend\Console\Adapter\AdapterInterface'))
+            $module->getConsoleUsage($this->createMock('Laminas\Console\Adapter\AdapterInterface'))
         );
     }
 }

--- a/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
+++ b/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
@@ -5,8 +5,8 @@ namespace DoctrineModuleTest\Mvc\Router\Console;
 use DoctrineModule\Mvc\Router\Console\SymfonyCli;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Zend\Console\Request;
-use Zend\Router\RouteMatch;
+use Laminas\Console\Request;
+use Laminas\Router\RouteMatch;
 
 /**
  * Tests for {@see \DoctrineModule\Mvc\Router\Console\SymfonyCli}

--- a/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
@@ -4,7 +4,7 @@ namespace DoctrineModuleTest\Service\Authentication;
 
 use DoctrineModule\Service\Authentication\AdapterFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 class AdapterFactoryTest extends BaseTestCase
 {

--- a/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -6,7 +6,7 @@ use DoctrineModule\Service\Authentication\AuthenticationServiceFactory;
 use DoctrineModule\Service\Authentication\AdapterFactory;
 use DoctrineModule\Service\Authentication\StorageFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 class AuthenticationServiceFactoryTest extends BaseTestCase
 {
@@ -36,12 +36,12 @@ class AuthenticationServiceFactoryTest extends BaseTestCase
         );
         $serviceManager->setInvokableClass(
             'DoctrineModule\Authentication\Storage\Session',
-            'Zend\Authentication\Storage\Session'
+            'Laminas\Authentication\Storage\Session'
         );
         $serviceManager->setFactory('doctrine.authenticationadapter.' . $name, new AdapterFactory($name));
         $serviceManager->setFactory('doctrine.authenticationstorage.' . $name, new StorageFactory($name));
 
         $authenticationService = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Zend\Authentication\AuthenticationService', $authenticationService);
+        $this->assertInstanceOf('Laminas\Authentication\AuthenticationService', $authenticationService);
     }
 }

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -4,7 +4,7 @@ namespace DoctrineModuleTest\Service\Authentication;
 
 use DoctrineModule\Service\Authentication\StorageFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 class StorageFactoryTest extends BaseTestCase
 {
@@ -18,7 +18,7 @@ class StorageFactoryTest extends BaseTestCase
         $serviceManager = new ServiceManager();
         $serviceManager->setInvokableClass(
             'DoctrineModule\Authentication\Storage\Session',
-            'Zend\Authentication\Storage\Session'
+            'Laminas\Authentication\Storage\Session'
         );
         $serviceManager->setService(
             'config',
@@ -43,8 +43,8 @@ class StorageFactoryTest extends BaseTestCase
     public function testCanInstantiateStorageFromServiceLocator()
     {
         $factory        = new StorageFactory('testFactory');
-        $serviceManager = $this->createMock('Zend\ServiceManager\ServiceManager');
-        $storage        = $this->createMock('Zend\Authentication\Storage\StorageInterface');
+        $serviceManager = $this->createMock('Laminas\ServiceManager\ServiceManager');
+        $storage        = $this->createMock('Laminas\Authentication\Storage\StorageInterface');
         $config         = [
             'doctrine' => [
                 'authentication' => [

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -5,7 +5,7 @@ namespace DoctrineModuleTest\Service;
 use Doctrine\Common\Cache\ChainCache;
 use DoctrineModule\Service\CacheFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * Test for {@see \DoctrineModule\Service\CacheFactory}
@@ -45,7 +45,7 @@ class CacheFactoryTest extends BaseTestCase
      * @covers \DoctrineModule\Service\CacheFactory::createService
      * @group 547
      */
-    public function testCreateZendCache()
+    public function testCreateLaminasCache()
     {
         $factory        = new CacheFactory('phpunit');
         $serviceManager = new ServiceManager();
@@ -70,7 +70,7 @@ class CacheFactoryTest extends BaseTestCase
                 ],
             ]
         );
-        $serviceManager->addAbstractFactory('Zend\Cache\Service\StorageCacheAbstractServiceFactory');
+        $serviceManager->addAbstractFactory('Laminas\Cache\Service\StorageCacheAbstractServiceFactory');
 
         $cache = $factory->createService($serviceManager);
 

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -55,7 +55,7 @@ class CacheFactoryTest extends BaseTestCase
                 'doctrine' => [
                     'cache' => [
                         'phpunit' => [
-                            'class' => 'DoctrineModule\Cache\ZendStorageCache',
+                            'class' => 'DoctrineModule\Cache\LaminasStorageCache',
                             'instance' => 'my-zend-cache',
                             'namespace' => 'DoctrineModule',
                         ],
@@ -74,7 +74,7 @@ class CacheFactoryTest extends BaseTestCase
 
         $cache = $factory->createService($serviceManager);
 
-        $this->assertInstanceOf('DoctrineModule\Cache\ZendStorageCache', $cache);
+        $this->assertInstanceOf('DoctrineModule\Cache\LaminasStorageCache', $cache);
     }
 
     public function testCreatePredisCache()

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -56,13 +56,13 @@ class CacheFactoryTest extends BaseTestCase
                     'cache' => [
                         'phpunit' => [
                             'class' => 'DoctrineModule\Cache\LaminasStorageCache',
-                            'instance' => 'my-zend-cache',
+                            'instance' => 'my-laminas-cache',
                             'namespace' => 'DoctrineModule',
                         ],
                     ],
                 ],
                 'caches' => [
-                    'my-zend-cache' => [
+                    'my-laminas-cache' => [
                         'adapter' => [
                             'name' => 'blackhole',
                         ],

--- a/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
@@ -3,8 +3,8 @@
 namespace DoctrineModuleTest\Service;
 
 use DoctrineModule\Service\DriverFactory;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
  * Base test case to be used when a service manager instance is required

--- a/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
@@ -4,7 +4,7 @@ namespace DoctrineModuleTest\Service;
 
 use DoctrineModule\Service\DriverFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * Base test case to be used when a service manager instance is required

--- a/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
@@ -4,7 +4,7 @@ namespace DoctrineModuleTest\Service;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use DoctrineModule\Service\EventManagerFactory;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use DoctrineModuleTest\Service\TestAsset\DummyEventSubscriber;
 
 /**

--- a/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 class ModuleDefinedServicesTest extends TestCase
 {
     /**
-     * @var \Zend\ServiceManager\ServiceLocatorInterface
+     * @var \Laminas\ServiceManager\ServiceLocatorInterface
      */
     protected $serviceManager;
 
@@ -54,7 +54,7 @@ class ModuleDefinedServicesTest extends TestCase
      */
     public function testModuleInvalidService($serviceName)
     {
-        $this->expectException('Zend\ServiceManager\Exception\ServiceNotFoundException');
+        $this->expectException('Laminas\ServiceManager\Exception\ServiceNotFoundException');
 
         $this->serviceManager->get($serviceName);
     }
@@ -87,7 +87,7 @@ class ModuleDefinedServicesTest extends TestCase
             ['doctrine.foo', false],
             ['doctrine.foo.bar', false],
             ['doctrine.cache.bar', false],
-            //['doctrine.cache.zendcachestorage'],
+            //['doctrine.cache.laminascachestorage'],
         ];
     }
 

--- a/tests/DoctrineModuleTest/ServiceManagerFactory.php
+++ b/tests/DoctrineModuleTest/ServiceManagerFactory.php
@@ -2,8 +2,8 @@
 
 namespace DoctrineModuleTest;
 
-use Zend\Mvc\Service\ServiceManagerConfig;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Mvc\Service\ServiceManagerConfig;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * Base test case to be used when a service manager instance is required
@@ -33,10 +33,10 @@ class ServiceManagerFactory
 
         $serviceManager->setService('ApplicationConfig', $configuration);
         if (! $serviceManager->has('ServiceListener')) {
-            $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
+            $serviceManager->setFactory('ServiceListener', 'Laminas\Mvc\Service\ServiceListenerFactory');
         }
 
-        /* @var $moduleManager \Zend\ModuleManager\ModuleManagerInterface */
+        /* @var $moduleManager \Laminas\ModuleManager\ModuleManagerInterface */
         $moduleManager = $serviceManager->get('ModuleManager');
         $moduleManager->loadModules();
 

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/ContextStrategy.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/ContextStrategy.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
 
-use Zend\Hydrator\Strategy\StrategyInterface;
+use Laminas\Hydrator\Strategy\StrategyInterface;
 
 class ContextStrategy implements StrategyInterface
 {

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleStrategy.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/Asset/SimpleStrategy.php
@@ -1,7 +1,7 @@
 <?php
 namespace DoctrineModuleTest\Stdlib\Hydrator\Asset;
 
-use Zend\Hydrator\Strategy\StrategyInterface;
+use Laminas\Hydrator\Strategy\StrategyInterface;
 
 class SimpleStrategy implements StrategyInterface
 {

--- a/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
+++ b/tests/DoctrineModuleTest/Stdlib/Hydrator/DoctrineObjectTest.php
@@ -16,8 +16,8 @@ use DoctrineModule\Stdlib\Hydrator\DoctrineObject as DoctrineObjectHydrator;
 use DoctrineModule\Stdlib\Hydrator\Strategy;
 use DoctrineModule\Stdlib\Hydrator\Filter;
 use DoctrineModuleTest\Stdlib\Hydrator\Asset\NamingStrategyEntity;
-use Zend\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
-use Zend\Hydrator\Strategy\StrategyInterface;
+use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
+use Laminas\Hydrator\Strategy\StrategyInterface;
 
 class DoctrineObjectTest extends BaseTestCase
 {

--- a/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
@@ -75,28 +75,28 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testWillRefuseMissingRepository()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['fields' => 'field']);
     }
 
     public function testWillRefuseNonObjectRepository()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['object_repository' => 'invalid', 'fields' => 'field']);
     }
 
     public function testWillRefuseInvalidRepository()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['object_repository' => new stdClass(), 'fields' => 'field']);
     }
 
     public function testWillRefuseMissingFields()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists([
             'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
@@ -105,7 +105,7 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testWillRefuseEmptyFields()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists([
             'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
@@ -115,7 +115,7 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testWillRefuseNonStringFields()
     {
-        $this->expectException('Zend\Validator\Exception\InvalidArgumentException');
+        $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
         new ObjectExists([
             'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
             'fields'            => [123],
@@ -125,7 +125,7 @@ class ObjectExistsTest extends BaseTestCase
     public function testWillNotValidateOnFieldsCountMismatch()
     {
         $this->expectException(
-            'Zend\Validator\Exception\RuntimeException'
+            'Laminas\Validator\Exception\RuntimeException'
         );
         $this->expectExceptionMessage(
             'Provided values count is 1, while expected number of fields to be matched is 2'
@@ -140,7 +140,7 @@ class ObjectExistsTest extends BaseTestCase
     public function testWillNotValidateOnFieldKeysMismatch()
     {
         $this->expectException(
-            'Zend\Validator\Exception\RuntimeException'
+            'Laminas\Validator\Exception\RuntimeException'
         );
         $this->expectExceptionMessage(
             'Field "field2" was not provided, but was expected since the configured field lists needs it for validation'

--- a/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
@@ -3,8 +3,8 @@
 namespace DoctrineModule\Validator\Service;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use DoctrineModule\Validator\NoObjectExists;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;

--- a/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
+++ b/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
@@ -157,7 +157,7 @@ class UniqueObjectTest extends BaseTestCase
 
     public function testThrowsAnExceptionOnUsedButMissingContext()
     {
-        $this->expectException(\Zend\Validator\Exception\RuntimeException::class);
+        $this->expectException(\Laminas\Validator\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Expected context to be an array but is null');
 
         $match = new stdClass();
@@ -182,7 +182,7 @@ class UniqueObjectTest extends BaseTestCase
 
     public function testThrowsAnExceptionOnMissingIdentifier()
     {
-        $this->expectException(\Zend\Validator\Exception\RuntimeException::class);
+        $this->expectException(\Laminas\Validator\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Expected context to contain id');
 
         $match = new stdClass();
@@ -220,7 +220,7 @@ class UniqueObjectTest extends BaseTestCase
 
     public function testThrowsAnExceptionOnMissingIdentifierInContext()
     {
-        $this->expectException(\Zend\Validator\Exception\RuntimeException::class);
+        $this->expectException(\Laminas\Validator\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Expected context to contain id');
 
         $match = new stdClass();
@@ -259,7 +259,7 @@ class UniqueObjectTest extends BaseTestCase
 
     public function testThrowsAnExceptionOnMissingObjectManager()
     {
-        $this->expectException(\Zend\Validator\Exception\InvalidArgumentException::class);
+        $this->expectException(\Laminas\Validator\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Common\\Persistence\\ObjectManager, nothing given');
 
         $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
@@ -272,7 +272,7 @@ class UniqueObjectTest extends BaseTestCase
 
     public function testThrowsAnExceptionOnWrongObjectManager()
     {
-        $this->expectException(\Zend\Validator\Exception\InvalidArgumentException::class);
+        $this->expectException(\Laminas\Validator\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Common\\Persistence\\ObjectManager, stdClass given');
 
         $objectManager = new stdClass();

--- a/tests/TestConfiguration.php
+++ b/tests/TestConfiguration.php
@@ -1,13 +1,13 @@
 <?php
 return [
     'modules' => [
-        'Zend\Cache',
-        'Zend\Form',
-        'Zend\Hydrator',
-        'Zend\Mvc\Console',
-        'Zend\Paginator',
-        'Zend\Router',
-        'Zend\Validator',
+        'Laminas\Cache',
+        'Laminas\Form',
+        'Laminas\Hydrator',
+        'Laminas\Mvc\Console',
+        'Laminas\Paginator',
+        'Laminas\Router',
+        'Laminas\Validator',
         'DoctrineModule',
     ],
     'module_listener_options' => [


### PR DESCRIPTION
Reference: https://getlaminas.org/blog/2019-12-31-out-with-the-old-in-with-the-new.html

1. PR created with `laminas-migration migrate --no-plugin --no-config-processor`
1. Links to https://framework.zend.com/ were **not** updated because as the time of writing this PR there is no Laminas framework website