### PR TITLE
Authentication: Allow specification of session container/member

### DIFF
--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -115,11 +115,15 @@ class Authentication extends AbstractOptions
     protected $storage = 'DoctrineModule\Authentication\Storage\Session';
 
     /**
+     * Session container to use in the underlying session storage
+     *
      * @var string
      */
     protected $sessionContainer;
 
     /**
+     * Session member to use in the underlying session storage
+     *
      * @var string
      */
     protected $sessionMember;
@@ -275,25 +279,16 @@ class Authentication extends AbstractOptions
         $this->storage = $storage;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSessionContainer() : ?string
     {
         return $this->sessionContainer;
     }
 
-    /**
-     * @param string $container
-     */
     public function setSessionContainer(string $container) : void
     {
         $this->sessionContainer = $container;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSessionMember() : ?string
     {
         return $this->sessionMember;

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -110,9 +110,19 @@ class Authentication extends AbstractOptions
      * the option storeOnlyKeys == false, this is the storage instance that the whole
      * object will be stored in.
      *
-     * @var StorageInterface|string;
+     * @var StorageInterface
      */
     protected $storage = 'DoctrineModule\Authentication\Storage\Session';
+
+    /**
+     * @var string
+     */
+    protected $sessionContainer;
+
+    /**
+     * @var string
+     */
+    protected $sessionMember;
 
     /**
      * @param  string | ObjectManager $objectManager
@@ -263,6 +273,35 @@ class Authentication extends AbstractOptions
     public function setStorage($storage) : void
     {
         $this->storage = $storage;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSessionContainer() : ?string
+    {
+        return $this->sessionContainer;
+    }
+
+    /**
+     * @param string $container
+     */
+    public function setSessionContainer(string $container) : void
+    {
+        $this->sessionContainer = $container;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSessionMember() : ?string
+    {
+        return $this->sessionMember;
+    }
+
+    public function setSessionMember(string $member) : void
+    {
+        $this->sessionMember = $member;
     }
 }
 

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -110,7 +110,7 @@ class Authentication extends AbstractOptions
      * the option storeOnlyKeys == false, this is the storage instance that the whole
      * object will be stored in.
      *
-     * @var StorageInterface
+     * @var StorageInterface|string
      */
     protected $storage = 'DoctrineModule\Authentication\Storage\Session';
 

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Service\Authentication;
 use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
+use Laminas\Authentication\Storage\Session;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use function is_string;
 
@@ -31,7 +32,17 @@ class StorageFactory extends AbstractFactory
 
         $storage = $options->getStorage();
         if (is_string($storage)) {
-            $options->setStorage($container->get($storage));
+            $sessionContainer = $options->getSessionContainer();
+            $sessionMember = $options->getSessionMember();
+            if ($sessionContainer || $sessionMember) {
+                $storage = new Session(
+                    $options->getSessionContainer(),
+                    $options->getSessionMember()
+                );
+            } else {
+                $storage = $container->get($storage);
+            }
+            $options->setStorage($storage);
         }
 
         return new ObjectRepository($options);

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -33,7 +33,7 @@ class StorageFactory extends AbstractFactory
         $storage = $options->getStorage();
         if (is_string($storage)) {
             $sessionContainer = $options->getSessionContainer();
-            $sessionMember = $options->getSessionMember();
+            $sessionMember    = $options->getSessionMember();
             if ($sessionContainer || $sessionMember) {
                 $storage = new Session(
                     $options->getSessionContainer(),
@@ -42,6 +42,7 @@ class StorageFactory extends AbstractFactory
             } else {
                 $storage = $container->get($storage);
             }
+
             $options->setStorage($storage);
         }
 

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -72,7 +72,7 @@ class StorageFactoryTest extends BaseTestCase
         );
     }
 
-    public function testCanInstantiateCustomStorage()
+    public function testCanInstantiateCustomStorage() : void
     {
         // TODO: this
     }

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -71,4 +71,9 @@ class StorageFactoryTest extends BaseTestCase
             $factory->createService($serviceManager)
         );
     }
+
+    public function testCanInstantiateCustomStorage()
+    {
+        // TODO: this
+    }
 }


### PR DESCRIPTION
Hello,

This PR allows specifying the session container name and member to use in the underlying Session Storage instead of using the default. In case one of the new options are set, the StorageFactory creates a local instance of the Session Storage. Otherwise, it will retrieve the default aliased Session Storage `'DoctrineModule\Authentication\Storage\Session'`

The Session Storage instance wrapper (ObjectRepository) is still cached by service manager.