### PR TITLE
Ignore the .phpunit.result.cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 nbproject/
 composer.lock
 .DS_Store
+.phpunit.result.cache


### PR DESCRIPTION
PHPUnit 8 enabled the result cache by default.