### PR TITLE
PR towards a 4.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "laminas/laminas-mvc": "^3.1",
         "laminas/laminas-paginator": "^2.8",
         "laminas/laminas-servicemanager": "^3.3",
-        "laminas/laminas-stdlib": "^3.1",
+        "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-validator": "^2.10",
         "symfony/console": "^3.3 || ^4.0 || ^5.0",
         "laminas/laminas-dependency-plugin": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-validator": "^2.10",
         "symfony/console": "^3.3 || ^4.0 || ^5.0",
-        "laminas/laminas-dependency-plugin": "^1.0",
         "doctrine/doctrine-laminas-hydrator": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-validator": "^2.10",
         "symfony/console": "^3.3 || ^4.0 || ^5.0",
-        "doctrine/doctrine-laminas-hydrator": "^2.0"
+        "doctrine/doctrine-laminas-hydrator": "^2.0.2"
     },
     "require-dev": {
         "laminas/laminas-i18n": "^2.7",

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -4,7 +4,7 @@ namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
 use RuntimeException;
-use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Base ServiceManager factory to be extended


### PR DESCRIPTION
3.0 had incorrect factory interface definitions.  That will necessitate a 4.0 release.

In the mean time  the 3.0 release is helpful in building the doctrine-orm-module PR 