### PR TITLE
Update old Zend Framework links in the docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -123,9 +123,9 @@ class Module
 }
 ```
 
-Please note that I am using here a ``Laminas\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Laminas\Authentication\AuthenticationService`` will allow it to be recognised by the Laminas [Identity view helper](https://framework.zend.com/manual/2.4/en/modules/zend.view.helpers.identity.html).
+Please note that I am using here a ``Laminas\Authentication\AuthenticationService`` name, but it can be anything else (``my_auth_service``…). However, using the name ``Laminas\Authentication\AuthenticationService`` will allow it to be recognised by the Laminas [Identity view helper](https://docs.laminas.dev/laminas-view/helpers/identity/).
 
-In ZF3, you can inject the ``Laminas\Authentication\AuthenticationService`` into your controller factories as in the example below:
+In Laminas, you can inject the ``Laminas\Authentication\AuthenticationService`` into your controller factories as in the example below:
 
 ```php
 <?php
@@ -146,7 +146,7 @@ class ApplicationControllerFactory implements FactoryInterface
 
 #### Using the AuthenticationService
 
-Now that we have defined how to create a `Laminas\Authentication\AuthenticationService` object we can use it in our code. For more information about Laminas authentication mechanisms please read [the ZF 2 Authentication's documentation](http://framework.zend.com/manual/2.4/en/modules/zend.authentication.intro.html).
+Now that we have defined how to create a `Laminas\Authentication\AuthenticationService` object we can use it in our code. For more information about Laminas authentication mechanisms please read [the laminas-authentication documentation](https://docs.laminas.dev/laminas-authentication/).
 
 Here is an example of how we could use it from a controller action (we stripped any Form things for simplicity):
 
@@ -173,7 +173,7 @@ public function loginAction()
 }
 ```
 
-Instead of ZF2, you can do like this in ZF3:
+Instead of Zend Framework 2, you can do like this in Zend Framework 3 and Laminas:
 
 ```php
 
@@ -227,7 +227,7 @@ The authentication storage will automatically handle the conversion from saved d
 
 #### View helper and controller helper
 
-You may also need to know if there is an authenticated user within your other controllers or in views. ZF2 provides a controller plugin and a view helper you may use.
+You may also need to know if there is an authenticated user within your other controllers or in views. Laminas provides a controller plugin and a view helper you may use.
 
 Here is how you use it in your controller :
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,3 @@ class Module
     }
 }
 ```
-
-This is not the suggested way of attaching new commands to the CLI, since ZF2 comes
-already with console support.

--- a/docs/paginator.md
+++ b/docs/paginator.md
@@ -29,7 +29,7 @@ $paginator->setCurrentPageNumber(1)
 // Pass it to the view, and use it like a "standard" Laminas paginator
 ```
 
-For more information about Laminas Paginator, please read the [Laminas Paginator documentation](http://framework.zend.com/manual/2.0/en/modules/zend.paginator.introduction.html).
+For more information about Laminas paginator, please read the [laminas-paginator documentation](https://docs.laminas.dev/laminas-paginator/).
 
 ### Selectable adapter
 
@@ -77,4 +77,4 @@ $paginator->setCurrentPageNumber(1)
 // Pass it to the view, and use it like a "standard" Laminas paginator
 ```
 
-For more information about Laminas Paginator, please read the [Laminas Paginator documentation](http://framework.zend.com/manual/2.3/en/modules/zend.paginator.introduction.html).
+For more information about Laminas paginator, please read the [laminas-paginator documentation](https://docs.laminas.dev/laminas-paginator/).


### PR DESCRIPTION
Since laminas-console and laminas-mvc-console components are deprecated,
they are removed from cli.md. There are still some outdated code
examples in authentication.md.