### PR TITLE
Feature/coding standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-validator": "^2.10",
-        "symfony/console": "^3.3 || ^4.0 || ^5.0"
+        "symfony/console": "^5.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
             "@cs-check",
             "@test"
         ],
-        "cs-check": "phpcs",
+        "cs-check": "phpcs --standard=Doctrine src/",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --coverage-clover build/clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         },
         "branch-alias": {
             "dev-1.2-dev": "1.2-dev",
-            "dev-2.0-dev": "2.0-dev",
+            "dev-2.0-dev": "2.0-dev"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -71,9 +71,9 @@
         "laminas/laminas-serializer": "^2.8",
         "laminas/laminas-session": "^2.8",
         "laminas/laminas-test": "^3.1.1",
-        "phpunit/phpunit": "^7.5.2",
+        "phpunit/phpunit": "^8.5",
         "predis/predis": "^1.1",
-        "squizlabs/php_codesniffer": "^2.7"
+        "doctrine/coding-standard": "^7.0"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",

--- a/composer.json
+++ b/composer.json
@@ -43,14 +43,13 @@
         "branch-alias": {
             "dev-1.2-dev": "1.2-dev",
             "dev-2.0-dev": "2.0-dev",
-            "dev-master": "1.2-dev",
-            "dev-develop": "2.0-dev"
         }
     },
     "require": {
         "php": "^7.2",
-        "doctrine/common": "^2.8",
         "doctrine/cache": "^1.7",
+        "doctrine/common": "^2.8",
+        "doctrine/doctrine-laminas-hydrator": "^2.0.2",
         "laminas/laminas-authentication": "^2.5.3",
         "laminas/laminas-cache": "^2.7.1",
         "laminas/laminas-form": "^2.11",
@@ -60,10 +59,10 @@
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-validator": "^2.10",
-        "symfony/console": "^3.3 || ^4.0 || ^5.0",
-        "doctrine/doctrine-laminas-hydrator": "^2.0.2"
+        "symfony/console": "^3.3 || ^4.0 || ^5.0"
     },
     "require-dev": {
+        "doctrine/coding-standard": "^7.0",
         "laminas/laminas-i18n": "^2.7",
         "laminas/laminas-log": "^2.9",
         "laminas/laminas-modulemanager": "^2.8",
@@ -72,8 +71,7 @@
         "laminas/laminas-session": "^2.8",
         "laminas/laminas-test": "^3.1.1",
         "phpunit/phpunit": "^8.5",
-        "predis/predis": "^1.1",
-        "doctrine/coding-standard": "^7.0"
+        "predis/predis": "^1.1"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -132,9 +132,8 @@ class ObjectRepository extends AbstractAdapter
      * This method abstracts the steps involved with making sure that this adapter was
      * indeed setup properly with all required pieces of information.
      *
-     * In the event that setup was not done properly throw exception
-     *
-     * @throws Exception\RuntimeException
+     * @throws Exception\RuntimeException In the event that setup was not
+     *                                    done properly throw exception.
      */
     protected function setup() : void
     {

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Authentication\Adapter;
 
 use Doctrine\Common\Inflector\Inflector;
@@ -7,21 +9,20 @@ use DoctrineModule\Options\Authentication as AuthenticationOptions;
 use Laminas\Authentication\Adapter\AbstractAdapter;
 use Laminas\Authentication\Adapter\Exception;
 use Laminas\Authentication\Result as AuthenticationResult;
+use function call_user_func;
+use function get_class;
+use function method_exists;
+use function property_exists;
+use function sprintf;
 
 /**
  * Authentication adapter that uses a Doctrine object for verification.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.5.0
- * @author  Tim Roediger <superdweebie@gmail.com>
- * @author  Michaël Gallego <mic.gallego@gmail.com>
  */
 class ObjectRepository extends AbstractAdapter
 {
-    /**
-     * @var AuthenticationOptions
-     */
+    /** @var AuthenticationOptions */
     protected $options;
 
     /**
@@ -51,13 +52,11 @@ class ObjectRepository extends AbstractAdapter
         }
 
         $this->options = $options;
+
         return $this;
     }
 
-    /**
-     * @return AuthenticationOptions
-     */
-    public function getOptions()
+    public function getOptions() : AuthenticationOptions
     {
         return $this->options;
     }
@@ -89,11 +88,9 @@ class ObjectRepository extends AbstractAdapter
      * This method attempts to validate that the record in the resultset is indeed a
      * record that matched the identity provided to this adapter.
      *
-     * @param  object                              $identity
      * @throws Exception\UnexpectedValueException
-     * @return AuthenticationResult
      */
-    protected function validateIdentity($identity)
+    protected function validateIdentity(object $identity) : AuthenticationResult
     {
         $credentialProperty = $this->options->getCredentialProperty();
         $getter             = 'get' . Inflector::classify($credentialProperty);
@@ -142,16 +139,16 @@ class ObjectRepository extends AbstractAdapter
      *
      * @throws Exception\RuntimeException - in the event that setup was not done properly
      */
-    protected function setup()
+    protected function setup() : void
     {
-        if (null === $this->identity) {
+        if ($this->identity === null) {
             throw new Exception\RuntimeException(
                 'A value for the identity was not provided prior to authentication with ObjectRepository '
                 . 'authentication adapter'
             );
         }
 
-        if (null === $this->credential) {
+        if ($this->credential === null) {
             throw new Exception\RuntimeException(
                 'A credential value was not provided prior to authentication with ObjectRepository'
                 . ' authentication adapter'
@@ -168,10 +165,8 @@ class ObjectRepository extends AbstractAdapter
     /**
      * Creates a Laminas\Authentication\Result object from the information that has been collected
      * during the authenticate() attempt.
-     *
-     * @return AuthenticationResult
      */
-    protected function createAuthenticationResult()
+    protected function createAuthenticationResult() : AuthenticationResult
     {
         return new AuthenticationResult(
             $this->authenticationResultInfo['code'],

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -28,14 +28,14 @@ class ObjectRepository extends AbstractAdapter
     /**
      * Contains the authentication results.
      *
-     * @var array
+     * @var mixed[]
      */
     protected $authenticationResultInfo = null;
 
     /**
      * Constructor
      *
-     * @param array|AuthenticationOptions $options
+     * @param mixed[]|AuthenticationOptions $options
      */
     public function __construct($options = [])
     {
@@ -43,9 +43,9 @@ class ObjectRepository extends AbstractAdapter
     }
 
     /**
-     * @param  array|AuthenticationOptions $options
+     * @param mixed[]|AuthenticationOptions $options
      */
-    public function setOptions($options)
+    public function setOptions($options) : self
     {
         if (! $options instanceof AuthenticationOptions) {
             $options = new AuthenticationOptions($options);
@@ -61,10 +61,7 @@ class ObjectRepository extends AbstractAdapter
         return $this->options;
     }
 
-    /*
-     * {@inheritDoc}
-     */
-    public function authenticate()
+    public function authenticate() : AuthenticationResult
     {
         $this->setup();
         $options  = $this->options;
@@ -79,9 +76,7 @@ class ObjectRepository extends AbstractAdapter
             return $this->createAuthenticationResult();
         }
 
-        $authResult = $this->validateIdentity($identity);
-
-        return $authResult;
+        return $this->validateIdentity($identity);
     }
 
     /**
@@ -137,7 +132,9 @@ class ObjectRepository extends AbstractAdapter
      * This method abstracts the steps involved with making sure that this adapter was
      * indeed setup properly with all required pieces of information.
      *
-     * @throws Exception\RuntimeException - in the event that setup was not done properly
+     * In the event that setup was not done properly throw exception
+     *
+     * @throws Exception\RuntimeException
      */
     protected function setup() : void
     {

--- a/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
@@ -70,7 +70,7 @@ class ObjectRepository implements StorageInterface
         return $identity = $this->options->getStorage()->read();
     }
 
-    public function write(object $identity) : void
+    public function write($identity) : void
     {
         $metadataInfo     = $this->options->getClassMetadata();
         $identifierValues = $metadataInfo->getIdentifierValues($identity);

--- a/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
@@ -18,7 +18,7 @@ class ObjectRepository implements StorageInterface
     protected $options;
 
     /**
-     * @param array|AuthenticationOptions $options
+     * @param mixed[]|AuthenticationOptions $options
      */
     public function setOptions($options) : ObjectRepository
     {
@@ -34,7 +34,7 @@ class ObjectRepository implements StorageInterface
     /**
      * Constructor
      *
-     * @param array|AuthenticationOptions $options
+     * @param mixed[]|AuthenticationOptions $options
      */
     public function __construct($options = [])
     {
@@ -52,7 +52,8 @@ class ObjectRepository implements StorageInterface
      */
     public function read() : ?object
     {
-        if (($identity = $this->options->getStorage()->read())) {
+        $identity = $this->options->getStorage()->read();
+        if ($identity) {
             return $this->options->getObjectRepository()->find($identity);
         }
 
@@ -70,6 +71,9 @@ class ObjectRepository implements StorageInterface
         return $identity = $this->options->getStorage()->read();
     }
 
+    /**
+     * @param mixed $identity
+     */
     public function write($identity) : void
     {
         $metadataInfo     = $this->options->getClassMetadata();

--- a/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Authentication\Storage;
 
 use DoctrineModule\Options\Authentication as AuthenticationOptions;
@@ -8,48 +10,38 @@ use Laminas\Authentication\Storage\StorageInterface;
 /**
  * This class implements StorageInterface and allow to save the result of an authentication against an object repository
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.5.0
- * @author  Michaël Gallego <mic.gallego@gmail.com>
  */
 class ObjectRepository implements StorageInterface
 {
-
-    /**
-     *
-     * @var \DoctrineModule\Options\Authentication
-     */
+    /** @var AuthenticationOptions */
     protected $options;
 
     /**
-     * @param  array | \DoctrineModule\Options\Authentication $options
-     * @return ObjectRepository
+     * @param array|AuthenticationOptions $options
      */
-    public function setOptions($options)
+    public function setOptions($options) : ObjectRepository
     {
         if (! $options instanceof AuthenticationOptions) {
             $options = new AuthenticationOptions($options);
         }
 
         $this->options = $options;
+
         return $this;
     }
 
     /**
      * Constructor
      *
-     * @param array | \DoctrineModule\Options\Authentication $options
+     * @param array|AuthenticationOptions $options
      */
     public function __construct($options = [])
     {
         $this->setOptions($options);
     }
 
-    /**
-     * @return bool
-     */
-    public function isEmpty()
+    public function isEmpty() : bool
     {
         return $this->options->getStorage()->isEmpty();
     }
@@ -57,10 +49,8 @@ class ObjectRepository implements StorageInterface
     /**
      * This function assumes that the storage only contains identifier values (which is the case if
      * the ObjectRepository authentication adapter is used).
-     *
-     * @return null|object
      */
-    public function read()
+    public function read() : ?object
     {
         if (($identity = $this->options->getStorage()->read())) {
             return $this->options->getObjectRepository()->find($identity);
@@ -80,11 +70,7 @@ class ObjectRepository implements StorageInterface
         return $identity = $this->options->getStorage()->read();
     }
 
-    /**
-     * @param  object $identity
-     * @return void
-     */
-    public function write($identity)
+    public function write(object $identity) : void
     {
         $metadataInfo     = $this->options->getClassMetadata();
         $identifierValues = $metadataInfo->getIdentifierValues($identity);
@@ -92,10 +78,7 @@ class ObjectRepository implements StorageInterface
         $this->options->getStorage()->write($identifierValues);
     }
 
-    /**
-     * @return void
-     */
-    public function clear()
+    public function clear() : void
     {
         $this->options->getStorage()->clear();
     }

--- a/src/DoctrineModule/Cache/DoctrineCacheStorage.php
+++ b/src/DoctrineModule/Cache/DoctrineCacheStorage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Cache;
 
 use Doctrine\Common\Cache\Cache;
@@ -8,19 +10,16 @@ use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 /**
  * Bridge class that allows usage of a Doctrine Cache Storage as a Laminas Cache Storage
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class DoctrineCacheStorage extends AbstractAdapter
 {
-    /**
-     * @var Cache
-     */
+    /** @var Cache */
     protected $cache;
 
     /**
      * {@inheritDoc}
+     *
      * @param Cache $cache
      */
     public function __construct($options, Cache $cache)
@@ -33,11 +32,11 @@ class DoctrineCacheStorage extends AbstractAdapter
     /**
      * {@inheritDoc}
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem(&$normalizedKey, &$success = null, &$casToken = null)
     {
         $key     = $this->getOptions()->getNamespace() . $normalizedKey;
         $fetched = $this->cache->fetch($key);
-        $success = ($fetched === false ? false : true);
+        $success = ($fetched !== false);
 
         if ($success) {
             $casToken = $fetched;
@@ -51,7 +50,7 @@ class DoctrineCacheStorage extends AbstractAdapter
     /**
      * {@inheritDoc}
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(&$normalizedKey, &$value)
     {
         $key = $this->getOptions()->getNamespace() . $normalizedKey;
         $ttl = $this->getOptions()->getTtl();
@@ -62,7 +61,7 @@ class DoctrineCacheStorage extends AbstractAdapter
     /**
      * {@inheritDoc}
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem(&$normalizedKey)
     {
         $key = $this->getOptions()->getNamespace() . $normalizedKey;
         if (! $this->cache->contains($key)) {

--- a/src/DoctrineModule/Cache/LaminasStorageCache.php
+++ b/src/DoctrineModule/Cache/LaminasStorageCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Cache;
 
 use Doctrine\Common\Cache\Cache;
@@ -8,25 +10,18 @@ use Laminas\Cache\Storage\AvailableSpaceCapableInterface;
 use Laminas\Cache\Storage\FlushableInterface;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\Cache\Storage\TotalSpaceCapableInterface;
+use function assert;
 
 /**
  * Bridge class that allows usage of a Laminas Cache Storage as a Doctrine Cache
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class LaminasStorageCache extends CacheProvider
 {
-
-    /**
-     * @var StorageInterface
-     */
+    /** @var StorageInterface */
     protected $storage;
 
-    /**
-     * @param StorageInterface $storage
-     */
     public function __construct(StorageInterface $storage)
     {
         $this->storage = $storage;
@@ -39,7 +34,7 @@ class LaminasStorageCache extends CacheProvider
     {
         $hit = $this->storage->getItem($id);
 
-        return null === $hit ? false : $hit;
+        return $hit ?? false;
     }
 
     /**
@@ -73,8 +68,8 @@ class LaminasStorageCache extends CacheProvider
     protected function doFlush()
     {
         if ($this->storage instanceof FlushableInterface) {
-            /* @var $storage FlushableInterface */
             $storage = $this->storage;
+            assert($storage instanceof FlushableInterface);
 
             return $storage->flush();
         }
@@ -87,9 +82,9 @@ class LaminasStorageCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        /* @var $storage TotalSpaceCapableInterface */
-        /* @var $storage AvailableSpaceCapableInterface */
         $storage = $this->storage;
+        assert($storage instanceof TotalSpaceCapableInterface);
+        assert($storage instanceof AvailableSpaceCapableInterface);
 
         return [
             Cache::STATS_HITS              => $this->storage->getMetadata(Cache::STATS_HITS),

--- a/src/DoctrineModule/Cache/ZendStorageCache.php
+++ b/src/DoctrineModule/Cache/ZendStorageCache.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Cache;
 
 /**
- * @license MIT
- * @link    http://www.doctrine-project.org/
- *
  * @deprecated use \DoctrineModule\Cache\LaminasStorageCache
+ *
+ * @link    http://www.doctrine-project.org/
  */
 class ZendStorageCache extends LaminasStorageCache
 {

--- a/src/DoctrineModule/Component/Console/Input/RequestInput.php
+++ b/src/DoctrineModule/Component/Console/Input/RequestInput.php
@@ -1,35 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Component\Console\Input;
 
 use Laminas\Console\Request;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
+use function is_numeric;
 
 /**
  * RequestInput represents an input provided as an console request.
- *
- * @license MIT
- * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
  */
 class RequestInput extends ArgvInput
 {
     /**
      * Constructor
-     *
-     * @param Request $request
-     * @param \Symfony\Component\Console\Input\InputDefinition $definition
      */
-    public function __construct(Request $request, InputDefinition $definition = null)
+    public function __construct(Request $request, ?InputDefinition $definition = null)
     {
-        $parameters = [
-            null,
-        ];
+        $parameters = [null];
 
         foreach ($request->getParams() as $key => $param) {
-            if (is_numeric($key)) {
-                $parameters[] = $param;
+            if (! is_numeric($key)) {
+                continue;
             }
+
+            $parameters[] = $param;
         }
 
         parent::__construct($parameters, $definition);

--- a/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
+++ b/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
@@ -1,45 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Component\Console\Output;
 
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\Output;
+use function function_exists;
+use function getenv;
+use function posix_isatty;
+use const DIRECTORY_SEPARATOR;
+use const PHP_EOL;
+use const STDOUT;
 
 /**
  * Output writing in class member variable
- *
- * @license MIT
- * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
  */
 class PropertyOutput extends Output
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $message = '';
 
     /**
-     * @param int $verbosity
      * @param null $decorated
-     * @param \Symfony\Component\Console\Formatter\OutputFormatterInterface $formatter
      */
     public function __construct(
-        $verbosity = self::VERBOSITY_NORMAL,
+        int $verbosity = self::VERBOSITY_NORMAL,
         $decorated = null,
-        OutputFormatterInterface $formatter = null
+        ?OutputFormatterInterface $formatter = null
     ) {
-        if (null === $decorated) {
+        if ($decorated === null) {
             $decorated = $this->hasColorSupport();
         }
 
         parent::__construct($verbosity, $decorated, $formatter);
     }
 
-    /**
-     * @param string $message
-     * @param bool $newline
-     */
-    protected function doWrite($message, $newline)
+    protected function doWrite(string $message, bool $newline) : void
     {
         $this->message .= $message . ($newline === false ? '' : PHP_EOL);
     }
@@ -52,13 +49,10 @@ class PropertyOutput extends Output
         return $this->message;
     }
 
-    /**
-     * @return bool
-     */
-    protected function hasColorSupport()
+    protected function hasColorSupport() : bool
     {
         if (DIRECTORY_SEPARATOR === '\\') {
-            return false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
+            return getenv('ANSICON') !== false || getenv('ConEmuANSI') === 'ON';
         }
 
         return function_exists('posix_isatty') && @posix_isatty(STDOUT);

--- a/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
+++ b/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
@@ -36,8 +36,10 @@ class PropertyOutput extends Output
         parent::__construct($verbosity, $decorated, $formatter);
     }
 
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint
     protected function doWrite(string $message, bool $newline)
     {
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint
         $this->message .= $message . ($newline === false ? '' : PHP_EOL);
     }
 

--- a/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
+++ b/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
@@ -36,7 +36,7 @@ class PropertyOutput extends Output
         parent::__construct($verbosity, $decorated, $formatter);
     }
 
-    protected function doWrite(string $message, bool $newline) : void
+    protected function doWrite(string $message, bool $newline)
     {
         $this->message .= $message . ($newline === false ? '' : PHP_EOL);
     }

--- a/src/DoctrineModule/ConfigProvider.php
+++ b/src/DoctrineModule/ConfigProvider.php
@@ -12,7 +12,7 @@ namespace DoctrineModule;
 class ConfigProvider
 {
     /**
-     * @return array
+     * @return mixed[]
      */
     public function __invoke() : array
     {
@@ -30,21 +30,24 @@ class ConfigProvider
     /**
      * Return application-level dependency configuration
      *
-     * @return array
+     * @return mixed[]
      */
     public function getDependencyConfig() : array
     {
+// phpcs:disable
+
         return [
             'invokables' => ['DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session'],
             'factories' => ['doctrine.cli' => 'DoctrineModule\Service\CliFactory'],
             'abstract_factories' => ['DoctrineModule' => 'DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory'],
         ];
+// phpcs:enable
     }
 
     /**
      * Return controller configuration
      *
-     * @return array
+     * @return mixed[]
      */
     public function getControllerConfig() : array
     {
@@ -56,7 +59,7 @@ class ConfigProvider
     /**
      * Return route manager configuration
      *
-     * @return array
+     * @return mixed[]
      */
     public function getRouteManagerConfig() : array
     {
@@ -68,7 +71,7 @@ class ConfigProvider
     /**
      * Return configuration for console routes
      *
-     * @return array
+     * @return mixed[]
      */
     public function getConsoleConfig() : array
     {
@@ -84,7 +87,7 @@ class ConfigProvider
     /**
      * Default configuration for Doctrine module
      *
-     * @return array
+     * @return mixed[]
      */
     public function getDoctrineConfig() : array
     {
@@ -166,7 +169,7 @@ class ConfigProvider
     /**
      * Factory mappings - used to define which factory to use to instantiate a particular doctrine service type
      *
-     * @return array
+     * @return mixed[]
      */
     public function getDoctrineFactoryConfig() : array
     {
@@ -181,7 +184,7 @@ class ConfigProvider
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getValidatorConfig() : array
     {

--- a/src/DoctrineModule/ConfigProvider.php
+++ b/src/DoctrineModule/ConfigProvider.php
@@ -1,20 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule;
 
 /**
  * Config provider for DoctrineORMModule config
  *
- * @license MIT
  * @link    www.doctrine-project.org
- * @author  James Titcumb <james@asgrim.com>
  */
 class ConfigProvider
 {
     /**
      * @return array
      */
-    public function __invoke()
+    public function __invoke() : array
     {
         return [
             'doctrine' => $this->getDoctrineConfig(),
@@ -32,18 +32,12 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getDependencyConfig()
+    public function getDependencyConfig() : array
     {
         return [
-            'invokables' => [
-                'DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session',
-            ],
-            'factories' => [
-                'doctrine.cli' => 'DoctrineModule\Service\CliFactory',
-            ],
-            'abstract_factories' => [
-                'DoctrineModule' => 'DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory',
-            ],
+            'invokables' => ['DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session'],
+            'factories' => ['doctrine.cli' => 'DoctrineModule\Service\CliFactory'],
+            'abstract_factories' => ['DoctrineModule' => 'DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory'],
         ];
     }
 
@@ -52,12 +46,10 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getControllerConfig()
+    public function getControllerConfig() : array
     {
         return [
-            'factories' => [
-                'DoctrineModule\Controller\Cli' => 'DoctrineModule\Service\CliControllerFactory',
-            ],
+            'factories' => ['DoctrineModule\Controller\Cli' => 'DoctrineModule\Service\CliControllerFactory'],
         ];
     }
 
@@ -66,12 +58,10 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getRouteManagerConfig()
+    public function getRouteManagerConfig() : array
     {
         return [
-            'factories' => [
-                'symfony_cli' => 'DoctrineModule\Service\SymfonyCliRouteFactory',
-            ],
+            'factories' => ['symfony_cli' => 'DoctrineModule\Service\SymfonyCliRouteFactory'],
         ];
     }
 
@@ -80,14 +70,12 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getConsoleConfig()
+    public function getConsoleConfig() : array
     {
         return [
             'router' => [
                 'routes' => [
-                    'doctrine_cli' => [
-                        'type' => 'symfony_cli',
-                    ],
+                    'doctrine_cli' => ['type' => 'symfony_cli'],
                 ],
             ],
         ];
@@ -98,7 +86,7 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getDoctrineConfig()
+    public function getDoctrineConfig() : array
     {
         return [
             'cache' => [
@@ -180,7 +168,7 @@ class ConfigProvider
      *
      * @return array
      */
-    public function getDoctrineFactoryConfig()
+    public function getDoctrineFactoryConfig() : array
     {
         return [
             'cache'                 => 'DoctrineModule\Service\CacheFactory',
@@ -195,7 +183,7 @@ class ConfigProvider
     /**
      * @return array
      */
-    public function getValidatorConfig()
+    public function getValidatorConfig() : array
     {
         return [
             'aliases'   => [

--- a/src/DoctrineModule/ConfigProvider.php
+++ b/src/DoctrineModule/ConfigProvider.php
@@ -34,15 +34,16 @@ class ConfigProvider
      */
     public function getDependencyConfig() : array
     {
-// phpcs:disable
+    // phpcs:disable Generic.Files.LineLength
 
         return [
             'invokables' => ['DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session'],
             'factories' => ['doctrine.cli' => 'DoctrineModule\Service\CliFactory'],
             'abstract_factories' => ['DoctrineModule' => 'DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory'],
         ];
-// phpcs:enable
     }
+
+    // phpcs:enable Generic.Files.LineLength
 
     /**
      * Return controller configuration

--- a/src/DoctrineModule/Controller/CliController.php
+++ b/src/DoctrineModule/Controller/CliController.php
@@ -34,6 +34,8 @@ class CliController extends AbstractActionController
 
     /**
      * Index action - runs the console application
+     *
+     * @return mixed
      */
     public function cliAction()
     {

--- a/src/DoctrineModule/Controller/CliController.php
+++ b/src/DoctrineModule/Controller/CliController.php
@@ -1,40 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Controller;
 
 use DoctrineModule\Component\Console\Input\RequestInput;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Output\OutputInterface;
 use Laminas\Mvc\Console\View\ViewModel;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
+use function is_numeric;
 
 /**
  * Index controller
- *
- * @license MIT
- * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
  */
 class CliController extends AbstractActionController
 {
-    /**
-     * @var \Symfony\Component\Console\Application
-     */
+    /** @var Application */
     protected $cliApplication;
 
-    /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
-     */
+    /** @var OutputInterface */
     protected $output;
 
-    /**
-     * @param \Symfony\Component\Console\Application $cliApplication
-     */
     public function __construct(Application $cliApplication)
     {
         $this->cliApplication = $cliApplication;
     }
 
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output) : void
     {
         $this->output = $output;
     }

--- a/src/DoctrineModule/Form/Element/Exception/InvalidRepositoryResultException.php
+++ b/src/DoctrineModule/Form/Element/Exception/InvalidRepositoryResultException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Form\Element\Exception;
 
 use InvalidArgumentException;

--- a/src/DoctrineModule/Form/Element/Exception/InvalidRepositoryResultException.php
+++ b/src/DoctrineModule/Form/Element/Exception/InvalidRepositoryResultException.php
@@ -6,6 +6,8 @@ namespace DoctrineModule\Form\Element\Exception;
 
 use InvalidArgumentException;
 
+// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming
 class InvalidRepositoryResultException extends InvalidArgumentException
 {
 }
+// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming

--- a/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
+++ b/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
@@ -37,7 +37,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
     /**
      * @param mixed $value
      */
-    public function setOption(string $key, $value) : self
+    public function setOption($key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
+++ b/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
@@ -1,48 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Form\Element;
 
-use DoctrineModule\Form\Element\Proxy;
-use Laminas\Form\Form;
 use Laminas\Form\Element\MultiCheckbox;
 use Laminas\Stdlib\ArrayUtils;
+use Traversable;
+use function array_map;
+use function is_array;
 
 class ObjectMultiCheckbox extends MultiCheckbox
 {
-    /**
-     * @var Proxy
-     */
+    /** @var Proxy */
     protected $proxy;
 
-    /**
-     * @return Proxy
-     */
-    public function getProxy()
+    public function getProxy() : Proxy
     {
-        if (null === $this->proxy) {
+        if ($this->proxy === null) {
             $this->proxy = new Proxy();
         }
+
         return $this->proxy;
     }
 
     /**
-     * @param  array|\Traversable $options
-     * @return self
+     * @param array|Traversable $options
      */
-    public function setOptions($options)
+    public function setOptions($options) : self
     {
         $this->getProxy()->setOptions($options);
+
         return parent::setOptions($options);
     }
 
     /**
-     * @param string $key
      * @param mixed $value
-     * @return self
      */
-    public function setOption($key, $value)
+    public function setOption(string $key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
+
         return parent::setOption($key, $value);
     }
 
@@ -51,12 +49,12 @@ class ObjectMultiCheckbox extends MultiCheckbox
      */
     public function setValue($value)
     {
-        if ($value instanceof \Traversable) {
+        if ($value instanceof Traversable) {
             $value = ArrayUtils::iteratorToArray($value);
-        } elseif ($value == null) {
+        } elseif ($value === null) {
             return parent::setValue([]);
         } elseif (! is_array($value)) {
-            $value = (array)$value;
+            $value = (array) $value;
         }
 
         return parent::setValue(array_map([$this->getProxy(), 'getValue'], $value));

--- a/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
+++ b/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
@@ -25,7 +25,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
     }
 
     /**
-     * @param array|Traversable $options
+     * @param mixed $options
      */
     public function setOptions($options) : self
     {
@@ -36,6 +36,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
 
     /**
      * @param mixed $value
+     * @param mixed $key
      */
     public function setOption($key, $value) : self
     {

--- a/src/DoctrineModule/Form/Element/ObjectRadio.php
+++ b/src/DoctrineModule/Form/Element/ObjectRadio.php
@@ -34,7 +34,7 @@ class ObjectRadio extends RadioElement
     /**
      * @param mixed $value
      */
-    public function setOption(string $key, $value) : self
+    public function setOption($key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/ObjectRadio.php
+++ b/src/DoctrineModule/Form/Element/ObjectRadio.php
@@ -1,47 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Form\Element;
 
-use DoctrineModule\Form\Element\Proxy;
 use Laminas\Form\Element\Radio as RadioElement;
-use Laminas\Form\Form;
+use Traversable;
 
 class ObjectRadio extends RadioElement
 {
-    /**
-     * @var Proxy
-     */
+    /** @var Proxy */
     protected $proxy;
 
-    /**
-     * @return Proxy
-     */
-    public function getProxy()
+    public function getProxy() : Proxy
     {
-        if (null === $this->proxy) {
+        if ($this->proxy === null) {
             $this->proxy = new Proxy();
         }
+
         return $this->proxy;
     }
 
     /**
-     * @param  array|\Traversable $options
-     * @return self
+     * @param array|Traversable $options
      */
-    public function setOptions($options)
+    public function setOptions($options) : self
     {
         $this->getProxy()->setOptions($options);
+
         return parent::setOptions($options);
     }
 
     /**
-     * @param string $key
      * @param mixed $value
-     * @return self
      */
-    public function setOption($key, $value)
+    public function setOption(string $key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
+
         return parent::setOption($key, $value);
     }
 

--- a/src/DoctrineModule/Form/Element/ObjectRadio.php
+++ b/src/DoctrineModule/Form/Element/ObjectRadio.php
@@ -23,6 +23,8 @@ class ObjectRadio extends RadioElement
 
     /**
      * @param array|Traversable $options
+     *
+     * {@inheritDoc}
      */
     public function setOptions($options) : self
     {
@@ -33,6 +35,8 @@ class ObjectRadio extends RadioElement
 
     /**
      * @param mixed $value
+     *
+     * {@inheritDoc}
      */
     public function setOption($key, $value) : self
     {

--- a/src/DoctrineModule/Form/Element/ObjectSelect.php
+++ b/src/DoctrineModule/Form/Element/ObjectSelect.php
@@ -37,7 +37,7 @@ class ObjectSelect extends SelectElement
     /**
      * @param mixed $value
      */
-    public function setOption(string $key, $value) : self
+    public function setOption($key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/ObjectSelect.php
+++ b/src/DoctrineModule/Form/Element/ObjectSelect.php
@@ -1,48 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Form\Element;
 
-use DoctrineModule\Form\Element\Proxy;
-use Laminas\Form\Form;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Stdlib\ArrayUtils;
+use Traversable;
+use function array_map;
+use function is_array;
 
 class ObjectSelect extends SelectElement
 {
-    /**
-     * @var Proxy
-     */
+    /** @var Proxy */
     protected $proxy;
 
-    /**
-     * @return Proxy
-     */
-    public function getProxy()
+    public function getProxy() : Proxy
     {
-        if (null === $this->proxy) {
+        if ($this->proxy === null) {
             $this->proxy = new Proxy();
         }
+
         return $this->proxy;
     }
 
     /**
-     * @param  array|\Traversable $options
-     * @return self
+     * @param array|Traversable $options
      */
-    public function setOptions($options)
+    public function setOptions($options) : self
     {
         $this->getProxy()->setOptions($options);
+
         return parent::setOptions($options);
     }
 
     /**
-     * @param string $key
      * @param mixed $value
-     * @return self
      */
-    public function setOption($key, $value)
+    public function setOption(string $key, $value) : self
     {
         $this->getProxy()->setOptions([$key => $value]);
+
         return parent::setOption($key, $value);
     }
 
@@ -53,10 +51,10 @@ class ObjectSelect extends SelectElement
     {
         $multiple = $this->getAttribute('multiple');
 
-        if (true === $multiple || 'multiple' === $multiple) {
-            if ($value instanceof \Traversable) {
+        if ($multiple === true || $multiple === 'multiple') {
+            if ($value instanceof Traversable) {
                 $value = ArrayUtils::iteratorToArray($value);
-            } elseif ($value == null) {
+            } elseif ($value === null) {
                 return parent::setValue([]);
             } elseif (! is_array($value)) {
                 $value = (array) $value;

--- a/src/DoctrineModule/Form/Element/ObjectSelect.php
+++ b/src/DoctrineModule/Form/Element/ObjectSelect.php
@@ -26,6 +26,8 @@ class ObjectSelect extends SelectElement
 
     /**
      * @param array|Traversable $options
+     *
+     * {@inheritDoc}
      */
     public function setOptions($options) : self
     {
@@ -36,6 +38,8 @@ class ObjectSelect extends SelectElement
 
     /**
      * @param mixed $value
+     *
+     * {@inheritDoc}
      */
     public function setOption($key, $value) : self
     {

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -288,10 +288,7 @@ class Proxy implements ObjectManagerAwareInterface
         return $this;
     }
 
-    /**
-     * @return boolean|null
-     */
-    public function getIsMethod()
+    public function getIsMethod() : ?bool
     {
         return $this->isMethod;
     }

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -188,11 +188,9 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the object manager
      */
-    public function setObjectManager(ObjectManager $objectManager) : Proxy
+    public function setObjectManager(ObjectManager $objectManager) : void
     {
         $this->objectManager = $objectManager;
-
-        return $this;
     }
 
     /**
@@ -243,17 +241,9 @@ class Proxy implements ObjectManagerAwareInterface
      * Set the label generator callable that is responsible for generating labels for the items in the collection
      *
      * @param callable $callable A callable used to create a label based off of an Entity
-     *
-     * @throws InvalidArgumentException
      */
     public function setLabelGenerator(callable $callable) : void
     {
-        if (! is_callable($callable)) {
-            throw new InvalidArgumentException(
-                'Property "label_generator" needs to be a callable function or a \Closure'
-            );
-        }
-
         $this->labelGenerator = $callable;
     }
 
@@ -474,7 +464,10 @@ class Proxy implements ObjectManagerAwareInterface
             if (($generatedLabel = $this->generateLabel($object)) !== null) {
                 $label = $generatedLabel;
             } elseif ($property = $this->property) {
-                if ($this->isMethod === false && ! $metadata->hasField($property)) {
+                if (
+                    ($this->getIsMethod() === false || $this->getIsMethod() === null)
+                    && ! $metadata->hasField($property)
+                ) {
                     throw new RuntimeException(
                         sprintf(
                             'Property "%s" could not be found in object "%s"',

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -289,7 +289,7 @@ class Proxy implements ObjectManagerAwareInterface
     }
 
     /**
-     * @return mixed
+     * @return boolean|null
      */
     public function getIsMethod()
     {

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Form\Element;
 
 use Doctrine\Common\Collections\Collection;
@@ -11,77 +13,65 @@ use Laminas\Stdlib\Guard\ArrayOrTraversableGuardTrait;
 use ReflectionMethod;
 use RuntimeException;
 use Traversable;
+use function array_change_key_case;
+use function array_key_exists;
+use function array_shift;
+use function call_user_func;
+use function count;
+use function current;
+use function get_class;
+use function gettype;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function method_exists;
+use function sprintf;
+use function strtolower;
 
 class Proxy implements ObjectManagerAwareInterface
 {
     use ArrayOrTraversableGuardTrait;
 
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $objects;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $targetClass;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $valueOptions = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $findMethod = [];
 
-    /**
-     * @var
-     */
+    /** @var */
     protected $property;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $option_attributes = [];
 
-    /**
-     * @var callable $labelGenerator A callable used to create a label based on an item in the collection an Entity
-     */
+    /** @var callable $labelGenerator A callable used to create a label based on an item in the collection an Entity */
     protected $labelGenerator;
 
-    /**
-     * @var bool|null
-     */
+    /** @var bool|null */
     protected $isMethod;
 
-    /**
-     * @var ObjectManager
-     */
+    /** @var ObjectManager */
     protected $objectManager;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $displayEmptyItem = false;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $emptyItemLabel = '';
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $optgroupIdentifier;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $optgroupDefault;
 
-    public function setOptions($options)
+    public function setOptions($options) : void
     {
         if (isset($options['object_manager'])) {
             $this->setObjectManager($options['object_manager']);
@@ -123,9 +113,11 @@ class Proxy implements ObjectManagerAwareInterface
             $this->setOptgroupIdentifier($options['optgroup_identifier']);
         }
 
-        if (isset($options['optgroup_default'])) {
-            $this->setOptgroupDefault($options['optgroup_default']);
+        if (! isset($options['optgroup_default'])) {
+            return;
         }
+
+        $this->setOptgroupDefault($options['optgroup_default']);
     }
 
     public function getValueOptions()
@@ -149,22 +141,15 @@ class Proxy implements ObjectManagerAwareInterface
 
     /**
      * Set the label for the empty option
-     *
-     * @param string $emptyItemLabel
-     *
-     * @return Proxy
      */
-    public function setEmptyItemLabel($emptyItemLabel)
+    public function setEmptyItemLabel(string $emptyItemLabel) : Proxy
     {
         $this->emptyItemLabel = $emptyItemLabel;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getEmptyItemLabel()
+    public function getEmptyItemLabel() : string
     {
         return $this->emptyItemLabel;
     }
@@ -172,7 +157,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @return array
      */
-    public function getOptionAttributes()
+    public function getOptionAttributes() : array
     {
         return $this->option_attributes;
     }
@@ -180,41 +165,30 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @param array $option_attributes
      */
-    public function setOptionAttributes(array $option_attributes)
+    public function setOptionAttributes(array $option_attributes) : void
     {
         $this->option_attributes = $option_attributes;
     }
 
     /**
      * Set a flag, whether to include the empty option at the beginning or not
-     *
-     * @param boolean $displayEmptyItem
-     *
-     * @return Proxy
      */
-    public function setDisplayEmptyItem($displayEmptyItem)
+    public function setDisplayEmptyItem(bool $displayEmptyItem) : Proxy
     {
         $this->displayEmptyItem = $displayEmptyItem;
 
         return $this;
     }
 
-    /**
-     * @return boolean
-     */
-    public function getDisplayEmptyItem()
+    public function getDisplayEmptyItem() : bool
     {
         return $this->displayEmptyItem;
     }
 
     /**
      * Set the object manager
-     *
-     * @param  ObjectManager $objectManager
-     *
-     * @return Proxy
      */
-    public function setObjectManager(ObjectManager $objectManager)
+    public function setObjectManager(ObjectManager $objectManager) : Proxy
     {
         $this->objectManager = $objectManager;
 
@@ -223,22 +197,16 @@ class Proxy implements ObjectManagerAwareInterface
 
     /**
      * Get the object manager
-     *
-     * @return ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager() : ObjectManager
     {
         return $this->objectManager;
     }
 
     /**
      * Set the FQCN of the target object
-     *
-     * @param  string $targetClass
-     *
-     * @return Proxy
      */
-    public function setTargetClass($targetClass)
+    public function setTargetClass(string $targetClass) : Proxy
     {
         $this->targetClass = $targetClass;
 
@@ -247,22 +215,16 @@ class Proxy implements ObjectManagerAwareInterface
 
     /**
      * Get the target class
-     *
-     * @return string
      */
-    public function getTargetClass()
+    public function getTargetClass() : string
     {
         return $this->targetClass;
     }
 
     /**
      * Set the property to use as the label in the options
-     *
-     * @param  string $property
-     *
-     * @return Proxy
      */
-    public function setProperty($property)
+    public function setProperty(string $property) : Proxy
     {
         $this->property = $property;
 
@@ -283,10 +245,8 @@ class Proxy implements ObjectManagerAwareInterface
      * @param callable $callable A callable used to create a label based off of an Entity
      *
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
-    public function setLabelGenerator($callable)
+    public function setLabelGenerator(callable $callable) : void
     {
         if (! is_callable($callable)) {
             throw new InvalidArgumentException(
@@ -297,54 +257,35 @@ class Proxy implements ObjectManagerAwareInterface
         $this->labelGenerator = $callable;
     }
 
-    /**
-     * @return callable|null
-     */
-    public function getLabelGenerator()
+    public function getLabelGenerator() : ?callable
     {
         return $this->labelGenerator;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getOptgroupIdentifier()
+    public function getOptgroupIdentifier() : ?string
     {
         return $this->optgroupIdentifier;
     }
 
-    /**
-     * @param string $optgroupIdentifier
-     */
-    public function setOptgroupIdentifier($optgroupIdentifier)
+    public function setOptgroupIdentifier(string $optgroupIdentifier) : void
     {
         $this->optgroupIdentifier = (string) $optgroupIdentifier;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getOptgroupDefault()
+    public function getOptgroupDefault() : ?string
     {
         return $this->optgroupDefault;
     }
 
-    /**
-     * @param string $optgroupDefault
-     */
-    public function setOptgroupDefault($optgroupDefault)
+    public function setOptgroupDefault(string $optgroupDefault) : void
     {
         $this->optgroupDefault = (string) $optgroupDefault;
     }
 
     /**
      * Set if the property is a method to use as the label in the options
-     *
-     * @param  boolean $method
-     *
-     * @return Proxy
      */
-    public function setIsMethod($method)
+    public function setIsMethod(bool $method) : Proxy
     {
         $this->isMethod = (bool) $method;
 
@@ -362,10 +303,8 @@ class Proxy implements ObjectManagerAwareInterface
     /** Set the findMethod property to specify the method to use on repository
      *
      * @param array $findMethod
-     *
-     * @return Proxy
      */
-    public function setFindMethod($findMethod)
+    public function setFindMethod(array $findMethod) : Proxy
     {
         $this->findMethod = $findMethod;
 
@@ -377,19 +316,14 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @return array
      */
-    public function getFindMethod()
+    public function getFindMethod() : array
     {
         return $this->findMethod;
     }
 
-    /**
-     * @param $targetEntity
-     *
-     * @return string|null
-     */
-    protected function generateLabel($targetEntity)
+    protected function generateLabel($targetEntity) : ?string
     {
-        if (null === ($labelGenerator = $this->getLabelGenerator())) {
+        if (($labelGenerator = $this->getLabelGenerator()) === null) {
             return null;
         }
 
@@ -400,6 +334,7 @@ class Proxy implements ObjectManagerAwareInterface
      * @param  $value
      *
      * @return array|mixed|object
+     *
      * @throws RuntimeException
      */
     public function getValue($value)
@@ -429,7 +364,7 @@ class Proxy implements ObjectManagerAwareInterface
                 $identifier = $metadata->getIdentifierFieldNames();
 
                 // TODO: handle composite (multiple) identifiers
-                if (null !== $identifier && count($identifier) > 1) {
+                if ($identifier !== null && count($identifier) > 1) {
                     //$value = $key;
                 } else {
                     $value = current($metadata->getIdentifierValues($value));
@@ -445,9 +380,8 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @throws RuntimeException
      * @throws Exception\InvalidRepositoryResultException
-     * @return void
      */
-    protected function loadObjects()
+    protected function loadObjects() : void
     {
         if (! empty($this->objects)) {
             return;
@@ -463,6 +397,7 @@ class Proxy implements ObjectManagerAwareInterface
             if (! isset($findMethod['name'])) {
                 throw new RuntimeException('No method name was set');
             }
+
             $findMethodName   = $findMethod['name'];
             $findMethodParams = isset($findMethod['params']) ? array_change_key_case($findMethod['params']) : [];
             $repository       = $this->objectManager->getRepository($this->targetClass);
@@ -497,6 +432,7 @@ class Proxy implements ObjectManagerAwareInterface
                     );
                 }
             }
+
             $objects = $r->invokeArgs($repository, $args);
         }
 
@@ -513,9 +449,8 @@ class Proxy implements ObjectManagerAwareInterface
      * Load value options
      *
      * @throws RuntimeException
-     * @return void
      */
-    protected function loadValueOptions()
+    protected function loadValueOptions() : void
     {
         if (! ($om = $this->objectManager)) {
             throw new RuntimeException('No object manager was set');
@@ -536,10 +471,10 @@ class Proxy implements ObjectManagerAwareInterface
         }
 
         foreach ($objects as $key => $object) {
-            if (null !== ($generatedLabel = $this->generateLabel($object))) {
+            if (($generatedLabel = $this->generateLabel($object)) !== null) {
                 $label = $generatedLabel;
             } elseif ($property = $this->property) {
-                if ($this->isMethod == false && ! $metadata->hasField($property)) {
+                if ($this->isMethod === false && ! $metadata->hasField($property)) {
                     throw new RuntimeException(
                         sprintf(
                             'Property "%s" could not be found in object "%s"',
@@ -572,7 +507,7 @@ class Proxy implements ObjectManagerAwareInterface
                 $label = (string) $object;
             }
 
-            if (null !== $identifier && count($identifier) > 1) {
+            if ($identifier !== null && count($identifier) > 1) {
                 $value = $key;
             } else {
                 $value = current($metadata->getIdentifierValues($object));
@@ -620,7 +555,7 @@ class Proxy implements ObjectManagerAwareInterface
             $optgroup = $object->{$optgroupGetter}();
 
             // optgroup_identifier contains a valid group-name. Handle default grouping.
-            if (false === is_null($optgroup) && trim($optgroup) !== '') {
+            if (is_null($optgroup) === false && trim($optgroup) !== '') {
                 $options[$optgroup]['label']     = $optgroup;
                 $options[$optgroup]['options'][] = [
                     'label'      => $label,

--- a/src/DoctrineModule/Module.php
+++ b/src/DoctrineModule/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -10,22 +12,20 @@ use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\InitProviderInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
+use function assert;
+use function class_exists;
 
 /**
  * Base module for integration of Doctrine projects with ZF2 applications
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.1.0
- * @author  Kyle Spraggs <theman@spiffyjr.me>
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class Module implements ConfigProviderInterface, InitProviderInterface, BootstrapListenerInterface
 {
-    /**
-     * @var \Laminas\ServiceManager\ServiceLocatorInterface
-     */
+    /** @var ServiceLocatorInterface */
     private $serviceManager;
 
     /**
@@ -54,6 +54,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
     public function getConfig()
     {
         $provider = new ConfigProvider();
+
         return [
             'doctrine' => $provider->getDoctrineConfig(),
             'doctrine_factories' => $provider->getDoctrineFactoryConfig(),
@@ -70,8 +71,8 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
      */
     public function getConsoleUsage(Console $console)
     {
-        /* @var $cli \Symfony\Component\Console\Application */
-        $cli    = $this->serviceManager->get('doctrine.cli');
+        $cli = $this->serviceManager->get('doctrine.cli');
+        assert($cli instanceof Application);
         $output = new PropertyOutput();
 
         $cli->run(new StringInput('list'), $output);

--- a/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
+++ b/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
@@ -22,14 +22,14 @@ class SymfonyCli implements RouteInterface
     /**
      * Default values.
      *
-     * @var array
+     * @var mixed[]
      */
     protected $defaults;
 
     /**
      * Constructor
      *
-     * @param array $defaults
+     * @param mixed[] $defaults
      */
     public function __construct(Application $cliApplication, array $defaults = [])
     {
@@ -60,7 +60,7 @@ class SymfonyCli implements RouteInterface
      *
      * {@inheritDoc}
      *
-     * @throws BadMethodCallException this method is disabled
+     * @throws BadMethodCallException this method is disabled.
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -80,7 +80,7 @@ class SymfonyCli implements RouteInterface
      *
      * {@inheritDoc}
      *
-     * @throws BadMethodCallException this method is disabled
+     * @throws BadMethodCallException this method is disabled.
      */
     public static function factory($options = [])
     {

--- a/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
+++ b/src/DoctrineModule/Mvc/Router/Console/SymfonyCli.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Mvc\Router\Console;
 
+use BadMethodCallException;
 use Laminas\Console\Request as ConsoleRequest;
 use Laminas\Mvc\Console\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
@@ -10,15 +13,10 @@ use Symfony\Component\Console\Application;
 
 /**
  * Route matching commands in Symfony CLI
- *
- * @license MIT
- * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
  */
 class SymfonyCli implements RouteInterface
 {
-    /**
-     * @var \Symfony\Component\Console\Application
-     */
+    /** @var Application */
     protected $cliApplication;
 
     /**
@@ -31,8 +29,7 @@ class SymfonyCli implements RouteInterface
     /**
      * Constructor
      *
-     * @param \Symfony\Component\Console\Application $cliApplication
-     * @param array                                  $defaults
+     * @param array $defaults
      */
     public function __construct(Application $cliApplication, array $defaults = [])
     {
@@ -63,11 +60,11 @@ class SymfonyCli implements RouteInterface
      *
      * {@inheritDoc}
      *
-     * @throws \BadMethodCallException this method is disabled
+     * @throws BadMethodCallException this method is disabled
      */
     public function assemble(array $params = [], array $options = [])
     {
-        throw new \BadMethodCallException('Unsupported');
+        throw new BadMethodCallException('Unsupported');
     }
 
     /**
@@ -83,10 +80,10 @@ class SymfonyCli implements RouteInterface
      *
      * {@inheritDoc}
      *
-     * @throws \BadMethodCallException this method is disabled
+     * @throws BadMethodCallException this method is disabled
      */
     public static function factory($options = [])
     {
-        throw new \BadMethodCallException('Unsupported');
+        throw new BadMethodCallException('Unsupported');
     }
 }

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -1,14 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Options;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Laminas\Authentication\Adapter\Exception;
-use Laminas\Authentication\Storage\Session as SessionStorage;
 use Laminas\Authentication\Storage\StorageInterface;
 use Laminas\Stdlib\AbstractOptions;
+use function gettype;
+use function is_callable;
+use function is_string;
+use function sprintf;
 
 /**
  * This options class can be consumed by five different classes:
@@ -42,10 +47,7 @@ use Laminas\Stdlib\AbstractOptions;
  * however, a string may be passed to $objectManager. This string must be a valid key to
  * retrieve an ObjectManager instance from the ServiceManager.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.5.0
- * @author  Michaël Gallego <mic.gallego@gmail.com>
  */
 class Authentication extends AbstractOptions
 {
@@ -95,7 +97,7 @@ class Authentication extends AbstractOptions
      * If an objectManager is not supplied, this metadata will be used
      * by DoctrineModule/Authentication/Storage/ObjectRepository
      *
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     protected $classMetadata;
 
@@ -113,36 +115,27 @@ class Authentication extends AbstractOptions
 
     /**
      * @param  string | ObjectManager $objectManager
-     * @return Authentication
      */
-    public function setObjectManager($objectManager)
+    public function setObjectManager($objectManager) : Authentication
     {
         $this->objectManager = $objectManager;
+
         return $this;
     }
 
-    /**
-     * @return ObjectManager
-     */
-    public function getObjectManager()
+    public function getObjectManager() : ObjectManager
     {
         return $this->objectManager;
     }
 
-    /**
-     * @param  ObjectRepository $objectRepository
-     * @return Authentication
-     */
-    public function setObjectRepository(ObjectRepository $objectRepository)
+    public function setObjectRepository(ObjectRepository $objectRepository) : Authentication
     {
         $this->objectRepository = $objectRepository;
+
         return $this;
     }
 
-    /**
-     * @return ObjectRepository
-     */
-    public function getObjectRepository()
+    public function getObjectRepository() : ObjectRepository
     {
         if ($this->objectRepository) {
             return $this->objectRepository;
@@ -151,30 +144,22 @@ class Authentication extends AbstractOptions
         return $this->objectManager->getRepository($this->identityClass);
     }
 
-    /**
-     * @param string $identityClass
-     * @return Authentication
-     */
-    public function setIdentityClass($identityClass)
+    public function setIdentityClass(string $identityClass) : Authentication
     {
         $this->identityClass = $identityClass;
+
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentityClass()
+    public function getIdentityClass() : string
     {
         return $this->identityClass;
     }
 
     /**
-     * @param  string $identityProperty
      * @throws Exception\InvalidArgumentException
-     * @return Authentication
      */
-    public function setIdentityProperty($identityProperty)
+    public function setIdentityProperty(string $identityProperty) : Authentication
     {
         if (! is_string($identityProperty) || $identityProperty === '') {
             throw new Exception\InvalidArgumentException(
@@ -187,20 +172,15 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentityProperty()
+    public function getIdentityProperty() : string
     {
         return $this->identityProperty;
     }
 
     /**
-     * @param  string $credentialProperty
      * @throws Exception\InvalidArgumentException
-     * @return Authentication
      */
-    public function setCredentialProperty($credentialProperty)
+    public function setCredentialProperty(string $credentialProperty) : Authentication
     {
         if (! is_string($credentialProperty) || $credentialProperty === '') {
             throw new Exception\InvalidArgumentException(
@@ -213,20 +193,17 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getCredentialProperty()
+    public function getCredentialProperty() : string
     {
         return $this->credentialProperty;
     }
 
     /**
      * @param  mixed $credentialCallable
+     *
      * @throws Exception\InvalidArgumentException
-     * @return Authentication
      */
-    public function setCredentialCallable($credentialCallable)
+    public function setCredentialCallable($credentialCallable) : Authentication
     {
         if (! is_callable($credentialCallable)) {
             throw new Exception\InvalidArgumentException(
@@ -250,10 +227,7 @@ class Authentication extends AbstractOptions
         return $this->credentialCallable;
     }
 
-    /**
-     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
-     */
-    public function getClassMetadata()
+    public function getClassMetadata() : ClassMetadata
     {
         if ($this->classMetadata) {
             return $this->classMetadata;
@@ -262,11 +236,7 @@ class Authentication extends AbstractOptions
         return $this->objectManager->getClassMetadata($this->identityClass);
     }
 
-    /**
-     *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $classMetadata
-     */
-    public function setClassMetadata(ClassMetadata $classMetadata)
+    public function setClassMetadata(ClassMetadata $classMetadata) : void
     {
         $this->classMetadata = $classMetadata;
     }
@@ -282,7 +252,7 @@ class Authentication extends AbstractOptions
     /**
      * @param StorageInterface|string $storage
      */
-    public function setStorage($storage)
+    public function setStorage($storage) : void
     {
         $this->storage = $storage;
     }

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -123,9 +123,14 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    // Causes issue with unit test StorageFactoryTest::testCanInstantiateStorageFromServiceLocator
-    // when return type is specified
-    public function getObjectManager() # : ObjectManager
+    /**
+     * Causes issue with unit test StorageFactoryTest::testCanInstantiateStorageFromServiceLocator
+     * when return type is specified
+     * : ObjectManager
+     *
+     * @return mixed
+     */
+    public function getObjectManager()
     {
         return $this->objectManager;
     }

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -123,7 +123,9 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    public function getObjectManager() : ObjectManager
+    // Causes issue with unit test StorageFactoryTest::testCanInstantiateStorageFromServiceLocator
+    // when return type is specified
+    public function getObjectManager() # : ObjectManager
     {
         return $this->objectManager;
     }

--- a/src/DoctrineModule/Options/Cache.php
+++ b/src/DoctrineModule/Options/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Options;
 
 use Laminas\Stdlib\AbstractOptions;
@@ -7,9 +9,7 @@ use Laminas\Stdlib\AbstractOptions;
 /**
  * Cache options
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 class Cache extends AbstractOptions
 {
@@ -42,78 +42,50 @@ class Cache extends AbstractOptions
      */
     protected $instance = null;
 
-    /**
-     * @param  string $class
-     * @return self
-     */
-    public function setClass($class)
+    public function setClass(string $class) : self
     {
         $this->class = $class;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getClass()
+    public function getClass() : string
     {
         return $this->class;
     }
 
-    /**
-     * @param  string $instance
-     * @return self
-     */
-    public function setInstance($instance)
+    public function setInstance(string $instance) : self
     {
         $this->instance = $instance;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getInstance()
+    public function getInstance() : string
     {
         return $this->instance;
     }
 
-    /**
-     * @param  string $namespace
-     * @return self
-     */
-    public function setNamespace($namespace)
+    public function setNamespace(string $namespace) : self
     {
         $this->namespace = (string) $namespace;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getNamespace()
+    public function getNamespace() : string
     {
         return $this->namespace;
     }
 
-    /**
-     * @param  string $directory
-     * @return self
-     */
-    public function setDirectory($directory)
+    public function setDirectory(string $directory) : self
     {
         $this->directory = $directory;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getDirectory()
+    public function getDirectory() : string
     {
         return $this->directory;
     }

--- a/src/DoctrineModule/Options/Cache.php
+++ b/src/DoctrineModule/Options/Cache.php
@@ -63,7 +63,7 @@ class Cache extends AbstractOptions
 
     public function getInstance() : string
     {
-        return $this->instance;
+        return (string) $this->instance;
     }
 
     public function setNamespace(string $namespace) : self

--- a/src/DoctrineModule/Options/Driver.php
+++ b/src/DoctrineModule/Options/Driver.php
@@ -25,7 +25,7 @@ class Driver extends AbstractOptions
      * may set this value as a string (for a single path) or an array
      * for multiple paths.
      *
-     * @var array
+     * @var mixed[]
      */
     protected $paths = [];
 
@@ -52,7 +52,7 @@ class Driver extends AbstractOptions
      * "doctrine.driver.{key}" and pulled from the service
      * locator. This option is only valid for DriverChain.
      *
-     * @var array
+     * @var mixed[]
      */
     protected $drivers = [];
 
@@ -63,7 +63,7 @@ class Driver extends AbstractOptions
 
     public function getCache() : string
     {
-        return "doctrine.cache.{$this->cache}";
+        return 'doctrine.cache.' . $this->cache;
     }
 
     public function setClass(string $class) : void
@@ -77,7 +77,7 @@ class Driver extends AbstractOptions
     }
 
     /**
-     * @param array $drivers
+     * @param mixed[] $drivers
      */
     public function setDrivers(array $drivers) : void
     {
@@ -85,7 +85,7 @@ class Driver extends AbstractOptions
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getDrivers() : array
     {
@@ -106,7 +106,7 @@ class Driver extends AbstractOptions
     }
 
     /**
-     * @param array $paths
+     * @param mixed[] $paths
      */
     public function setPaths(array $paths) : void
     {
@@ -114,7 +114,7 @@ class Driver extends AbstractOptions
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getPaths() : array
     {

--- a/src/DoctrineModule/Options/Driver.php
+++ b/src/DoctrineModule/Options/Driver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Options;
 
 use Laminas\Stdlib\AbstractOptions;
@@ -7,9 +9,7 @@ use Laminas\Stdlib\AbstractOptions;
 /**
  * MappingDriver options
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 class Driver extends AbstractOptions
 {
@@ -56,34 +56,22 @@ class Driver extends AbstractOptions
      */
     protected $drivers = [];
 
-    /**
-     * @param string $cache
-     */
-    public function setCache($cache)
+    public function setCache(string $cache) : void
     {
         $this->cache = $cache;
     }
 
-    /**
-     * @return string
-     */
-    public function getCache()
+    public function getCache() : string
     {
         return "doctrine.cache.{$this->cache}";
     }
 
-    /**
-     * @param string $class
-     */
-    public function setClass($class)
+    public function setClass(string $class) : void
     {
         $this->class = $class;
     }
 
-    /**
-     * @return string
-     */
-    public function getClass()
+    public function getClass() : string
     {
         return $this->class;
     }
@@ -91,7 +79,7 @@ class Driver extends AbstractOptions
     /**
      * @param array $drivers
      */
-    public function setDrivers($drivers)
+    public function setDrivers(array $drivers) : void
     {
         $this->drivers = $drivers;
     }
@@ -99,7 +87,7 @@ class Driver extends AbstractOptions
     /**
      * @return array
      */
-    public function getDrivers()
+    public function getDrivers() : array
     {
         return $this->drivers;
     }
@@ -107,15 +95,12 @@ class Driver extends AbstractOptions
     /**
      * @param null $extension
      */
-    public function setExtension($extension)
+    public function setExtension($extension) : void
     {
         $this->extension = $extension;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getExtension()
+    public function getExtension() : ?string
     {
         return $this->extension;
     }
@@ -123,7 +108,7 @@ class Driver extends AbstractOptions
     /**
      * @param array $paths
      */
-    public function setPaths($paths)
+    public function setPaths(array $paths) : void
     {
         $this->paths = $paths;
     }
@@ -131,7 +116,7 @@ class Driver extends AbstractOptions
     /**
      * @return array
      */
-    public function getPaths()
+    public function getPaths() : array
     {
         return $this->paths;
     }

--- a/src/DoctrineModule/Options/EventManager.php
+++ b/src/DoctrineModule/Options/EventManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Options;
 
 use Laminas\Stdlib\AbstractOptions;
@@ -7,9 +9,7 @@ use Laminas\Stdlib\AbstractOptions;
 /**
  * EventManager options
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 class EventManager extends AbstractOptions
 {
@@ -24,9 +24,8 @@ class EventManager extends AbstractOptions
 
     /**
      * @param  array $subscribers
-     * @return self
      */
-    public function setSubscribers($subscribers)
+    public function setSubscribers(array $subscribers) : self
     {
         $this->subscribers = $subscribers;
 
@@ -36,7 +35,7 @@ class EventManager extends AbstractOptions
     /**
      * @return array
      */
-    public function getSubscribers()
+    public function getSubscribers() : array
     {
         return $this->subscribers;
     }

--- a/src/DoctrineModule/Options/EventManager.php
+++ b/src/DoctrineModule/Options/EventManager.php
@@ -18,12 +18,12 @@ class EventManager extends AbstractOptions
      * class to instantiate OR a string to be located with the
      * service locator.
      *
-     * @var array
+     * @var mixed[]
      */
     protected $subscribers = [];
 
     /**
-     * @param  array $subscribers
+     * @param mixed[] $subscribers
      */
     public function setSubscribers(array $subscribers) : self
     {
@@ -33,7 +33,7 @@ class EventManager extends AbstractOptions
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getSubscribers() : array
     {

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -9,18 +9,13 @@ use Laminas\Paginator\Adapter\AdapterInterface;
 use function array_values;
 use function count;
 
-/**
- * Base module for Doctrine ORM.
- *
- * @link    http://www.doctrine-project.org/
- */
 class Collection implements AdapterInterface
 {
-    /** @var DoctrineCollection */
+    /** @var Doctrine\Common\Collections\Collection */
     protected $collection;
 
     /**
-     * @param DoctrineCollection $collection
+     * @param mixed[] $collection
      */
     public function __construct(DoctrineCollection $collection)
     {

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -23,8 +23,7 @@ class Collection implements AdapterInterface
     }
 
     /**
-     * @param integer $offset
-     * @param integer $itemCountPerPage
+     * {@inheritDoc}
      */
     public function getItems($offset, $itemCountPerPage)
     {

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -1,23 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Laminas\Paginator\Adapter\AdapterInterface;
+use function array_values;
+use function count;
 
 /**
  * Base module for Doctrine ORM.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class Collection implements AdapterInterface
 {
-    /**
-     * @var DoctrineCollection
-     */
+    /** @var DoctrineCollection */
     protected $collection;
 
     /**

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -23,7 +23,8 @@ class Collection implements AdapterInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param integer $offset
+     * @param integer $itemCountPerPage
      */
     public function getItems($offset, $itemCountPerPage)
     {

--- a/src/DoctrineModule/Paginator/Adapter/Selectable.php
+++ b/src/DoctrineModule/Paginator/Adapter/Selectable.php
@@ -1,39 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
 use Laminas\Paginator\Adapter\AdapterInterface;
+use function count;
 
 /**
  * Provides a wrapper around a Selectable object
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class Selectable implements AdapterInterface
 {
-    /**
-     * @var DoctrineSelectable
-     */
+    /** @var DoctrineSelectable */
     protected $selectable;
 
-    /**
-     * @var \Doctrine\Common\Collections\Criteria
-     */
+    /** @var Criteria */
     protected $criteria;
 
     /**
      * Create a paginator around a Selectable object. You can also provide an optional Criteria object with
      * some predefined filters
-     *
-     * @param \Doctrine\Common\Collections\Selectable    $selectable
-     * @param \Doctrine\Common\Collections\Criteria|null $criteria
      */
-    public function __construct(DoctrineSelectable $selectable, Criteria $criteria = null)
+    public function __construct(DoctrineSelectable $selectable, ?Criteria $criteria = null)
     {
         $this->selectable = $selectable;
         $this->criteria   = $criteria ? clone $criteria : new Criteria();

--- a/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
+++ b/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Persistence;
 
 use Doctrine\Common\Persistence\ObjectManager;
@@ -8,15 +10,11 @@ interface ObjectManagerAwareInterface
 {
     /**
      * Set the object manager
-     *
-     * @param ObjectManager $objectManager
      */
-    public function setObjectManager(ObjectManager $objectManager);
+    public function setObjectManager(ObjectManager $objectManager) : void;
 
     /**
      * Get the object manager
-     *
-     * @return ObjectManager
      */
-    public function getObjectManager();
+    public function getObjectManager() : ObjectManager;
 }

--- a/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
+++ b/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
@@ -6,8 +6,11 @@ namespace DoctrineModule\Persistence;
 
 use Doctrine\Common\Persistence\ObjectManager;
 
+// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
 interface ObjectManagerAwareInterface
 {
+// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
+
     /**
      * Set the object manager
      */

--- a/src/DoctrineModule/Persistence/ProvidesObjectManager.php
+++ b/src/DoctrineModule/Persistence/ProvidesObjectManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Persistence;
 
 use Doctrine\Common\Persistence\ObjectManager;
@@ -9,27 +11,21 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 trait ProvidesObjectManager
 {
-    /**
-     * @var ObjectManager
-     */
+    /** @var ObjectManager */
     protected $objectManager;
 
     /**
      * Set the object manager
-     *
-     * @param ObjectManager $objectManager
      */
-    public function setObjectManager(ObjectManager $objectManager)
+    public function setObjectManager(ObjectManager $objectManager) : void
     {
         $this->objectManager = $objectManager;
     }
 
     /**
      * Get the object manager
-     *
-     * @return ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager() : ObjectManager
     {
         return $this->objectManager;
     }

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -45,7 +45,7 @@ abstract class AbstractFactory implements FactoryInterface
      */
     public function getMappingType() : string
     {
-        return $this->mappingType;
+        return (string) $this->mappingType;
     }
 
     /**

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -12,11 +12,11 @@ use function sprintf;
 
 /**
  * Base ServiceManager factory to be extended
- *
- * @link    http://www.doctrine-project.org/
  */
-abstract class ServiceFactory implements FactoryInterface
+// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
+abstract class AbstractFactory implements FactoryInterface
 {
+// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
     /**
      * Would normally be set to orm | odm
      *

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\Stdlib\AbstractOptions;
 use RuntimeException;
+use function sprintf;
 
 /**
  * Base ServiceManager factory to be extended
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 abstract class AbstractFactory implements FactoryInterface
 {
@@ -22,38 +24,26 @@ abstract class AbstractFactory implements FactoryInterface
      */
     protected $mappingType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var \Laminas\Stdlib\AbstractOptions
-     */
+    /** @var AbstractOptions */
     protected $options;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
 
     /**
      * Would normally be set to orm | odm
-     *
-     * @return string
      */
-    public function getMappingType()
+    public function getMappingType() : string
     {
         return $this->mappingType;
     }
@@ -61,13 +51,9 @@ abstract class AbstractFactory implements FactoryInterface
     /**
      * Gets options from configuration based on name.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $key
-     * @param  null|string        $name
-     * @return \Laminas\Stdlib\AbstractOptions
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
-    public function getOptions(ContainerInterface $container, $key, $name = null)
+    public function getOptions(ContainerInterface $container, string $key, ?string $name = null) : AbstractOptions
     {
         if ($name === null) {
             $name = $this->getName();
@@ -78,9 +64,10 @@ abstract class AbstractFactory implements FactoryInterface
         if ($mappingType = $this->getMappingType()) {
             $options = $options[$mappingType];
         }
-        $options = isset($options[$key][$name]) ? $options[$key][$name] : null;
 
-        if (null === $options) {
+        $options = $options[$key][$name] ?? null;
+
+        if ($options === null) {
             throw new RuntimeException(
                 sprintf(
                     'Options with name "%s" could not be found in "doctrine.%s".',
@@ -99,7 +86,6 @@ abstract class AbstractFactory implements FactoryInterface
      * Get the class name of the options associated with this factory.
      *
      * @abstract
-     * @return string
      */
-    abstract public function getOptionsClass();
+    abstract public function getOptionsClass() : string;
 }

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -47,7 +47,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Authentication';
     }

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Options\Authentication;
-use DoctrineModule\Service\AbstractFactory;
+use DoctrineModule\Service\ServiceFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function assert;
@@ -17,7 +17,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AdapterFactory extends AbstractFactory
+class AdapterFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}
@@ -27,7 +27,8 @@ class AdapterFactory extends AbstractFactory
         $options = $this->getOptions($container, 'authentication');
         assert($options instanceof Authentication);
 
-        if (is_string($objectManager = $options->getObjectManager())) {
+        $objectManager = $options->getObjectManager();
+        if (is_string($objectManager)) {
             $options->setObjectManager($container->get($objectManager));
         }
 
@@ -44,9 +45,6 @@ class AdapterFactory extends AbstractFactory
         return $this($serviceLocator, ObjectRepository::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Authentication';

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -1,28 +1,31 @@
 <?php
+
+declare(strict_types=1);
+
 namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Adapter\ObjectRepository;
+use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use function assert;
+use function is_string;
 
 /**
  * Factory to create authentication adapter object.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.1.0
- * @author  Tim Roediger <superdweebie@gmail.com>
  */
 class AdapterFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $options \DoctrineModule\Options\Authentication */
         $options = $this->getOptions($container, 'authentication');
+        assert($options instanceof Authentication);
 
         if (is_string($objectManager = $options->getObjectManager())) {
             $options->setObjectManager($container->get($objectManager));
@@ -34,7 +37,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return \DoctrineModule\Authentication\Adapter\ObjectRepository
+     * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Options\Authentication;
-use DoctrineModule\Service\ServiceFactory;
+use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function assert;
@@ -17,7 +17,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AdapterFactory extends ServiceFactory
+class AdapterFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\Service\Authentication;
 
 use BadMethodCallException;
-use DoctrineModule\Service\AbstractFactory;
+use DoctrineModule\Service\ServiceFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\ServiceManager\ServiceLocatorInterface;
@@ -15,7 +15,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AuthenticationServiceFactory extends AbstractFactory
+class AuthenticationServiceFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}
@@ -33,9 +33,6 @@ class AuthenticationServiceFactory extends AbstractFactory
         return $this($container, AuthenticationService::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
         throw new BadMethodCallException('Not implemented');

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -36,7 +36,7 @@ class AuthenticationServiceFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         throw new BadMethodCallException('Not implemented');
     }

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\Service\Authentication;
 
 use BadMethodCallException;
-use DoctrineModule\Service\ServiceFactory;
+use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\ServiceManager\ServiceLocatorInterface;
@@ -15,7 +15,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AuthenticationServiceFactory extends ServiceFactory
+class AuthenticationServiceFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -1,6 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 namespace DoctrineModule\Service\Authentication;
 
+use BadMethodCallException;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
@@ -9,17 +13,14 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 /**
  * Factory to create authentication service object.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.1.0
- * @author  Tim Roediger <superdweebie@gmail.com>
  */
 class AuthenticationServiceFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new AuthenticationService(
             $container->get('doctrine.authenticationstorage.' . $this->getName()),
@@ -27,12 +28,7 @@ class AuthenticationServiceFactory extends AbstractFactory
         );
     }
 
-    /**
-     *
-     * @param ServiceLocatorInterface $container
-     * @return AuthenticationService
-     */
-    public function createService(ServiceLocatorInterface $container)
+    public function createService(ServiceLocatorInterface $container) : AuthenticationService
     {
         return $this($container, AuthenticationService::class);
     }
@@ -42,6 +38,6 @@ class AuthenticationServiceFactory extends AbstractFactory
      */
     public function getOptionsClass()
     {
-        throw new \BadMethodCallException('Not implemented');
+        throw new BadMethodCallException('Not implemented');
     }
 }

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -1,28 +1,31 @@
 <?php
+
+declare(strict_types=1);
+
 namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Storage\ObjectRepository;
+use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use function assert;
+use function is_string;
 
 /**
  * Factory to create authentication storage object.
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.1.0
- * @author  Tim Roediger <superdweebie@gmail.com>
  */
 class StorageFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $options \DoctrineModule\Options\Authentication */
         $options = $this->getOptions($container, 'authentication');
+        assert($options instanceof Authentication);
 
         if (is_string($objectManager = $options->getObjectManager())) {
             $options->setObjectManager($container->get($objectManager));
@@ -38,7 +41,7 @@ class StorageFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return \DoctrineModule\Authentication\Storage\ObjectRepository
+     * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -51,7 +51,7 @@ class StorageFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Authentication';
     }

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Options\Authentication;
-use DoctrineModule\Service\AbstractFactory;
+use DoctrineModule\Service\ServiceFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function assert;
@@ -17,7 +17,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class StorageFactory extends AbstractFactory
+class StorageFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}
@@ -27,11 +27,13 @@ class StorageFactory extends AbstractFactory
         $options = $this->getOptions($container, 'authentication');
         assert($options instanceof Authentication);
 
-        if (is_string($objectManager = $options->getObjectManager())) {
+        $objectManager = $options->getObjectManager();
+        if (is_string($objectManager)) {
             $options->setObjectManager($container->get($objectManager));
         }
 
-        if (is_string($storage = $options->getStorage())) {
+        $storage = $options->getStorage();
+        if (is_string($storage)) {
             $options->setStorage($container->get($storage));
         }
 
@@ -48,9 +50,6 @@ class StorageFactory extends AbstractFactory
         return $this($container, ObjectRepository::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Authentication';

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Options\Authentication;
-use DoctrineModule\Service\ServiceFactory;
+use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function assert;
@@ -17,7 +17,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class StorageFactory extends ServiceFactory
+class StorageFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use Doctrine\Common\Cache;
@@ -8,13 +10,13 @@ use DoctrineModule\Cache\LaminasStorageCache;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
+use function assert;
+use function is_string;
 
 /**
  * Cache ServiceManager factory
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 class CacheFactory extends AbstractFactory
 {
@@ -25,11 +27,11 @@ class CacheFactory extends AbstractFactory
      *
      * @throws RuntimeException
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /** @var $options \DoctrineModule\Options\Cache */
         $options = $this->getOptions($container, 'cache');
-        $class   = $options->getClass();
+        assert($options instanceof \DoctrineModule\Options\Cache);
+        $class = $options->getClass();
 
         if (! $class) {
             throw new RuntimeException('Cache must have a class name to instantiate');
@@ -55,19 +57,19 @@ class CacheFactory extends AbstractFactory
                     break;
 
                 default:
-                    $cache = new $class;
+                    $cache = new $class();
                     break;
             }
         }
 
         if ($cache instanceof Cache\MemcacheCache) {
-            /* @var $cache MemcacheCache */
+            /** @var MemcacheCache $cache */
             $cache->setMemcache($instance);
         } elseif ($cache instanceof Cache\MemcachedCache) {
-            /* @var $cache MemcachedCache */
+            /** @var MemcachedCache $cache */
             $cache->setMemcached($instance);
         } elseif ($cache instanceof Cache\RedisCache) {
-            /* @var $cache RedisCache */
+            /** @var RedisCache $cache */
             $cache->setRedis($instance);
         }
 

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -18,7 +18,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class CacheFactory extends ServiceFactory
+class CacheFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -18,7 +18,7 @@ use function is_string;
  *
  * @link    http://www.doctrine-project.org/
  */
-class CacheFactory extends AbstractFactory
+class CacheFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}
@@ -63,18 +63,18 @@ class CacheFactory extends AbstractFactory
         }
 
         if ($cache instanceof Cache\MemcacheCache) {
-            /** @var MemcacheCache $cache */
             $cache->setMemcache($instance);
         } elseif ($cache instanceof Cache\MemcachedCache) {
-            /** @var MemcachedCache $cache */
             $cache->setMemcached($instance);
         } elseif ($cache instanceof Cache\RedisCache) {
-            /** @var RedisCache $cache */
             $cache->setRedis($instance);
         }
 
-        if ($cache instanceof CacheProvider && ($namespace = $options->getNamespace())) {
-            $cache->setNamespace($namespace);
+        if ($cache instanceof CacheProvider) {
+            $namespace = $options->getNamespace();
+            if ($namespace) {
+                $cache->setNamespace($namespace);
+            }
         }
 
         return $cache;
@@ -92,9 +92,6 @@ class CacheFactory extends AbstractFactory
         return $this($container, \Doctrine\Common\Cache\Cache::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Cache';

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -95,7 +95,7 @@ class CacheFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Cache';
     }

--- a/src/DoctrineModule/Service/CliControllerFactory.php
+++ b/src/DoctrineModule/Service/CliControllerFactory.php
@@ -30,7 +30,7 @@ class CliControllerFactory implements FactoryInterface
      * @throws ServiceNotCreatedException if an exception is raised when creating a service.
      * @throws ContainerException if any other error occurs
      */
-    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null) : object
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null) : object
     {
         $application = $container->get('doctrine.cli');
         assert($application instanceof Application);

--- a/src/DoctrineModule/Service/CliControllerFactory.php
+++ b/src/DoctrineModule/Service/CliControllerFactory.php
@@ -24,11 +24,11 @@ class CliControllerFactory implements FactoryInterface
     /**
      * Create an object
      *
-     * @param array|null $options
+     * {@inheritDoc}
      *
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException if any other error occurs.
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null) : object
     {

--- a/src/DoctrineModule/Service/CliControllerFactory.php
+++ b/src/DoctrineModule/Service/CliControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use DoctrineModule\Controller\CliController;
@@ -9,32 +11,29 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Symfony\Component\Console\Application;
+use function assert;
 
 /**
  * Factory responsible of instantiating an {@see \DoctrineModule\Controller\CliController}
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class CliControllerFactory implements FactoryInterface
 {
     /**
      * Create an object
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
+     * @param array|null $options
      *
-     * @return object
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when creating a service.
      * @throws ContainerException if any other error occurs
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null) : object
     {
-        /* @var $application \Symfony\Component\Console\Application */
         $application = $container->get('doctrine.cli');
+        assert($application instanceof Application);
 
         return new CliController($application);
     }
@@ -42,7 +41,7 @@ class CliControllerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @return \DoctrineModule\Controller\CliController
+     * @return CliController
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/DoctrineModule/Service/CliFactory.php
+++ b/src/DoctrineModule/Service/CliFactory.php
@@ -25,7 +25,7 @@ class CliFactory implements FactoryInterface
     /** @var HelperSet */
     protected $helperSet;
 
-    /** @var array */
+    /** @var mixed[] */
     protected $commands = [];
 
     public function getEventManager(ContainerInterface $container) : EventManagerInterface

--- a/src/DoctrineModule/Service/CliFactory.php
+++ b/src/DoctrineModule/Service/CliFactory.php
@@ -1,48 +1,40 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
+use Laminas\EventManager\EventManagerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
+use function assert;
 
 /**
  * CLI Application ServiceManager factory responsible for instantiating a Symfony CLI application
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Kyle Spraggs <theman@spiffyjr.me>
  */
 class CliFactory implements FactoryInterface
 {
-    /**
-     * @var \Laminas\EventManager\EventManagerInterface
-     */
+    /** @var EventManagerInterface */
     protected $events;
 
-    /**
-     * @var \Symfony\Component\Console\Helper\HelperSet
-     */
+    /** @var HelperSet */
     protected $helperSet;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $commands = [];
 
-    /**
-     * @param  ContainerInterface $container
-     * @return \Laminas\EventManager\EventManagerInterface
-     */
-    public function getEventManager(ContainerInterface $container)
+    public function getEventManager(ContainerInterface $container) : EventManagerInterface
     {
-        if (null === $this->events) {
-            /* @var $events \Laminas\EventManager\EventManagerInterface */
+        if ($this->events === null) {
             $events = $container->get('EventManager');
+            assert($events instanceof EventManagerInterface);
 
-            $events->addIdentifiers([__CLASS__, 'doctrine']);
+            $events->addIdentifiers([self::class, 'doctrine']);
 
             $this->events = $events;
         }
@@ -52,13 +44,14 @@ class CliFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
      * @return Application
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $cli = new Application;
+        $cli = new Application();
         $cli->setName('DoctrineModule Command Line Interface');
-        $cli->setHelperSet(new HelperSet);
+        $cli->setHelperSet(new HelperSet());
         $cli->setCatchExceptions(true);
         $cli->setAutoExit(false);
 
@@ -70,6 +63,7 @@ class CliFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
      * @return Application
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -26,7 +26,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class DriverFactory extends AbstractFactory
+class DriverFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}
@@ -51,9 +51,6 @@ class DriverFactory extends AbstractFactory
         return $this($container, MappingDriver::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Driver';
@@ -94,7 +91,6 @@ class DriverFactory extends AbstractFactory
         }
 
         if ($options->getExtension() && $driver instanceof FileDriver) {
-            /** @var FileDriver $driver */
             $locator = $driver->getLocator();
             assert($locator instanceof FileLocator);
 
@@ -114,7 +110,6 @@ class DriverFactory extends AbstractFactory
 
         // Extra post-create options for DriverChain.
         if ($driver instanceof MappingDriverChain && $options->getDrivers()) {
-            /** @var MappingDriverChain $driver */
             $drivers = $options->getDrivers();
 
             if (! is_array($drivers)) {

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -54,7 +54,7 @@ class DriverFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\Driver';
     }

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -26,7 +26,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class DriverFactory extends ServiceFactory
+class DriverFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -20,7 +20,7 @@ use function sprintf;
 /**
  * Factory responsible for creating EventManager instances
  */
-class EventManagerFactory extends AbstractFactory
+class EventManagerFactory extends ServiceFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use Doctrine\Common\EventManager;
@@ -7,6 +9,13 @@ use Doctrine\Common\EventSubscriber;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use function assert;
+use function class_exists;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 /**
  * Factory responsible for creating EventManager instances
@@ -16,10 +25,10 @@ class EventManagerFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /** @var $options \DoctrineModule\Options\EventManager */
-        $options      = $this->getOptions($container, 'eventmanager');
+        $options = $this->getOptions($container, 'eventmanager');
+        assert($options instanceof \DoctrineModule\Options\EventManager);
         $eventManager = new EventManager();
 
         foreach ($options->getSubscribers() as $subscriberName) {
@@ -62,10 +71,8 @@ class EventManagerFactory extends AbstractFactory
 
     /**
      * Get the class name of the options associated with this factory.
-     *
-     * @return string
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
         return 'DoctrineModule\Options\EventManager';
     }

--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -20,7 +20,7 @@ use function sprintf;
 /**
  * Factory responsible for creating EventManager instances
  */
-class EventManagerFactory extends ServiceFactory
+class EventManagerFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Service/ServiceFactory.php
+++ b/src/DoctrineModule/Service/ServiceFactory.php
@@ -15,7 +15,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-abstract class AbstractFactory implements FactoryInterface
+abstract class ServiceFactory implements FactoryInterface
 {
     /**
      * Would normally be set to orm | odm
@@ -59,9 +59,10 @@ abstract class AbstractFactory implements FactoryInterface
             $name = $this->getName();
         }
 
-        $options = $container->get('config');
-        $options = $options['doctrine'];
-        if ($mappingType = $this->getMappingType()) {
+        $options     = $container->get('config');
+        $options     = $options['doctrine'];
+        $mappingType = $this->getMappingType();
+        if ($mappingType) {
             $options = $options[$mappingType];
         }
 

--- a/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
+++ b/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
@@ -1,21 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Service;
 
 use DoctrineModule\Mvc\Router\Console\SymfonyCli;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Symfony\Component\Console\Application;
+use function assert;
 
 /**
  * Factory responsible of instantiating {@see \DoctrineModule\Mvc\Router\Console\SymfonyCli}
  */
 class SymfonyCliRouteFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $application \Symfony\Component\Console\Application */
         $application = $container->get('doctrine.cli');
+        assert($application instanceof Application);
 
         return new SymfonyCli(
             $application,

--- a/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
+++ b/src/DoctrineModule/Service/SymfonyCliRouteFactory.php
@@ -16,6 +16,9 @@ use function assert;
  */
 class SymfonyCliRouteFactory implements FactoryInterface
 {
+    /**
+     * {@inheritDoc}
+     */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $application = $container->get('doctrine.cli');

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\ServiceFactory;
 
-use DoctrineModule\Service\AbstractFactory;
+use DoctrineModule\Service\ServiceFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
@@ -41,7 +41,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 
         $factoryClass = $mappings['factoryClass'];
         $factory      = new $factoryClass($mappings['serviceName']);
-        assert($factory instanceof AbstractFactory);
+        assert($factory instanceof ServiceFactory);
 
         return $factory->createService($container);
     }
@@ -67,7 +67,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @return array|bool
+     * @return mixed[]|bool
      */
     private function getFactoryMapping(ContainerInterface $serviceLocator, string $name)
     {

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -100,10 +100,10 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
             ];
         }
 
-        if (! isset($config['doctrine_factories'][$mappingType]) ||
-             ! isset($config['doctrine_factories'][$mappingType][$serviceType]) ||
-             ! isset($config['doctrine'][$mappingType][$serviceType][$serviceName])
-        ) {
+        if (! isset(
+            $config['doctrine_factories'][$mappingType][$serviceType],
+            $config['doctrine'][$mappingType][$serviceType][$serviceName]
+        )) {
             return false;
         }
 

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\ServiceFactory;
 
+use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use function assert;
+use function preg_match;
 
 /**
  * Abstract service factory capable of instantiating services whose names match the
  * pattern <code>doctrine.$serviceType.$serviceName</doctrine>
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 {
@@ -22,13 +25,13 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
      */
     public function canCreate(ContainerInterface $container, $requestedName)
     {
-        return false !== $this->getFactoryMapping($container, $requestedName);
+        return $this->getFactoryMapping($container, $requestedName) !== false;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $mappings = $this->getFactoryMapping($container, $requestedName);
 
@@ -37,14 +40,15 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
         }
 
         $factoryClass = $mappings['factoryClass'];
-        /* @var $factory \DoctrineModule\Service\AbstractFactory */
-        $factory = new $factoryClass($mappings['serviceName']);
+        $factory      = new $factoryClass($mappings['serviceName']);
+        assert($factory instanceof AbstractFactory);
 
         return $factory->createService($container);
     }
 
     /**
      * {@inheritDoc}
+     *
      * @deprecated
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
@@ -54,6 +58,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
      * @deprecated
      */
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
@@ -62,12 +67,9 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param ContainerInterface $serviceLocator
-     * @param string             $name
-     *
      * @return array|bool
      */
-    private function getFactoryMapping(ContainerInterface $serviceLocator, $name)
+    private function getFactoryMapping(ContainerInterface $serviceLocator, string $name)
     {
         $matches = [];
 
@@ -84,7 +86,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
         $serviceType = $matches['serviceType'];
         $serviceName = $matches['serviceName'];
 
-        if ($mappingType == '') {
+        if ($mappingType === '') {
             if (! isset($config['doctrine_factories'][$serviceType]) ||
                  ! isset($config['doctrine'][$serviceType][$serviceName])
             ) {
@@ -96,18 +98,19 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
                 'serviceName'  => $serviceName,
                 'factoryClass' => $config['doctrine_factories'][$serviceType],
             ];
-        } else {
-            if (! isset($config['doctrine_factories'][$mappingType]) ||
-                 ! isset($config['doctrine_factories'][$mappingType][$serviceType]) ||
-                 ! isset($config['doctrine'][$mappingType][$serviceType][$serviceName])
-            ) {
-                return false;
-            }
-            return [
-                'serviceType'  => $serviceType,
-                'serviceName'  => $serviceName,
-                'factoryClass' => $config['doctrine_factories'][$mappingType][$serviceType],
-            ];
         }
+
+        if (! isset($config['doctrine_factories'][$mappingType]) ||
+             ! isset($config['doctrine_factories'][$mappingType][$serviceType]) ||
+             ! isset($config['doctrine'][$mappingType][$serviceType][$serviceName])
+        ) {
+            return false;
+        }
+
+        return [
+            'serviceType'  => $serviceType,
+            'serviceName'  => $serviceName,
+            'factoryClass' => $config['doctrine_factories'][$mappingType][$serviceType],
+        ];
     }
 }

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\ServiceFactory;
 
-use DoctrineModule\Service\ServiceFactory;
+use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
@@ -41,7 +41,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 
         $factoryClass = $mappings['factoryClass'];
         $factory      = new $factoryClass($mappings['serviceName']);
-        assert($factory instanceof ServiceFactory);
+        assert($factory instanceof AbstractFactory);
 
         return $factory->createService($container);
     }

--- a/src/DoctrineModule/Validator/NoObjectExists.php
+++ b/src/DoctrineModule/Validator/NoObjectExists.php
@@ -1,28 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator;
+
+use function is_object;
 
 /**
  * Class that validates if objects does not exist in a given repository with a given list of matched fields
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.4.0
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class NoObjectExists extends ObjectExists
 {
     /**
      * Error constants
      */
-    const ERROR_OBJECT_FOUND = 'objectFound';
+    public const ERROR_OBJECT_FOUND = 'objectFound';
 
-    /**
-     * @var array Message templates
-     */
-    protected $messageTemplates = [
-        self::ERROR_OBJECT_FOUND    => "An object matching '%value%' was found",
-    ];
+    /** @var array Message templates */
+    protected $messageTemplates = [self::ERROR_OBJECT_FOUND => "An object matching '%value%' was found"];
 
     /**
      * {@inheritDoc}

--- a/src/DoctrineModule/Validator/NoObjectExists.php
+++ b/src/DoctrineModule/Validator/NoObjectExists.php
@@ -18,7 +18,7 @@ class NoObjectExists extends ObjectExists
      */
     public const ERROR_OBJECT_FOUND = 'objectFound';
 
-    /** @var array Message templates */
+    /** @var mixed[] Message templates */
     protected $messageTemplates = [self::ERROR_OBJECT_FOUND => "An object matching '%value%' was found"];
 
     /**

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -117,6 +117,8 @@ class ObjectExists extends AbstractValidator
         }
 
         $this->fields = array_values($fields);
+
+        return $this->fields;
     }
 
     /**

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -1,33 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception;
+use function array_combine;
+use function array_key_exists;
+use function array_values;
+use function count;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   0.4.0
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class ObjectExists extends AbstractValidator
 {
     /**
      * Error constants
      */
-    const ERROR_NO_OBJECT_FOUND = 'noObjectFound';
+    public const ERROR_NO_OBJECT_FOUND = 'noObjectFound';
 
-    /**
-     * @var array Message templates
-     */
-    protected $messageTemplates = [
-        self::ERROR_NO_OBJECT_FOUND => "No object matching '%value%' was found",
-    ];
+    /** @var array Message templates */
+    protected $messageTemplates = [self::ERROR_NO_OBJECT_FOUND => "No object matching '%value%' was found"];
 
     /**
      * ObjectRepository from which to search for entities
@@ -49,6 +53,7 @@ class ObjectExists extends AbstractValidator
      * @param array $options required keys are `object_repository`, which must be an instance of
      *                       Doctrine\Common\Persistence\ObjectRepository, and `fields`, with either
      *                       a string or an array of strings representing the fields to be matched by the validator.
+     *
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(array $options)
@@ -60,7 +65,7 @@ class ObjectExists extends AbstractValidator
                 if (is_object($options['object_repository'])) {
                     $provided = get_class($options['object_repository']);
                 } else {
-                    $provided = getType($options['object_repository']);
+                    $provided = gettype($options['object_repository']);
                 }
             }
 
@@ -91,10 +96,11 @@ class ObjectExists extends AbstractValidator
     /**
      * Filters and validates the fields passed to the constructor
      *
-     * @throws Exception\InvalidArgumentException
      * @return array
+     *
+     * @throws Exception\InvalidArgumentException
      */
-    private function validateFields()
+    private function validateFields() : array
     {
         $fields = (array) $this->fields;
 
@@ -116,10 +122,12 @@ class ObjectExists extends AbstractValidator
     /**
      * @param string|array $value a field value or an array of field values if more fields have been configured to be
      *                      matched
+     *
      * @return array
+     *
      * @throws Exception\RuntimeException
      */
-    protected function cleanSearchValue($value)
+    protected function cleanSearchValue($value) : array
     {
         $value = is_object($value) ? [$value] : (array) $value;
 
@@ -142,7 +150,7 @@ class ObjectExists extends AbstractValidator
         } else {
             $matchedFieldsValues = @array_combine($this->fields, $value);
 
-            if (false === $matchedFieldsValues) {
+            if ($matchedFieldsValues === false) {
                 throw new Exception\RuntimeException(
                     sprintf(
                         'Provided values count is %s, while expected number of fields to be matched is %s',

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -30,7 +30,7 @@ class ObjectExists extends AbstractValidator
      */
     public const ERROR_NO_OBJECT_FOUND = 'noObjectFound';
 
-    /** @var array Message templates */
+    /** @var mixed[] Message templates */
     protected $messageTemplates = [self::ERROR_NO_OBJECT_FOUND => "No object matching '%value%' was found"];
 
     /**
@@ -43,14 +43,14 @@ class ObjectExists extends AbstractValidator
     /**
      * Fields to be checked
      *
-     * @var array
+     * @var mixed[]
      */
     protected $fields;
 
     /**
      * Constructor
      *
-     * @param array $options required keys are `object_repository`, which must be an instance of
+     * @param mixed[] $options required keys are `object_repository`, which must be an instance of
      *                       Doctrine\Common\Persistence\ObjectRepository, and `fields`, with either
      *                       a string or an array of strings representing the fields to be matched by the validator.
      *
@@ -96,7 +96,7 @@ class ObjectExists extends AbstractValidator
     /**
      * Filters and validates the fields passed to the constructor
      *
-     * @return array
+     * @return mixed[]
      *
      * @throws Exception\InvalidArgumentException
      */
@@ -122,10 +122,10 @@ class ObjectExists extends AbstractValidator
     }
 
     /**
-     * @param string|array $value a field value or an array of field values if more fields have been configured to be
+     * @param string|mixed[] $value a field value or an array of field values if more fields have been configured to be
      *                      matched
      *
-     * @return array
+     * @return mixed[]
      *
      * @throws Exception\RuntimeException
      */

--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -20,16 +20,20 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
+// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractValidatorFactory implements FactoryInterface
 {
+// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
     public const DEFAULT_OBJECTMANAGER_KEY = 'doctrine.entitymanager.orm_default';
 
+    /** @var mixed[] */
     protected $creationOptions = [];
 
+    /** @var string $validatorClass */
     protected $validatorClass;
 
     /**
-     * @param array $options
+     * @param mixed[] $options
      *
      * @throws ServiceCreationException
      */
@@ -49,7 +53,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     }
 
     /**
-     * @param array $options
+     * @param mixed[] $options
      */
     protected function getObjectManager(ContainerInterface $container, ?array $options = null) : ObjectManager
     {
@@ -63,9 +67,9 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     }
 
     /**
-     * @param array $options
+     * @param mixed[] $options
      *
-     * @return array
+     * @return mixed[]
      */
     protected function getFields(array $options) : array
     {
@@ -81,10 +85,10 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      * together with the options array created based on the above
      * helper methods.
      *
-     * @param array $previousOptions
-     * @param array $newOptions
+     * @param mixed[] $previousOptions
+     * @param mixed[] $newOptions
      *
-     * @return array
+     * @return mixed[]
      */
     protected function merge(array $previousOptions, array $newOptions) : array
     {
@@ -106,11 +110,17 @@ abstract class AbstractValidatorFactory implements FactoryInterface
         return $container;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         return $this($serviceLocator, $this->validatorClass, $this->creationOptions);
     }
 
+    /**
+     * @param mixed[] $options
+     */
     public function setCreationOptions(array $options) : void
     {
         $this->creationOptions = $options;

--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -1,60 +1,59 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator\Service;
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
 use DoctrineModule\Validator\Service\Exception\ServiceCreationException;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Stdlib\ArrayUtils;
+use function is_string;
+use function sprintf;
 
 /**
  * Factory for creating NoObjectExists instances
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   1.3.0
- * @author  Fabian Grutschus <f.grutschus@lubyte.de>
  */
 abstract class AbstractValidatorFactory implements FactoryInterface
 {
-    const DEFAULT_OBJECTMANAGER_KEY = 'doctrine.entitymanager.orm_default';
+    public const DEFAULT_OBJECTMANAGER_KEY = 'doctrine.entitymanager.orm_default';
 
     protected $creationOptions = [];
 
     protected $validatorClass;
 
     /**
-     * @param ContainerInterface $container
      * @param array $options
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     *
      * @throws ServiceCreationException
      */
-    protected function getRepository(ContainerInterface $container, array $options = null)
+    protected function getRepository(ContainerInterface $container, ?array $options = null) : ObjectRepository
     {
         if (empty($options['target_class'])) {
             throw new ServiceCreationException(sprintf(
                 "Option 'target_class' is missing when creating validator %s",
-                __CLASS__
+                self::class
             ));
         }
 
-        $objectManager    = $this->getObjectManager($container, $options);
-        $targetClassName  = $options['target_class'];
-        $objectRepository = $objectManager->getRepository($targetClassName);
+        $objectManager   = $this->getObjectManager($container, $options);
+        $targetClassName = $options['target_class'];
 
-        return $objectRepository;
+        return $objectManager->getRepository($targetClassName);
     }
 
     /**
-     * @param ContainerInterface $container
      * @param array $options
-     * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    protected function getObjectManager(ContainerInterface $container, array $options = null)
+    protected function getObjectManager(ContainerInterface $container, ?array $options = null) : ObjectManager
     {
-        $objectManager = ($options['object_manager']) ?? self::DEFAULT_OBJECTMANAGER_KEY;
+        $objectManager = $options['object_manager'] ?? self::DEFAULT_OBJECTMANAGER_KEY;
 
         if (is_string($objectManager)) {
             $objectManager = $container->get($objectManager);
@@ -65,9 +64,10 @@ abstract class AbstractValidatorFactory implements FactoryInterface
 
     /**
      * @param array $options
+     *
      * @return array
      */
-    protected function getFields(array $options)
+    protected function getFields(array $options) : array
     {
         if (isset($options['fields'])) {
             return (array) $options['fields'];
@@ -83,9 +83,10 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      *
      * @param array $previousOptions
      * @param array $newOptions
+     *
      * @return array
      */
-    protected function merge($previousOptions, $newOptions)
+    protected function merge(array $previousOptions, array $newOptions) : array
     {
         return ArrayUtils::merge($previousOptions, $newOptions, true);
     }
@@ -95,11 +96,8 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      *
      * In ZF2 the plugin manager instance if passed to `createService`
      * instead of the global service manager instance (as in ZF3).
-     *
-     * @param ContainerInterface $container
-     * @return ContainerInterface
      */
-    protected function container(ContainerInterface $container)
+    protected function container(ContainerInterface $container) : ContainerInterface
     {
         if ($container instanceof ServiceLocatorAwareInterface) {
             $container = $container->getServiceLocator();
@@ -113,7 +111,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
         return $this($serviceLocator, $this->validatorClass, $this->creationOptions);
     }
 
-    public function setCreationOptions(array $options)
+    public function setCreationOptions(array $options) : void
     {
         $this->creationOptions = $options;
     }

--- a/src/DoctrineModule/Validator/Service/Exception/ServiceCreationException.php
+++ b/src/DoctrineModule/Validator/Service/Exception/ServiceCreationException.php
@@ -1,14 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator\Service\Exception;
 
 use RuntimeException as BaseRuntimeException;
 
 /**
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   1.3.0
- * @author  Fabian Grutschus <f.grutschus@lubyte.de>
  */
 class ServiceCreationException extends BaseRuntimeException
 {

--- a/src/DoctrineModule/Validator/Service/Exception/ServiceCreationException.php
+++ b/src/DoctrineModule/Validator/Service/Exception/ServiceCreationException.php
@@ -6,9 +6,8 @@ namespace DoctrineModule\Validator\Service\Exception;
 
 use RuntimeException as BaseRuntimeException;
 
-/**
- * @link    http://www.doctrine-project.org/
- */
+// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming
 class ServiceCreationException extends BaseRuntimeException
 {
 }
+// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming

--- a/src/DoctrineModule/Validator/Service/NoObjectExistsFactory.php
+++ b/src/DoctrineModule/Validator/Service/NoObjectExistsFactory.php
@@ -14,8 +14,12 @@ use Interop\Container\ContainerInterface;
  */
 class NoObjectExistsFactory extends AbstractValidatorFactory
 {
+    /** @var string */
     protected $validatorClass = NoObjectExists::class;
 
+    /**
+     * {@inheritDoc}
+     */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);

--- a/src/DoctrineModule/Validator/Service/NoObjectExistsFactory.php
+++ b/src/DoctrineModule/Validator/Service/NoObjectExistsFactory.php
@@ -1,33 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator\Service;
 
-use Interop\Container\ContainerInterface;
 use DoctrineModule\Validator\NoObjectExists;
+use Interop\Container\ContainerInterface;
 
 /**
  * Factory for creating NoObjectExists instances
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   1.3.0
- * @author  Fabian Grutschus <f.grutschus@lubyte.de>
  */
 class NoObjectExistsFactory extends AbstractValidatorFactory
 {
     protected $validatorClass = NoObjectExists::class;
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);
 
         $repository = $this->getRepository($container, $options);
 
-        $validator = new NoObjectExists($this->merge($options, [
+        return new NoObjectExists($this->merge($options, [
             'object_repository' => $repository,
             'fields'            => $this->getFields($options),
         ]));
-
-        return $validator;
     }
 }

--- a/src/DoctrineModule/Validator/Service/ObjectExistsFactory.php
+++ b/src/DoctrineModule/Validator/Service/ObjectExistsFactory.php
@@ -14,8 +14,12 @@ use Interop\Container\ContainerInterface;
  */
 class ObjectExistsFactory extends AbstractValidatorFactory
 {
+    /** @var string */
     protected $validatorClass = ObjectExists::class;
 
+    /**
+     * {@inheritDoc}
+     */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);

--- a/src/DoctrineModule/Validator/Service/ObjectExistsFactory.php
+++ b/src/DoctrineModule/Validator/Service/ObjectExistsFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineModule\Validator\Service;
 
 use DoctrineModule\Validator\ObjectExists;
@@ -8,26 +10,21 @@ use Interop\Container\ContainerInterface;
 /**
  * Factory for creating ObjectExists instances
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @since   1.3.0
- * @author  Fabian Grutschus <f.grutschus@lubyte.de>
  */
 class ObjectExistsFactory extends AbstractValidatorFactory
 {
     protected $validatorClass = ObjectExists::class;
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);
 
         $repository = $this->getRepository($container, $options);
 
-        $validator = new ObjectExists($this->merge($options, [
+        return new ObjectExists($this->merge($options, [
             'object_repository' => $repository,
             'fields'            => $this->getFields($options),
         ]));
-
-        return $validator;
     }
 }

--- a/src/DoctrineModule/Validator/Service/UniqueObjectFactory.php
+++ b/src/DoctrineModule/Validator/Service/UniqueObjectFactory.php
@@ -9,8 +9,12 @@ use Interop\Container\ContainerInterface;
 
 class UniqueObjectFactory extends AbstractValidatorFactory
 {
+    /** @var string */
     protected $validatorClass = UniqueObject::class;
 
+    /**
+     * {@inheritDoc}
+     */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);

--- a/src/DoctrineModule/Validator/Service/UniqueObjectFactory.php
+++ b/src/DoctrineModule/Validator/Service/UniqueObjectFactory.php
@@ -1,28 +1,27 @@
 <?php
 
+declare(strict_types=1);
 
 namespace DoctrineModule\Validator\Service;
 
-use Interop\Container\ContainerInterface;
 use DoctrineModule\Validator\UniqueObject;
+use Interop\Container\ContainerInterface;
 
 class UniqueObjectFactory extends AbstractValidatorFactory
 {
     protected $validatorClass = UniqueObject::class;
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $container = $this->container($container);
 
-        $useContext = isset($options['use_context']) ? (boolean) $options['use_context'] : false;
+        $useContext = isset($options['use_context']) ? (bool) $options['use_context'] : false;
 
-        $validator = new UniqueObject($this->merge($options, [
+        return new UniqueObject($this->merge($options, [
             'object_manager'    => $this->getObjectManager($container, $options),
             'use_context'       => $useContext,
             'object_repository' => $this->getRepository($container, $options),
             'fields'            => $this->getFields($options),
         ]));
-
-        return $validator;
     }
 }

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -16,8 +16,6 @@ use function sprintf;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields only once.
- *
- * @link    http://www.doctrine-project.org/
  */
 class UniqueObject extends ObjectExists
 {
@@ -26,8 +24,8 @@ class UniqueObject extends ObjectExists
      */
     public const ERROR_OBJECT_NOT_UNIQUE = 'objectNotUnique';
 
-    /** @var mixed[] */
     // phpcs:disable
+    /** @var mixed[] */
     protected $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
     // phpcs:enable
 

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -26,8 +26,10 @@ class UniqueObject extends ObjectExists
      */
     public const ERROR_OBJECT_NOT_UNIQUE = 'objectNotUnique';
 
-    /** @var array Message templates */
+    /** @var mixed[] */
+    // phpcs:disable
     protected $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
+    // phpcs:enable
 
     /** @var ObjectManager */
     protected $objectManager;
@@ -38,7 +40,7 @@ class UniqueObject extends ObjectExists
     /***
      * Constructor
      *
-     * @param array $options required keys are `object_repository`, which must be an instance of
+     * @param mixed[] $options required keys are `object_repository`, which must be an instance of
      *                       Doctrine\Common\Persistence\ObjectRepository, `object_manager`, which
      *                       must be an instance of Doctrine\Common\Persistence\ObjectManager,
      *                       and `fields`, with either a string or an array of strings representing
@@ -77,8 +79,8 @@ class UniqueObject extends ObjectExists
     /**
      * Returns false if there is another object with the same field values but other identifiers.
      *
-     * @param  mixed $value
-     * @param  mexed $context
+     * @param mixed $value
+     * @param mixed $context
      */
     public function isValid($value, $context = null) : bool
     {
@@ -108,7 +110,7 @@ class UniqueObject extends ObjectExists
     /**
      * Gets the identifiers from the matched object.
      *
-     * @return array
+     * @return mixed[]
      *
      * @throws Exception\RuntimeException
      */
@@ -122,9 +124,9 @@ class UniqueObject extends ObjectExists
     /**
      * Gets the identifiers from the context.
      *
-     * @param  array|object $context
+     * @param  mixed[]|object $context
      *
-     * @return array
+     * @return mixed[]
      *
      * @throws Exception\RuntimeException
      */
@@ -157,7 +159,7 @@ class UniqueObject extends ObjectExists
     }
 
     /**
-     * @return array the names of the identifiers
+     * @return mixed[] the names of the identifiers
      */
     protected function getIdentifiers() : array
     {

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -24,10 +24,10 @@ class UniqueObject extends ObjectExists
      */
     public const ERROR_OBJECT_NOT_UNIQUE = 'objectNotUnique';
 
-    // phpcs:disable
+    // phpcs:disable Generic.Files.LineLength
     /** @var mixed[] */
     protected $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
-    // phpcs:enable
+    // phpcs:enable Generic.Files.LineLength
 
     /** @var ObjectManager */
     protected $objectManager;

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -78,9 +78,9 @@ class UniqueObject extends ObjectExists
      * Returns false if there is another object with the same field values but other identifiers.
      *
      * @param  mixed $value
-     * @param  array $context
+     * @param  mexed $context
      */
-    public function isValid($value, ?array $context = null) : bool
+    public function isValid($value, $context = null) : bool
     {
         if (! $this->useContext) {
             $context = (array) $value;

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -22,7 +22,7 @@ class ObjectRepositoryTest extends BaseTestCase
             'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
         );
         $this->expectExceptionMessage(
-            'Provided $identityProperty is invalid, boolean given'
+            'Provided $identityProperty is invalid, string given'
         );
 
         new ObjectRepositoryAdapter(['identity_property' => false]);
@@ -34,7 +34,7 @@ class ObjectRepositoryTest extends BaseTestCase
             'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
         );
         $this->expectExceptionMessage(
-            'Provided $credentialProperty is invalid, boolean given'
+            'Provided $credentialProperty is invalid, string given'
         );
         new ObjectRepositoryAdapter(['credential_property' => false]);
     }

--- a/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
+++ b/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
@@ -39,7 +39,7 @@ class DoctrineCacheStorageTest extends TestCase
      */
     protected $phpDatatypes = ['NULL', 'boolean', 'integer', 'double', 'string', 'array', 'object', 'resource'];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->options = new AdapterOptions();
         // @todo fix constructor as it is messy
@@ -57,7 +57,7 @@ class DoctrineCacheStorageTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         // be sure the error handler has been stopped
         if (ErrorHandler::started()) {

--- a/tests/DoctrineModuleTest/Controller/CliControllerTest.php
+++ b/tests/DoctrineModuleTest/Controller/CliControllerTest.php
@@ -21,7 +21,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->setApplicationConfig(ServiceManagerFactory::getConfiguration());
         parent::setUp();

--- a/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
@@ -28,7 +28,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->element = new ObjectMultiCheckbox();

--- a/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
@@ -19,7 +19,7 @@ class ObjectRadioTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->element = new ObjectRadio();

--- a/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
@@ -28,7 +28,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->element = new ObjectSelect();

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -30,7 +30,7 @@ class ProxyTest extends TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->proxy = new Proxy;
@@ -258,13 +258,13 @@ class ProxyTest extends TestCase
         $this->prepareProxy();
 
         $this->expectException(
-            'InvalidArgumentException'
+            'TypeError'
         );
         $this->expectExceptionMessage(
-            'Property "label_generator" needs to be a callable function or a \Closure'
+            'Argument 1 passed to DoctrineModule\Form\Element\Proxy::setLabelGenerator() must be callable'
         );
 
-        $this->proxy->setOptions(['label_generator' => 'I throw an InvalidArgumentException']);
+        $this->proxy->setOptions(['label_generator' => 'I throw an invalid type error']);
     }
 
     public function testUsingOptionAttributesOfTypeString()

--- a/tests/DoctrineModuleTest/ModuleTest.php
+++ b/tests/DoctrineModuleTest/ModuleTest.php
@@ -35,7 +35,7 @@ class ModuleTest extends TestCase
      */
     private $cli;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->application    = $this->getMockBuilder('Laminas\Mvc\Application')
             ->disableOriginalConstructor()

--- a/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
+++ b/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
@@ -26,7 +26,7 @@ class SymfonyCliTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->route = new SymfonyCli(new Application());
     }

--- a/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
@@ -23,7 +23,7 @@ class CollectionAdapterTest extends TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->adapter = new CollectionAdapter(new ArrayCollection(range(1, 101)));

--- a/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
@@ -22,7 +22,7 @@ class ModuleDefinedServicesTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->serviceManager = ServiceManagerFactory::getServiceManager();
     }

--- a/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
@@ -27,7 +27,7 @@ class NoObjectExistsFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->object = new NoObjectExistsFactory;
     }

--- a/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
@@ -25,7 +25,7 @@ class ObjectExistsFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->object = new ObjectExistsFactory;
     }

--- a/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
@@ -25,7 +25,7 @@ class UniqueObjectFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->object = new UniqueObjectFactory;
     }

--- a/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
+++ b/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
@@ -312,10 +312,6 @@ class UniqueObjectTest extends BaseTestCase
         $context     = new stdClass();
         $context->id = 'identifier';
 
-#        $context = [
-#            'id' => 'identifier'
-#        ];
-
         $match = new stdClass();
 
         $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');

--- a/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
+++ b/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
@@ -312,6 +312,10 @@ class UniqueObjectTest extends BaseTestCase
         $context     = new stdClass();
         $context->id = 'identifier';
 
+#        $context = [
+#            'id' => 'identifier'
+#        ];
+
         $match = new stdClass();
 
         $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');


### PR DESCRIPTION
This PR upgrades phpunit and phpcs and adds the Doctrine Coding Standard.

phpcs passes with the Doctrine standard.  

In making the many changes to make phpcs pass everything that was 
```
/**
 * @param array $something
```

became
```
/**
 * @param mixed[] $something
```

To research the origin of data for each array would be over taxing.  