### PR TITLE
Address deprecations from persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "doctrine/cache": "^1.7",
         "doctrine/common": "^2.8",
         "doctrine/doctrine-laminas-hydrator": "^2.0.2",
+        "doctrine/persistence": "^1.3.7",
         "laminas/laminas-authentication": "^2.5.3",
         "laminas/laminas-cache": "^2.7.1",
         "laminas/laminas-form": "^2.11",

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -35,7 +35,7 @@ return [
 
 Here are some explanations about the keys:
 
-* the `object_manager` key can either be a concrete instance of a `Doctrine\Common\Persistence\ObjectManager` or a single string that will fetched from the Service Manager in order to get a concrete instance. If you are using DoctrineORMModule, you can simply write 'Doctrine\ORM\EntityManager' (as the EntityManager implements the class `Doctrine\Common\Persistence\ObjectManager`).
+* the `object_manager` key can either be a concrete instance of a `Doctrine\Persistence\ObjectManager` or a single string that will fetched from the Service Manager in order to get a concrete instance. If you are using DoctrineORMModule, you can simply write 'Doctrine\ORM\EntityManager' (as the EntityManager implements the class `Doctrine\Persistence\ObjectManager`).
 * the `identity_class` contains the FQCN of the entity that will be used during the authentication process.
 * the `identity_property` contains the name of the property that will be used as the identity property (most often, this is email, username…). Please note that we are talking here of the PROPERTY, not the table column name (although it can be the same in most of the cases).
 * the `credential_property` contains the name of the property that will be used as the credential property (most often, this is password…).

--- a/docs/form-element.md
+++ b/docs/form-element.md
@@ -20,7 +20,7 @@ namespace Module\Form;
 
 use Laminas\Form\Form;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 class MyForm extends Form implements ObjectManagerAwareInterface
 {

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Form\Element;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Inflector\Inflector;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use Laminas\Stdlib\Guard\ArrayOrTraversableGuardTrait;
 use ReflectionMethod;
@@ -20,6 +20,7 @@ use function count;
 use function current;
 use function get_class;
 use function gettype;
+use function interface_exists;
 use function is_callable;
 use function is_object;
 use function is_string;
@@ -588,3 +589,5 @@ class Proxy implements ObjectManagerAwareInterface
         $this->valueOptions = $options;
     }
 }
+
+interface_exists(ObjectManager::class);

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Options;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Laminas\Authentication\Adapter\Exception;
 use Laminas\Authentication\Storage\StorageInterface;
 use Laminas\Stdlib\AbstractOptions;
 use function gettype;
+use function interface_exists;
 use function is_callable;
 use function is_string;
 use function sprintf;
@@ -264,3 +265,6 @@ class Authentication extends AbstractOptions
         $this->storage = $storage;
     }
 }
+
+interface_exists(ClassMetadata::class);
+interface_exists(ObjectRepository::class);

--- a/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
+++ b/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Persistence;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
+use function interface_exists;
 
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
 interface ObjectManagerAwareInterface
@@ -21,3 +22,5 @@ interface ObjectManagerAwareInterface
      */
     public function getObjectManager() : ObjectManager;
 }
+
+interface_exists(ObjectManager::class);

--- a/src/DoctrineModule/Persistence/ProvidesObjectManager.php
+++ b/src/DoctrineModule/Persistence/ProvidesObjectManager.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Persistence;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
+use function interface_exists;
 
 /**
  * Trait to provide object manager to a form (only works from PHP 5.4)
@@ -30,3 +31,5 @@ trait ProvidesObjectManager
         return $this->objectManager;
     }
 }
+
+interface_exists(ObjectManager::class);

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace DoctrineModule\Service;
 
 use Doctrine\Common\Annotations;
-use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
-use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
+use Doctrine\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Options\Driver as DriverOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function class_exists;
 use function get_class;
+use function interface_exists;
 use function is_array;
 use function is_subclass_of;
 use function sprintf;
@@ -72,8 +73,8 @@ class DriverFactory extends AbstractFactory
         $paths = $options->getPaths();
 
         // Special options for AnnotationDrivers.
-        if ($class === 'Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver'
-            || is_subclass_of($class, 'Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver')
+        if ($class === 'Doctrine\Persistence\Mapping\Driver\AnnotationDriver'
+            || is_subclass_of($class, 'Doctrine\Persistence\Mapping\Driver\AnnotationDriver')
         ) {
             $reader = new Annotations\AnnotationReader();
             $reader = new Annotations\CachedReader(
@@ -88,7 +89,7 @@ class DriverFactory extends AbstractFactory
         if ($options->getExtension() && $driver instanceof FileDriver) {
             $locator = $driver->getLocator();
 
-            if (get_class($locator) !== 'Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator') {
+            if (get_class($locator) !== 'Doctrine\Persistence\Mapping\Driver\DefaultFileLocator') {
                 throw new InvalidArgumentException(
                     sprintf(
                         'Discovered file locator for driver of type "%s" is an instance of "%s". This factory '
@@ -123,3 +124,5 @@ class DriverFactory extends AbstractFactory
         return $driver;
     }
 }
+
+interface_exists(MappingDriver::class);

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Validator;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception;
@@ -51,7 +51,7 @@ class ObjectExists extends AbstractValidator
      * Constructor
      *
      * @param mixed[] $options required keys are `object_repository`, which must be an instance of
-     *                       Doctrine\Common\Persistence\ObjectRepository, and `fields`, with either
+     *                       Doctrine\Persistence\ObjectRepository, and `fields`, with either
      *                       a string or an array of strings representing the fields to be matched by the validator.
      *
      * @throws Exception\InvalidArgumentException
@@ -72,7 +72,7 @@ class ObjectExists extends AbstractValidator
             throw new Exception\InvalidArgumentException(
                 sprintf(
                     'Option "object_repository" is required and must be an instance of'
-                    . ' Doctrine\Common\Persistence\ObjectRepository, %s given',
+                    . ' Doctrine\Persistence\ObjectRepository, %s given',
                     $provided
                 )
             );

--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Validator\Service;
 
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use DoctrineModule\Validator\Service\Exception\ServiceCreationException;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
@@ -126,3 +126,6 @@ abstract class AbstractValidatorFactory implements FactoryInterface
         $this->creationOptions = $options;
     }
 }
+
+interface_exists(ObjectManager::class);
+interface_exists(ObjectRepository::class);

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Validator;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Laminas\Validator\Exception;
 use function array_diff_assoc;
 use function array_key_exists;
@@ -39,8 +39,8 @@ class UniqueObject extends ObjectExists
      * Constructor
      *
      * @param mixed[] $options required keys are `object_repository`, which must be an instance of
-     *                       Doctrine\Common\Persistence\ObjectRepository, `object_manager`, which
-     *                       must be an instance of Doctrine\Common\Persistence\ObjectManager,
+     *                       Doctrine\Persistence\ObjectRepository, `object_manager`, which
+     *                       must be an instance of Doctrine\Persistence\ObjectManager,
      *                       and `fields`, with either a string or an array of strings representing
      *                       the fields to be matched by the validator.
      *
@@ -64,7 +64,7 @@ class UniqueObject extends ObjectExists
             throw new Exception\InvalidArgumentException(
                 sprintf(
                     'Option "object_manager" is required and must be an instance of'
-                    . ' Doctrine\Common\Persistence\ObjectManager, %s given',
+                    . ' Doctrine\Persistence\ObjectManager, %s given',
                     $provided
                 )
             );

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -50,7 +50,7 @@ class ObjectRepositoryTest extends BaseTestCase
         );
         $adapter = new ObjectRepositoryAdapter();
         $adapter->setOptions([
-            'object_manager' => $this->createMock('Doctrine\Common\Persistence\ObjectManager'),
+            'object_manager' => $this->createMock('Doctrine\Persistence\ObjectManager'),
             'identity_class' => 'DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject',
         ]);
         $adapter->setCredential('a credential');
@@ -67,7 +67,7 @@ class ObjectRepositoryTest extends BaseTestCase
         );
         $adapter = new ObjectRepositoryAdapter();
         $adapter->setOptions([
-            'object_manager' => $this->createMock('Doctrine\Common\Persistence\ObjectManager'),
+            'object_manager' => $this->createMock('Doctrine\Persistence\ObjectManager'),
             'identity_class' => 'DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject',
         ]);
 
@@ -85,7 +85,7 @@ class ObjectRepositoryTest extends BaseTestCase
         );
         $adapter = new ObjectRepositoryAdapter();
         $adapter->setOptions([
-            'object_manager'      => $this->createMock('Doctrine\Common\Persistence\ObjectManager'),
+            'object_manager'      => $this->createMock('Doctrine\Persistence\ObjectManager'),
             'identity_class'      => 'DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject',
             'credential_callable' => [],
         ]);
@@ -99,14 +99,14 @@ class ObjectRepositoryTest extends BaseTestCase
         $entity->setUsername('a username');
         $entity->setPassword('a password');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $method           = $objectRepository
             ->expects($this->exactly(2))
             ->method('findOneBy')
             ->with($this->equalTo(['username' => 'a username']))
             ->will($this->returnValue($entity));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->exactly(2))
                       ->method('getRepository')
                       ->with($this->equalTo('DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject'))
@@ -144,7 +144,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $entity->username = 'a username';
         $entity->password = 'a password';
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $method           = $objectRepository
             ->expects($this->exactly(2))
             ->method('findOneBy')
@@ -176,7 +176,7 @@ class ObjectRepositoryTest extends BaseTestCase
     {
         $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository
             ->expects($this->once())
             ->method('findOneBy')
@@ -203,7 +203,7 @@ class ObjectRepositoryTest extends BaseTestCase
         // Crypt password using Blowfish
         $entity->setPassword(crypt('password', $hash));
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository
             ->expects($this->exactly(2))
             ->method('findOneBy')
@@ -238,7 +238,7 @@ class ObjectRepositoryTest extends BaseTestCase
     {
         $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository
             ->expects($this->once())
             ->method('findOneBy')
@@ -260,7 +260,7 @@ class ObjectRepositoryTest extends BaseTestCase
 
     public function testWillNotCastAuthCredentialValue()
     {
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $adapter          = new ObjectRepositoryAdapter();
         $entity           = new IdentityObject();
 

--- a/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
@@ -23,13 +23,13 @@ class ObjectRepositoryTest extends BaseTestCase
         $entity->setUsername('a username');
         $entity->setPassword('a password');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository->expects($this->exactly(1))
                          ->method('find')
                          ->with($this->equalTo('a username'))
                          ->will($this->returnValue($entity));
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata->expects($this->exactly(1))
                  ->method('getIdentifierValues')
                  ->with($this->equalTo($entity))

--- a/tests/DoctrineModuleTest/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyAwareElementTestCase.php
@@ -33,7 +33,7 @@ class ProxyAwareElementTestCase extends TestCase
         $result       = new ArrayCollection([$objectOne, $objectTwo]);
         $this->values = $result;
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata
             ->expects($this->any())
             ->method('getIdentifierValues')
@@ -54,12 +54,12 @@ class ProxyAwareElementTestCase extends TestCase
                 )
             );
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository->expects($this->any())
             ->method('findAll')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 class ProxyTest extends TestCase
 {
     /**
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @var \Doctrine\Persistence\Mapping\ClassMetadata
      */
     protected $metadata;
 
@@ -51,7 +51,7 @@ class ProxyTest extends TestCase
         $this->expectExceptionMessage('No target class was set');
 
         $this->proxy->setOptions([
-            'object_manager' => $this->createMock('Doctrine\Common\Persistence\ObjectManager'),
+            'object_manager' => $this->createMock('Doctrine\Persistence\ObjectManager'),
         ]);
         $this->proxy->getValueOptions();
     }
@@ -62,9 +62,9 @@ class ProxyTest extends TestCase
         $this->expectExceptionMessage('No method name was set');
 
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
-        $metadata    = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata    = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->once())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -82,11 +82,11 @@ class ProxyTest extends TestCase
     public function testExceptionFindMethodNameNotExistentInRepository()
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
-        $metadata    = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata    = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->once())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -116,11 +116,11 @@ class ProxyTest extends TestCase
     public function testExceptionThrownForMissingRequiredParameter()
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
-        $metadata    = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata    = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->once())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -540,7 +540,7 @@ class ProxyTest extends TestCase
 
         $result = new ArrayCollection([$objectOne, $objectTwo]);
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata
             ->expects($this->any())
             ->method('getIdentifierValues')
@@ -561,12 +561,12 @@ class ProxyTest extends TestCase
                 )
             );
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository->expects($this->any())
             ->method('findAll')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -619,7 +619,7 @@ class ProxyTest extends TestCase
 
         $result = new ArrayCollection([$objectOne, $objectTwo, $objectThree]);
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata
             ->expects($this->any())
             ->method('getIdentifierValues')
@@ -642,12 +642,12 @@ class ProxyTest extends TestCase
                 )
             );
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository->expects($this->any())
             ->method('findAll')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -690,7 +690,7 @@ class ProxyTest extends TestCase
 
         $result = new ArrayCollection([$objectOne, $objectTwo]);
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata
             ->expects($this->any())
             ->method('getIdentifierValues')
@@ -711,12 +711,12 @@ class ProxyTest extends TestCase
                 )
             );
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository->expects($this->any())
             ->method('findAll')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
             ->with($this->equalTo($objectClass))
@@ -758,7 +758,7 @@ class ProxyTest extends TestCase
 
         $result = new ArrayCollection([$objectOne, $objectTwo]);
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $metadata
             ->expects($this->exactly(2))
             ->method('getIdentifierValues')
@@ -778,13 +778,13 @@ class ProxyTest extends TestCase
                 )
             );
 
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $objectRepository
             ->expects($this->once())
             ->method('findBy')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager
             ->expects($this->once())
             ->method('getClassMetadata')
@@ -818,15 +818,15 @@ class ProxyTest extends TestCase
         }
 
         $objectClass      = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
-        $metadata         = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $objectRepository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $metadata         = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
+        $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         $objectRepository
             ->expects($this->once())
             ->method('findAll')
             ->will($this->returnValue($result));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager
             ->expects($this->once())
             ->method('getClassMetadata')

--- a/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
@@ -13,7 +13,7 @@ class AdapterFactoryTest extends BaseTestCase
 
         $name           = 'testFactory';
         $factory        = new AdapterFactory($name);
-        $objectManager  = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager  = $this->createMock('Doctrine\Persistence\ObjectManager');
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
             'config',

--- a/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -16,7 +16,7 @@ class AuthenticationServiceFactoryTest extends BaseTestCase
         $name    = 'testFactory';
         $factory = new AuthenticationServiceFactory($name);
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $serviceManager = new ServiceManager();
         $serviceManager->setService(

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -13,7 +13,7 @@ class StorageFactoryTest extends BaseTestCase
         $name    = 'testFactory';
         $factory = new StorageFactory($name);
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $serviceManager = new ServiceManager();
         $serviceManager->setInvokableClass(

--- a/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
@@ -44,7 +44,7 @@ class DriverFactoryTest extends BaseTestCase
                             'class' => 'DoctrineModuleTest\Service\Mock\MetadataDriverMock',
                         ],
                         'testChainDriver' => [
-                            'class' => 'Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain',
+                            'class' => 'Doctrine\Persistence\Mapping\Driver\MappingDriverChain',
                             'drivers' => [
                                 'Foo\Bar' => 'testDriver',
                                 'Foo\Baz' => null,
@@ -57,7 +57,7 @@ class DriverFactoryTest extends BaseTestCase
 
         $factory = new DriverFactory('testChainDriver');
         $driver  = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain', $driver);
+        $this->assertInstanceOf('Doctrine\Persistence\Mapping\Driver\MappingDriverChain', $driver);
         $drivers = $driver->getDrivers();
         $this->assertCount(1, $drivers);
         $this->assertArrayHasKey('Foo\Bar', $drivers);

--- a/tests/DoctrineModuleTest/Service/Mock/MetadataDriverMock.php
+++ b/tests/DoctrineModuleTest/Service/Mock/MetadataDriverMock.php
@@ -2,8 +2,8 @@
 
 namespace DoctrineModuleTest\Service\Mock;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 class MetadataDriverMock implements MappingDriver
 {

--- a/tests/DoctrineModuleTest/Validator/NoObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/NoObjectExistsTest.php
@@ -17,7 +17,7 @@ class NoObjectExistsTest extends BaseTestCase
 {
     public function testCanValidateWithNoAvailableObjectInRepository()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         $repository
             ->expects($this->once())
@@ -31,7 +31,7 @@ class NoObjectExistsTest extends BaseTestCase
 
     public function testCannotValidateWithAvailableObjectInRepository()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         $repository
             ->expects($this->once())
@@ -45,7 +45,7 @@ class NoObjectExistsTest extends BaseTestCase
 
     public function testErrorMessageIsStringInsteadArray()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('findOneBy')

--- a/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
@@ -19,7 +19,7 @@ class ObjectExistsTest extends BaseTestCase
 {
     public function testCanValidateWithSingleField()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         $repository
             ->expects($this->exactly(2))
@@ -35,7 +35,7 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testCanValidateWithMultipleFields()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->exactly(2))
             ->method('findOneBy')
@@ -60,7 +60,7 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testCanValidateFalseOnNoResult()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('findOneBy')
@@ -99,7 +99,7 @@ class ObjectExistsTest extends BaseTestCase
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
         ]);
     }
 
@@ -108,7 +108,7 @@ class ObjectExistsTest extends BaseTestCase
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
             'fields'            => [],
         ]);
     }
@@ -117,7 +117,7 @@ class ObjectExistsTest extends BaseTestCase
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
         new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
             'fields'            => [123],
         ]);
     }
@@ -131,7 +131,7 @@ class ObjectExistsTest extends BaseTestCase
             'Provided values count is 1, while expected number of fields to be matched is 2'
         );
         $validator = new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
             'fields'            => ['field1', 'field2'],
         ]);
         $validator->isValid(['field1Value']);
@@ -147,7 +147,7 @@ class ObjectExistsTest extends BaseTestCase
         );
 
         $validator = new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
             'fields'            => ['field1', 'field2'],
         ]);
 
@@ -156,9 +156,9 @@ class ObjectExistsTest extends BaseTestCase
 
     public function testErrorMessageIsStringInsteadArray()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $validator  = new ObjectExists([
-            'object_repository' => $this->createMock('Doctrine\Common\Persistence\ObjectRepository'),
+            'object_repository' => $this->createMock('Doctrine\Persistence\ObjectRepository'),
             'fields'            => 'field',
         ]);
 

--- a/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use DoctrineModule\Validator\NoObjectExists;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Interop\Container\ContainerInterface;
 
 /**

--- a/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
@@ -4,8 +4,8 @@ namespace DoctrineModule\Validator\Service;
 
 use PHPUnit\Framework\TestCase;
 use DoctrineModule\Validator\ObjectExists;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Interop\Container\ContainerInterface;
 
 /**

--- a/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
@@ -4,8 +4,8 @@ namespace DoctrineModule\Validator\Service;
 
 use PHPUnit\Framework\TestCase;
 use DoctrineModule\Validator\UniqueObject;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Interop\Container\ContainerInterface;
 
 /**

--- a/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
+++ b/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
@@ -17,14 +17,14 @@ class UniqueObjectTest extends BaseTestCase
 {
     public function testCanValidateWithNotAvailableObjectInRepository()
     {
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('findOneBy')
             ->with(['matchKey' => 'matchValue'])
             ->will($this->returnValue(null));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $validator = new UniqueObject([
             'object_repository' => $repository,
@@ -38,7 +38,7 @@ class UniqueObjectTest extends BaseTestCase
     {
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
@@ -49,13 +49,13 @@ class UniqueObjectTest extends BaseTestCase
             ->with($match)
             ->will($this->returnValue(['id' => 'identifier']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -78,7 +78,7 @@ class UniqueObjectTest extends BaseTestCase
     {
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
@@ -89,13 +89,13 @@ class UniqueObjectTest extends BaseTestCase
             ->with($match)
             ->will($this->returnValue(['id' => 'identifier']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -118,7 +118,7 @@ class UniqueObjectTest extends BaseTestCase
     {
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
@@ -129,13 +129,13 @@ class UniqueObjectTest extends BaseTestCase
             ->with($match)
             ->will($this->returnValue(['id' => 'identifier']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -162,14 +162,14 @@ class UniqueObjectTest extends BaseTestCase
 
         $match = new stdClass();
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('findOneBy')
             ->with(['matchKey' => 'matchValue'])
             ->will($this->returnValue($match));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $validator = new UniqueObject([
             'object_repository' => $repository,
@@ -187,19 +187,19 @@ class UniqueObjectTest extends BaseTestCase
 
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
             ->will($this->returnValue(['id']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -225,19 +225,19 @@ class UniqueObjectTest extends BaseTestCase
 
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
             ->will($this->returnValue(['id']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -260,9 +260,9 @@ class UniqueObjectTest extends BaseTestCase
     public function testThrowsAnExceptionOnMissingObjectManager()
     {
         $this->expectException(\Laminas\Validator\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Common\\Persistence\\ObjectManager, nothing given');
+        $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Persistence\\ObjectManager, nothing given');
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         new UniqueObject([
             'object_repository' => $repository,
@@ -273,11 +273,11 @@ class UniqueObjectTest extends BaseTestCase
     public function testThrowsAnExceptionOnWrongObjectManager()
     {
         $this->expectException(\Laminas\Validator\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Common\\Persistence\\ObjectManager, stdClass given');
+        $this->expectExceptionMessage('Option "object_manager" is required and must be an instance of Doctrine\\Persistence\\ObjectManager, stdClass given');
 
         $objectManager = new stdClass();
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         new UniqueObject([
             'object_repository' => $repository,
@@ -289,14 +289,14 @@ class UniqueObjectTest extends BaseTestCase
     public function testCanValidateWithNotAvailableObjectInRepositoryByDateTimeObject()
     {
         $date       = new \DateTime("17 March 2014");
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->once())
             ->method('findOneBy')
             ->with(['date' => $date])
             ->will($this->returnValue(null));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $validator = new UniqueObject([
             'object_repository' => $repository,
@@ -314,7 +314,7 @@ class UniqueObjectTest extends BaseTestCase
 
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->at(0))
             ->method('getIdentifierValues')
@@ -326,13 +326,13 @@ class UniqueObjectTest extends BaseTestCase
             ->with($match)
             ->will($this->returnValue(['id' => 'identifier']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
             ->with('stdClass')
             ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')
@@ -357,7 +357,7 @@ class UniqueObjectTest extends BaseTestCase
     {
         $match = new stdClass();
 
-        $classMetadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
         $classMetadata
             ->expects($this->once())
             ->method('getIdentifierFieldNames')
@@ -368,13 +368,13 @@ class UniqueObjectTest extends BaseTestCase
             ->with($match)
             ->will($this->returnValue(['id' => 'identifier']));
 
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Persistence\ObjectManager');
         $objectManager->expects($this->any())
                       ->method('getClassMetadata')
                       ->with('stdClass')
                       ->will($this->returnValue($classMetadata));
 
-        $repository = $this->createMock('Doctrine\Common\Persistence\ObjectRepository');
+        $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
             ->expects($this->any())
             ->method('getClassName')


### PR DESCRIPTION
A backwards-compatibility layer has been added to persistence to help
consumers move to the new namespacing. It is based on class aliases,
which means the type declaration changes should not be a BC-break: types
are the same.
See doctrine/persistence#71

This means:
- using the new namespaces
- adding autoload calls for new types to types that may be extended and
use persistence types in type declarations of non-constructor methods,
so that signature compatibility is recognized by old versions of php.
More details on this at
https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf