### PR TITLE
Fixes for Composer 2 for 4.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/console": "^5.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^7.0",
+        "doctrine/coding-standard": "^8.2",
         "laminas/laminas-i18n": "^2.7",
         "laminas/laminas-log": "^2.9",
         "laminas/laminas-modulemanager": "^2.8",

--- a/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Adapter/ObjectRepository.php
@@ -9,6 +9,7 @@ use DoctrineModule\Options\Authentication as AuthenticationOptions;
 use Laminas\Authentication\Adapter\AbstractAdapter;
 use Laminas\Authentication\Adapter\Exception;
 use Laminas\Authentication\Result as AuthenticationResult;
+
 use function call_user_func;
 use function get_class;
 use function method_exists;
@@ -45,7 +46,7 @@ class ObjectRepository extends AbstractAdapter
     /**
      * @param mixed[]|AuthenticationOptions $options
      */
-    public function setOptions($options) : self
+    public function setOptions($options): self
     {
         if (! $options instanceof AuthenticationOptions) {
             $options = new AuthenticationOptions($options);
@@ -56,12 +57,12 @@ class ObjectRepository extends AbstractAdapter
         return $this;
     }
 
-    public function getOptions() : AuthenticationOptions
+    public function getOptions(): AuthenticationOptions
     {
         return $this->options;
     }
 
-    public function authenticate() : AuthenticationResult
+    public function authenticate(): AuthenticationResult
     {
         $this->setup();
         $options  = $this->options;
@@ -85,7 +86,7 @@ class ObjectRepository extends AbstractAdapter
      *
      * @throws Exception\UnexpectedValueException
      */
-    protected function validateIdentity(object $identity) : AuthenticationResult
+    protected function validateIdentity(object $identity): AuthenticationResult
     {
         $credentialProperty = $this->options->getCredentialProperty();
         $getter             = 'get' . Inflector::classify($credentialProperty);
@@ -135,7 +136,7 @@ class ObjectRepository extends AbstractAdapter
      * @throws Exception\RuntimeException In the event that setup was not
      *                                    done properly throw exception.
      */
-    protected function setup() : void
+    protected function setup(): void
     {
         if ($this->identity === null) {
             throw new Exception\RuntimeException(
@@ -162,7 +163,7 @@ class ObjectRepository extends AbstractAdapter
      * Creates a Laminas\Authentication\Result object from the information that has been collected
      * during the authenticate() attempt.
      */
-    protected function createAuthenticationResult() : AuthenticationResult
+    protected function createAuthenticationResult(): AuthenticationResult
     {
         return new AuthenticationResult(
             $this->authenticationResultInfo['code'],

--- a/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
+++ b/src/DoctrineModule/Authentication/Storage/ObjectRepository.php
@@ -20,7 +20,7 @@ class ObjectRepository implements StorageInterface
     /**
      * @param mixed[]|AuthenticationOptions $options
      */
-    public function setOptions($options) : ObjectRepository
+    public function setOptions($options): ObjectRepository
     {
         if (! $options instanceof AuthenticationOptions) {
             $options = new AuthenticationOptions($options);
@@ -41,7 +41,7 @@ class ObjectRepository implements StorageInterface
         $this->setOptions($options);
     }
 
-    public function isEmpty() : bool
+    public function isEmpty(): bool
     {
         return $this->options->getStorage()->isEmpty();
     }
@@ -50,7 +50,7 @@ class ObjectRepository implements StorageInterface
      * This function assumes that the storage only contains identifier values (which is the case if
      * the ObjectRepository authentication adapter is used).
      */
-    public function read() : ?object
+    public function read(): ?object
     {
         $identity = $this->options->getStorage()->read();
         if ($identity) {
@@ -74,7 +74,7 @@ class ObjectRepository implements StorageInterface
     /**
      * @param mixed $identity
      */
-    public function write($identity) : void
+    public function write($identity): void
     {
         $metadataInfo     = $this->options->getClassMetadata();
         $identifierValues = $metadataInfo->getIdentifierValues($identity);
@@ -82,7 +82,7 @@ class ObjectRepository implements StorageInterface
         $this->options->getStorage()->write($identifierValues);
     }
 
-    public function clear() : void
+    public function clear(): void
     {
         $this->options->getStorage()->clear();
     }

--- a/src/DoctrineModule/Component/Console/Input/RequestInput.php
+++ b/src/DoctrineModule/Component/Console/Input/RequestInput.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Component\Console\Input;
 use Laminas\Console\Request;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
+
 use function is_numeric;
 
 /**

--- a/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
+++ b/src/DoctrineModule/Component/Console/Output/PropertyOutput.php
@@ -6,9 +6,11 @@ namespace DoctrineModule\Component\Console\Output;
 
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\Output;
+
 use function function_exists;
 use function getenv;
 use function posix_isatty;
+
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 use const STDOUT;
@@ -51,7 +53,7 @@ class PropertyOutput extends Output
         return $this->message;
     }
 
-    protected function hasColorSupport() : bool
+    protected function hasColorSupport(): bool
     {
         if (DIRECTORY_SEPARATOR === '\\') {
             return getenv('ANSICON') !== false || getenv('ConEmuANSI') === 'ON';

--- a/src/DoctrineModule/ConfigProvider.php
+++ b/src/DoctrineModule/ConfigProvider.php
@@ -14,7 +14,7 @@ class ConfigProvider
     /**
      * @return mixed[]
      */
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'doctrine' => $this->getDoctrineConfig(),
@@ -32,7 +32,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getDependencyConfig() : array
+    public function getDependencyConfig(): array
     {
     // phpcs:disable Generic.Files.LineLength
         return [
@@ -49,7 +49,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getControllerConfig() : array
+    public function getControllerConfig(): array
     {
         return [
             'factories' => ['DoctrineModule\Controller\Cli' => 'DoctrineModule\Service\CliControllerFactory'],
@@ -61,7 +61,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getRouteManagerConfig() : array
+    public function getRouteManagerConfig(): array
     {
         return [
             'factories' => ['symfony_cli' => 'DoctrineModule\Service\SymfonyCliRouteFactory'],
@@ -73,7 +73,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getConsoleConfig() : array
+    public function getConsoleConfig(): array
     {
         return [
             'router' => [
@@ -89,7 +89,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getDoctrineConfig() : array
+    public function getDoctrineConfig(): array
     {
         return [
             'cache' => [
@@ -171,7 +171,7 @@ class ConfigProvider
      *
      * @return mixed[]
      */
-    public function getDoctrineFactoryConfig() : array
+    public function getDoctrineFactoryConfig(): array
     {
         return [
             'cache'                 => 'DoctrineModule\Service\CacheFactory',
@@ -186,7 +186,7 @@ class ConfigProvider
     /**
      * @return mixed[]
      */
-    public function getValidatorConfig() : array
+    public function getValidatorConfig(): array
     {
         return [
             'aliases'   => [

--- a/src/DoctrineModule/Controller/CliController.php
+++ b/src/DoctrineModule/Controller/CliController.php
@@ -9,6 +9,7 @@ use Laminas\Mvc\Console\View\ViewModel;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use function is_numeric;
 
 /**
@@ -27,7 +28,7 @@ class CliController extends AbstractActionController
         $this->cliApplication = $cliApplication;
     }
 
-    public function setOutput(OutputInterface $output) : void
+    public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
     }

--- a/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
+++ b/src/DoctrineModule/Form/Element/ObjectMultiCheckbox.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Form\Element;
 use Laminas\Form\Element\MultiCheckbox;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
+
 use function array_map;
 use function is_array;
 
@@ -15,7 +16,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
     /** @var Proxy */
     protected $proxy;
 
-    public function getProxy() : Proxy
+    public function getProxy(): Proxy
     {
         if ($this->proxy === null) {
             $this->proxy = new Proxy();
@@ -27,7 +28,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
     /**
      * @param mixed $options
      */
-    public function setOptions($options) : self
+    public function setOptions($options): self
     {
         $this->getProxy()->setOptions($options);
 
@@ -38,7 +39,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
      * @param mixed $value
      * @param mixed $key
      */
-    public function setOption($key, $value) : self
+    public function setOption($key, $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/ObjectRadio.php
+++ b/src/DoctrineModule/Form/Element/ObjectRadio.php
@@ -12,7 +12,7 @@ class ObjectRadio extends RadioElement
     /** @var Proxy */
     protected $proxy;
 
-    public function getProxy() : Proxy
+    public function getProxy(): Proxy
     {
         if ($this->proxy === null) {
             $this->proxy = new Proxy();
@@ -26,7 +26,7 @@ class ObjectRadio extends RadioElement
      *
      * {@inheritDoc}
      */
-    public function setOptions($options) : self
+    public function setOptions($options): self
     {
         $this->getProxy()->setOptions($options);
 
@@ -38,7 +38,7 @@ class ObjectRadio extends RadioElement
      *
      * {@inheritDoc}
      */
-    public function setOption($key, $value) : self
+    public function setOption($key, $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/ObjectSelect.php
+++ b/src/DoctrineModule/Form/Element/ObjectSelect.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Form\Element;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
+
 use function array_map;
 use function is_array;
 
@@ -15,7 +16,7 @@ class ObjectSelect extends SelectElement
     /** @var Proxy */
     protected $proxy;
 
-    public function getProxy() : Proxy
+    public function getProxy(): Proxy
     {
         if ($this->proxy === null) {
             $this->proxy = new Proxy();
@@ -29,7 +30,7 @@ class ObjectSelect extends SelectElement
      *
      * {@inheritDoc}
      */
-    public function setOptions($options) : self
+    public function setOptions($options): self
     {
         $this->getProxy()->setOptions($options);
 
@@ -41,7 +42,7 @@ class ObjectSelect extends SelectElement
      *
      * {@inheritDoc}
      */
-    public function setOption($key, $value) : self
+    public function setOption($key, $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/DoctrineModule/Form/Element/Proxy.php
+++ b/src/DoctrineModule/Form/Element/Proxy.php
@@ -12,6 +12,7 @@ use Laminas\Stdlib\Guard\ArrayOrTraversableGuardTrait;
 use ReflectionMethod;
 use RuntimeException;
 use Traversable;
+
 use function array_change_key_case;
 use function array_key_exists;
 use function array_shift;
@@ -75,7 +76,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @param mixed[] $options
      */
-    public function setOptions(array $options) : void
+    public function setOptions(array $options): void
     {
         if (isset($options['object_manager'])) {
             $this->setObjectManager($options['object_manager']);
@@ -149,14 +150,14 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the label for the empty option
      */
-    public function setEmptyItemLabel(string $emptyItemLabel) : Proxy
+    public function setEmptyItemLabel(string $emptyItemLabel): Proxy
     {
         $this->emptyItemLabel = $emptyItemLabel;
 
         return $this;
     }
 
-    public function getEmptyItemLabel() : string
+    public function getEmptyItemLabel(): string
     {
         return $this->emptyItemLabel;
     }
@@ -164,7 +165,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @return mixed[]
      */
-    public function getOptionAttributes() : array
+    public function getOptionAttributes(): array
     {
         return $this->optionAttributes;
     }
@@ -172,7 +173,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @param mixed[] $optionAttributes
      */
-    public function setOptionAttributes(array $optionAttributes) : void
+    public function setOptionAttributes(array $optionAttributes): void
     {
         $this->optionAttributes = $optionAttributes;
     }
@@ -180,14 +181,14 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set a flag, whether to include the empty option at the beginning or not
      */
-    public function setDisplayEmptyItem(bool $displayEmptyItem) : Proxy
+    public function setDisplayEmptyItem(bool $displayEmptyItem): Proxy
     {
         $this->displayEmptyItem = $displayEmptyItem;
 
         return $this;
     }
 
-    public function getDisplayEmptyItem() : bool
+    public function getDisplayEmptyItem(): bool
     {
         return $this->displayEmptyItem;
     }
@@ -195,7 +196,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the object manager
      */
-    public function setObjectManager(ObjectManager $objectManager) : void
+    public function setObjectManager(ObjectManager $objectManager): void
     {
         $this->objectManager = $objectManager;
     }
@@ -203,7 +204,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Get the object manager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }
@@ -211,7 +212,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the FQCN of the target object
      */
-    public function setTargetClass(string $targetClass) : Proxy
+    public function setTargetClass(string $targetClass): Proxy
     {
         $this->targetClass = $targetClass;
 
@@ -221,7 +222,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Get the target class
      */
-    public function getTargetClass() : string
+    public function getTargetClass(): string
     {
         return $this->targetClass;
     }
@@ -229,7 +230,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set the property to use as the label in the options
      */
-    public function setProperty(string $property) : Proxy
+    public function setProperty(string $property): Proxy
     {
         $this->property = $property;
 
@@ -249,32 +250,32 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @param callable $callable A callable used to create a label based off of an Entity
      */
-    public function setLabelGenerator(callable $callable) : void
+    public function setLabelGenerator(callable $callable): void
     {
         $this->labelGenerator = $callable;
     }
 
-    public function getLabelGenerator() : ?callable
+    public function getLabelGenerator(): ?callable
     {
         return $this->labelGenerator;
     }
 
-    public function getOptgroupIdentifier() : ?string
+    public function getOptgroupIdentifier(): ?string
     {
         return $this->optgroupIdentifier;
     }
 
-    public function setOptgroupIdentifier(string $optgroupIdentifier) : void
+    public function setOptgroupIdentifier(string $optgroupIdentifier): void
     {
         $this->optgroupIdentifier = (string) $optgroupIdentifier;
     }
 
-    public function getOptgroupDefault() : ?string
+    public function getOptgroupDefault(): ?string
     {
         return $this->optgroupDefault;
     }
 
-    public function setOptgroupDefault(string $optgroupDefault) : void
+    public function setOptgroupDefault(string $optgroupDefault): void
     {
         $this->optgroupDefault = (string) $optgroupDefault;
     }
@@ -282,14 +283,14 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * Set if the property is a method to use as the label in the options
      */
-    public function setIsMethod(bool $method) : Proxy
+    public function setIsMethod(bool $method): Proxy
     {
         $this->isMethod = (bool) $method;
 
         return $this;
     }
 
-    public function getIsMethod() : ?bool
+    public function getIsMethod(): ?bool
     {
         return $this->isMethod;
     }
@@ -298,7 +299,7 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @param mixed[] $findMethod
      */
-    public function setFindMethod(array $findMethod) : Proxy
+    public function setFindMethod(array $findMethod): Proxy
     {
         $this->findMethod = $findMethod;
 
@@ -310,7 +311,7 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @return mixed[]
      */
-    public function getFindMethod() : array
+    public function getFindMethod(): array
     {
         return $this->findMethod;
     }
@@ -318,7 +319,7 @@ class Proxy implements ObjectManagerAwareInterface
     /**
      * @param mixed $targetEntity
      */
-    protected function generateLabel($targetEntity) : ?string
+    protected function generateLabel($targetEntity): ?string
     {
         if ($this->getLabelGenerator() === null) {
             return null;
@@ -379,7 +380,7 @@ class Proxy implements ObjectManagerAwareInterface
      * @throws RuntimeException
      * @throws Exception\InvalidRepositoryResultException
      */
-    protected function loadObjects() : void
+    protected function loadObjects(): void
     {
         if (! empty($this->objects)) {
             return;
@@ -448,7 +449,7 @@ class Proxy implements ObjectManagerAwareInterface
      *
      * @throws RuntimeException
      */
-    protected function loadValueOptions() : void
+    protected function loadValueOptions(): void
     {
         if (! $this->objectManager) {
             throw new RuntimeException('No object manager was set');
@@ -474,7 +475,8 @@ class Proxy implements ObjectManagerAwareInterface
                 $label = $generatedLabel;
             } elseif ($this->property) {
                 $property = $this->property;
-                if (($this->getIsMethod() === false || $this->getIsMethod() === null)
+                if (
+                    ($this->getIsMethod() === false || $this->getIsMethod() === null)
                     && ! $metadata->hasField($property)
                 ) {
                     throw new RuntimeException(

--- a/src/DoctrineModule/Module.php
+++ b/src/DoctrineModule/Module.php
@@ -14,6 +14,7 @@ use Laminas\ModuleManager\Feature\InitProviderInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Symfony\Component\Console\Input\StringInput;
+
 use function class_exists;
 
 /**

--- a/src/DoctrineModule/Options/Authentication.php
+++ b/src/DoctrineModule/Options/Authentication.php
@@ -10,6 +10,7 @@ use Doctrine\Persistence\ObjectRepository;
 use Laminas\Authentication\Adapter\Exception;
 use Laminas\Authentication\Storage\StorageInterface;
 use Laminas\Stdlib\AbstractOptions;
+
 use function gettype;
 use function interface_exists;
 use function is_callable;
@@ -117,7 +118,7 @@ class Authentication extends AbstractOptions
     /**
      * @param  string | ObjectManager $objectManager
      */
-    public function setObjectManager($objectManager) : Authentication
+    public function setObjectManager($objectManager): Authentication
     {
         $this->objectManager = $objectManager;
 
@@ -136,14 +137,14 @@ class Authentication extends AbstractOptions
         return $this->objectManager;
     }
 
-    public function setObjectRepository(ObjectRepository $objectRepository) : Authentication
+    public function setObjectRepository(ObjectRepository $objectRepository): Authentication
     {
         $this->objectRepository = $objectRepository;
 
         return $this;
     }
 
-    public function getObjectRepository() : ObjectRepository
+    public function getObjectRepository(): ObjectRepository
     {
         if ($this->objectRepository) {
             return $this->objectRepository;
@@ -152,14 +153,14 @@ class Authentication extends AbstractOptions
         return $this->objectManager->getRepository($this->identityClass);
     }
 
-    public function setIdentityClass(string $identityClass) : Authentication
+    public function setIdentityClass(string $identityClass): Authentication
     {
         $this->identityClass = $identityClass;
 
         return $this;
     }
 
-    public function getIdentityClass() : string
+    public function getIdentityClass(): string
     {
         return $this->identityClass;
     }
@@ -167,7 +168,7 @@ class Authentication extends AbstractOptions
     /**
      * @throws Exception\InvalidArgumentException
      */
-    public function setIdentityProperty(string $identityProperty) : Authentication
+    public function setIdentityProperty(string $identityProperty): Authentication
     {
         if (! is_string($identityProperty) || $identityProperty === '') {
             throw new Exception\InvalidArgumentException(
@@ -180,7 +181,7 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    public function getIdentityProperty() : string
+    public function getIdentityProperty(): string
     {
         return $this->identityProperty;
     }
@@ -188,7 +189,7 @@ class Authentication extends AbstractOptions
     /**
      * @throws Exception\InvalidArgumentException
      */
-    public function setCredentialProperty(string $credentialProperty) : Authentication
+    public function setCredentialProperty(string $credentialProperty): Authentication
     {
         if (! is_string($credentialProperty) || $credentialProperty === '') {
             throw new Exception\InvalidArgumentException(
@@ -201,7 +202,7 @@ class Authentication extends AbstractOptions
         return $this;
     }
 
-    public function getCredentialProperty() : string
+    public function getCredentialProperty(): string
     {
         return $this->credentialProperty;
     }
@@ -211,7 +212,7 @@ class Authentication extends AbstractOptions
      *
      * @throws Exception\InvalidArgumentException
      */
-    public function setCredentialCallable($credentialCallable) : Authentication
+    public function setCredentialCallable($credentialCallable): Authentication
     {
         if (! is_callable($credentialCallable)) {
             throw new Exception\InvalidArgumentException(
@@ -235,7 +236,7 @@ class Authentication extends AbstractOptions
         return $this->credentialCallable;
     }
 
-    public function getClassMetadata() : ClassMetadata
+    public function getClassMetadata(): ClassMetadata
     {
         if ($this->classMetadata) {
             return $this->classMetadata;
@@ -244,7 +245,7 @@ class Authentication extends AbstractOptions
         return $this->objectManager->getClassMetadata($this->identityClass);
     }
 
-    public function setClassMetadata(ClassMetadata $classMetadata) : void
+    public function setClassMetadata(ClassMetadata $classMetadata): void
     {
         $this->classMetadata = $classMetadata;
     }
@@ -260,7 +261,7 @@ class Authentication extends AbstractOptions
     /**
      * @param StorageInterface|string $storage
      */
-    public function setStorage($storage) : void
+    public function setStorage($storage): void
     {
         $this->storage = $storage;
     }

--- a/src/DoctrineModule/Options/Cache.php
+++ b/src/DoctrineModule/Options/Cache.php
@@ -42,50 +42,50 @@ class Cache extends AbstractOptions
      */
     protected $instance = null;
 
-    public function setClass(string $class) : self
+    public function setClass(string $class): self
     {
         $this->class = $class;
 
         return $this;
     }
 
-    public function getClass() : string
+    public function getClass(): string
     {
         return $this->class;
     }
 
-    public function setInstance(string $instance) : self
+    public function setInstance(string $instance): self
     {
         $this->instance = $instance;
 
         return $this;
     }
 
-    public function getInstance() : ?string
+    public function getInstance(): ?string
     {
         return $this->instance;
     }
 
-    public function setNamespace(string $namespace) : self
+    public function setNamespace(string $namespace): self
     {
         $this->namespace = (string) $namespace;
 
         return $this;
     }
 
-    public function getNamespace() : string
+    public function getNamespace(): string
     {
         return $this->namespace;
     }
 
-    public function setDirectory(string $directory) : self
+    public function setDirectory(string $directory): self
     {
         $this->directory = $directory;
 
         return $this;
     }
 
-    public function getDirectory() : string
+    public function getDirectory(): string
     {
         return $this->directory;
     }

--- a/src/DoctrineModule/Options/Driver.php
+++ b/src/DoctrineModule/Options/Driver.php
@@ -56,22 +56,22 @@ class Driver extends AbstractOptions
      */
     protected $drivers = [];
 
-    public function setCache(string $cache) : void
+    public function setCache(string $cache): void
     {
         $this->cache = $cache;
     }
 
-    public function getCache() : string
+    public function getCache(): string
     {
         return 'doctrine.cache.' . $this->cache;
     }
 
-    public function setClass(string $class) : void
+    public function setClass(string $class): void
     {
         $this->class = $class;
     }
 
-    public function getClass() : string
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -79,7 +79,7 @@ class Driver extends AbstractOptions
     /**
      * @param mixed[] $drivers
      */
-    public function setDrivers(array $drivers) : void
+    public function setDrivers(array $drivers): void
     {
         $this->drivers = $drivers;
     }
@@ -87,7 +87,7 @@ class Driver extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getDrivers() : array
+    public function getDrivers(): array
     {
         return $this->drivers;
     }
@@ -95,12 +95,12 @@ class Driver extends AbstractOptions
     /**
      * @param null $extension
      */
-    public function setExtension($extension) : void
+    public function setExtension($extension): void
     {
         $this->extension = $extension;
     }
 
-    public function getExtension() : ?string
+    public function getExtension(): ?string
     {
         return $this->extension;
     }
@@ -108,7 +108,7 @@ class Driver extends AbstractOptions
     /**
      * @param mixed[] $paths
      */
-    public function setPaths(array $paths) : void
+    public function setPaths(array $paths): void
     {
         $this->paths = $paths;
     }
@@ -116,7 +116,7 @@ class Driver extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getPaths() : array
+    public function getPaths(): array
     {
         return $this->paths;
     }

--- a/src/DoctrineModule/Options/EventManager.php
+++ b/src/DoctrineModule/Options/EventManager.php
@@ -25,7 +25,7 @@ class EventManager extends AbstractOptions
     /**
      * @param mixed[] $subscribers
      */
-    public function setSubscribers(array $subscribers) : self
+    public function setSubscribers(array $subscribers): self
     {
         $this->subscribers = $subscribers;
 
@@ -35,7 +35,7 @@ class EventManager extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getSubscribers() : array
+    public function getSubscribers(): array
     {
         return $this->subscribers;
     }

--- a/src/DoctrineModule/Paginator/Adapter/Collection.php
+++ b/src/DoctrineModule/Paginator/Adapter/Collection.php
@@ -6,6 +6,7 @@ namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Laminas\Paginator\Adapter\AdapterInterface;
+
 use function array_values;
 use function count;
 

--- a/src/DoctrineModule/Paginator/Adapter/Selectable.php
+++ b/src/DoctrineModule/Paginator/Adapter/Selectable.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Paginator\Adapter;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
 use Laminas\Paginator\Adapter\AdapterInterface;
+
 use function count;
 
 /**

--- a/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
+++ b/src/DoctrineModule/Persistence/ObjectManagerAwareInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\Persistence;
 
 use Doctrine\Persistence\ObjectManager;
+
 use function interface_exists;
 
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
@@ -15,12 +16,12 @@ interface ObjectManagerAwareInterface
     /**
      * Set the object manager
      */
-    public function setObjectManager(ObjectManager $objectManager) : void;
+    public function setObjectManager(ObjectManager $objectManager): void;
 
     /**
      * Get the object manager
      */
-    public function getObjectManager() : ObjectManager;
+    public function getObjectManager(): ObjectManager;
 }
 
 interface_exists(ObjectManager::class);

--- a/src/DoctrineModule/Persistence/ProvidesObjectManager.php
+++ b/src/DoctrineModule/Persistence/ProvidesObjectManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\Persistence;
 
 use Doctrine\Persistence\ObjectManager;
+
 use function interface_exists;
 
 /**
@@ -18,7 +19,7 @@ trait ProvidesObjectManager
     /**
      * Set the object manager
      */
-    public function setObjectManager(ObjectManager $objectManager) : void
+    public function setObjectManager(ObjectManager $objectManager): void
     {
         $this->objectManager = $objectManager;
     }
@@ -26,7 +27,7 @@ trait ProvidesObjectManager
     /**
      * Get the object manager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }

--- a/src/DoctrineModule/Service/AbstractFactory.php
+++ b/src/DoctrineModule/Service/AbstractFactory.php
@@ -8,6 +8,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Stdlib\AbstractOptions;
 use RuntimeException;
+
 use function sprintf;
 
 /**
@@ -35,7 +36,7 @@ abstract class AbstractFactory implements FactoryInterface
         $this->name = $name;
     }
 
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -43,7 +44,7 @@ abstract class AbstractFactory implements FactoryInterface
     /**
      * Would normally be set to orm | odm
      */
-    public function getMappingType() : string
+    public function getMappingType(): string
     {
         return (string) $this->mappingType;
     }
@@ -53,7 +54,7 @@ abstract class AbstractFactory implements FactoryInterface
      *
      * @throws RuntimeException
      */
-    public function getOptions(ContainerInterface $container, string $key, ?string $name = null) : AbstractOptions
+    public function getOptions(ContainerInterface $container, string $key, ?string $name = null): AbstractOptions
     {
         if ($name === null) {
             $name = $this->getName();
@@ -88,5 +89,5 @@ abstract class AbstractFactory implements FactoryInterface
      *
      * @abstract
      */
-    abstract public function getOptionsClass() : string;
+    abstract public function getOptionsClass(): string;
 }

--- a/src/DoctrineModule/Service/Authentication/AdapterFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AdapterFactory.php
@@ -8,6 +8,7 @@ use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function is_string;
 
 /**
@@ -42,7 +43,7 @@ class AdapterFactory extends AbstractFactory
         return $this($serviceLocator, ObjectRepository::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return 'DoctrineModule\Options\Authentication';
     }

--- a/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/DoctrineModule/Service/Authentication/AuthenticationServiceFactory.php
@@ -28,12 +28,12 @@ class AuthenticationServiceFactory extends AbstractFactory
         );
     }
 
-    public function createService(ServiceLocatorInterface $container) : AuthenticationService
+    public function createService(ServiceLocatorInterface $container): AuthenticationService
     {
         return $this($container, AuthenticationService::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         throw new BadMethodCallException('Not implemented');
     }

--- a/src/DoctrineModule/Service/Authentication/StorageFactory.php
+++ b/src/DoctrineModule/Service/Authentication/StorageFactory.php
@@ -8,6 +8,7 @@ use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function is_string;
 
 /**
@@ -47,7 +48,7 @@ class StorageFactory extends AbstractFactory
         return $this($container, ObjectRepository::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return 'DoctrineModule\Options\Authentication';
     }

--- a/src/DoctrineModule/Service/CacheFactory.php
+++ b/src/DoctrineModule/Service/CacheFactory.php
@@ -10,6 +10,7 @@ use DoctrineModule\Cache\LaminasStorageCache;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
+
 use function is_string;
 
 /**
@@ -90,7 +91,7 @@ class CacheFactory extends AbstractFactory
         return $this($container, \Doctrine\Common\Cache\Cache::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return 'DoctrineModule\Options\Cache';
     }

--- a/src/DoctrineModule/Service/CliControllerFactory.php
+++ b/src/DoctrineModule/Service/CliControllerFactory.php
@@ -28,7 +28,7 @@ class CliControllerFactory implements FactoryInterface
      * @throws ServiceNotCreatedException if an exception is raised when creating a service.
      * @throws ContainerException if any other error occurs.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null) : object
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): object
     {
         $application = $container->get('doctrine.cli');
 

--- a/src/DoctrineModule/Service/CliFactory.php
+++ b/src/DoctrineModule/Service/CliFactory.php
@@ -27,7 +27,7 @@ class CliFactory implements FactoryInterface
     /** @var mixed[] */
     protected $commands = [];
 
-    public function getEventManager(ContainerInterface $container) : EventManagerInterface
+    public function getEventManager(ContainerInterface $container): EventManagerInterface
     {
         if ($this->events === null) {
             $events = $container->get('EventManager');

--- a/src/DoctrineModule/Service/DriverFactory.php
+++ b/src/DoctrineModule/Service/DriverFactory.php
@@ -13,6 +13,7 @@ use DoctrineModule\Options\Driver as DriverOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function class_exists;
 use function get_class;
 use function interface_exists;
@@ -49,7 +50,7 @@ class DriverFactory extends AbstractFactory
         return $this($container, MappingDriver::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return 'DoctrineModule\Options\Driver';
     }
@@ -57,7 +58,7 @@ class DriverFactory extends AbstractFactory
     /**
      * @throws InvalidArgumentException
      */
-    protected function createDriver(ContainerInterface $container, DriverOptions $options) : MappingDriver
+    protected function createDriver(ContainerInterface $container, DriverOptions $options): MappingDriver
     {
         $class = $options->getClass();
 
@@ -73,7 +74,8 @@ class DriverFactory extends AbstractFactory
         $paths = $options->getPaths();
 
         // Special options for AnnotationDrivers.
-        if ($class === 'Doctrine\Persistence\Mapping\Driver\AnnotationDriver'
+        if (
+            $class === 'Doctrine\Persistence\Mapping\Driver\AnnotationDriver'
             || is_subclass_of($class, 'Doctrine\Persistence\Mapping\Driver\AnnotationDriver')
         ) {
             $reader = new Annotations\AnnotationReader();

--- a/src/DoctrineModule/Service/EventManagerFactory.php
+++ b/src/DoctrineModule/Service/EventManagerFactory.php
@@ -9,6 +9,7 @@ use Doctrine\Common\EventSubscriber;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function class_exists;
 use function get_class;
 use function gettype;
@@ -70,7 +71,7 @@ class EventManagerFactory extends AbstractFactory
     /**
      * Get the class name of the options associated with this factory.
      */
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return 'DoctrineModule\Options\EventManager';
     }

--- a/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -8,6 +8,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function preg_match;
 
 /**
@@ -70,11 +71,13 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     {
         $matches = [];
 
-        if (! preg_match(
-            '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
-            $name,
-            $matches
-        )) {
+        if (
+            ! preg_match(
+                '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
+                $name,
+                $matches
+            )
+        ) {
             return false;
         }
 
@@ -84,7 +87,8 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
         $serviceName = $matches['serviceName'];
 
         if ($mappingType === '') {
-            if (! isset($config['doctrine_factories'][$serviceType]) ||
+            if (
+                ! isset($config['doctrine_factories'][$serviceType]) ||
                  ! isset($config['doctrine'][$serviceType][$serviceName])
             ) {
                 return false;
@@ -97,10 +101,12 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
             ];
         }
 
-        if (! isset(
-            $config['doctrine_factories'][$mappingType][$serviceType],
-            $config['doctrine'][$mappingType][$serviceType][$serviceName]
-        )) {
+        if (
+            ! isset(
+                $config['doctrine_factories'][$mappingType][$serviceType],
+                $config['doctrine'][$mappingType][$serviceType][$serviceName]
+            )
+        ) {
             return false;
         }
 

--- a/src/DoctrineModule/Validator/ObjectExists.php
+++ b/src/DoctrineModule/Validator/ObjectExists.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\ObjectRepository;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception;
+
 use function array_combine;
 use function array_key_exists;
 use function array_values;
@@ -100,7 +101,7 @@ class ObjectExists extends AbstractValidator
      *
      * @throws Exception\InvalidArgumentException
      */
-    private function validateFields() : array
+    private function validateFields(): array
     {
         $fields = (array) $this->fields;
 
@@ -129,7 +130,7 @@ class ObjectExists extends AbstractValidator
      *
      * @throws Exception\RuntimeException
      */
-    protected function cleanSearchValue($value) : array
+    protected function cleanSearchValue($value): array
     {
         $value = is_object($value) ? [$value] : (array) $value;
 

--- a/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
+++ b/src/DoctrineModule/Validator/Service/AbstractValidatorFactory.php
@@ -12,6 +12,7 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Stdlib\ArrayUtils;
+
 use function interface_exists;
 use function is_string;
 use function sprintf;
@@ -38,7 +39,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      *
      * @throws ServiceCreationException
      */
-    protected function getRepository(ContainerInterface $container, ?array $options = null) : ObjectRepository
+    protected function getRepository(ContainerInterface $container, ?array $options = null): ObjectRepository
     {
         if (empty($options['target_class'])) {
             throw new ServiceCreationException(sprintf(
@@ -56,7 +57,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     /**
      * @param mixed[] $options
      */
-    protected function getObjectManager(ContainerInterface $container, ?array $options = null) : ObjectManager
+    protected function getObjectManager(ContainerInterface $container, ?array $options = null): ObjectManager
     {
         $objectManager = $options['object_manager'] ?? self::DEFAULT_OBJECTMANAGER_KEY;
 
@@ -72,7 +73,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      *
      * @return mixed[]
      */
-    protected function getFields(array $options) : array
+    protected function getFields(array $options): array
     {
         if (isset($options['fields'])) {
             return (array) $options['fields'];
@@ -91,7 +92,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      *
      * @return mixed[]
      */
-    protected function merge(array $previousOptions, array $newOptions) : array
+    protected function merge(array $previousOptions, array $newOptions): array
     {
         return ArrayUtils::merge($previousOptions, $newOptions, true);
     }
@@ -102,7 +103,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
      * In ZF2 the plugin manager instance if passed to `createService`
      * instead of the global service manager instance (as in ZF3).
      */
-    protected function container(ContainerInterface $container) : ContainerInterface
+    protected function container(ContainerInterface $container): ContainerInterface
     {
         if ($container instanceof ServiceLocatorAwareInterface) {
             $container = $container->getServiceLocator();
@@ -122,7 +123,7 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     /**
      * @param mixed[] $options
      */
-    public function setCreationOptions(array $options) : void
+    public function setCreationOptions(array $options): void
     {
         $this->creationOptions = $options;
     }

--- a/src/DoctrineModule/Validator/UniqueObject.php
+++ b/src/DoctrineModule/Validator/UniqueObject.php
@@ -6,6 +6,7 @@ namespace DoctrineModule\Validator;
 
 use Doctrine\Persistence\ObjectManager;
 use Laminas\Validator\Exception;
+
 use function array_diff_assoc;
 use function array_key_exists;
 use function count;
@@ -80,7 +81,7 @@ class UniqueObject extends ObjectExists
      * @param mixed $value
      * @param mixed $context
      */
-    public function isValid($value, $context = null) : bool
+    public function isValid($value, $context = null): bool
     {
         if (! $this->useContext) {
             $context = (array) $value;
@@ -112,7 +113,7 @@ class UniqueObject extends ObjectExists
      *
      * @throws Exception\RuntimeException
      */
-    protected function getFoundIdentifiers(object $match) : array
+    protected function getFoundIdentifiers(object $match): array
     {
         return $this->objectManager
                     ->getClassMetadata($this->objectRepository->getClassName())
@@ -128,7 +129,7 @@ class UniqueObject extends ObjectExists
      *
      * @throws Exception\RuntimeException
      */
-    protected function getExpectedIdentifiers($context = null) : array
+    protected function getExpectedIdentifiers($context = null): array
     {
         if ($context === null) {
             throw new Exception\RuntimeException(
@@ -159,7 +160,7 @@ class UniqueObject extends ObjectExists
     /**
      * @return mixed[] the names of the identifiers
      */
-    protected function getIdentifiers() : array
+    protected function getIdentifiers(): array
     {
         return $this->objectManager
                     ->getClassMetadata($this->objectRepository->getClassName())

--- a/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/ObjectRepositoryTest.php
@@ -9,6 +9,7 @@ use DoctrineModuleTest\Authentication\Adapter\TestAsset\IdentityObject;
 use DoctrineModuleTest\Authentication\Adapter\TestAsset\PublicPropertiesIdentityObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use stdClass;
+
 use function crypt;
 
 /**
@@ -18,7 +19,7 @@ use function crypt;
  */
 class ObjectRepositoryTest extends BaseTestCase
 {
-    public function testWillRejectInvalidIdentityProperty() : void
+    public function testWillRejectInvalidIdentityProperty(): void
     {
         $this->expectException(
             'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
@@ -30,7 +31,7 @@ class ObjectRepositoryTest extends BaseTestCase
         new ObjectRepositoryAdapter(['identity_property' => false]);
     }
 
-    public function testWillRejectInvalidCredentialProperty() : void
+    public function testWillRejectInvalidCredentialProperty(): void
     {
         $this->expectException(
             'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
@@ -41,7 +42,7 @@ class ObjectRepositoryTest extends BaseTestCase
         new ObjectRepositoryAdapter(['credential_property' => false]);
     }
 
-    public function testWillRequireIdentityValue() : void
+    public function testWillRequireIdentityValue(): void
     {
         $this->expectException(
             'Laminas\Authentication\Adapter\Exception\RuntimeException'
@@ -59,7 +60,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $adapter->authenticate();
     }
 
-    public function testWillRequireCredentialValue() : void
+    public function testWillRequireCredentialValue(): void
     {
         $this->expectException(
             'Laminas\Authentication\Adapter\Exception\RuntimeException'
@@ -77,7 +78,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $adapter->authenticate();
     }
 
-    public function testWillRejectInvalidCredentialCallable() : void
+    public function testWillRejectInvalidCredentialCallable(): void
     {
         $this->expectException(
             'Laminas\Authentication\Adapter\Exception\InvalidArgumentException'
@@ -95,7 +96,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $adapter->authenticate();
     }
 
-    public function testAuthentication() : void
+    public function testAuthentication(): void
     {
         $entity = new IdentityObject();
         $entity->setUsername('a username');
@@ -140,7 +141,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $this->assertFalse($result->isValid());
     }
 
-    public function testAuthenticationWithPublicProperties() : void
+    public function testAuthenticationWithPublicProperties(): void
     {
         $entity           = new PublicPropertiesIdentityObject();
         $entity->username = 'a username';
@@ -174,7 +175,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $this->assertFalse($result->isValid());
     }
 
-    public function testWillRefuseToAuthenticateWithoutGettersOrPublicMethods() : void
+    public function testWillRefuseToAuthenticateWithoutGettersOrPublicMethods(): void
     {
         $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
@@ -197,7 +198,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $adapter->authenticate();
     }
 
-    public function testCanValidateWithSpecialCrypt() : void
+    public function testCanValidateWithSpecialCrypt(): void
     {
         $hash   = '$2y$07$usesomesillystringforsalt$';
         $entity = new IdentityObject();
@@ -236,7 +237,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $this->assertFalse($result->isValid());
     }
 
-    public function testWillRefuseToAuthenticateWhenInvalidInstanceIsFound() : void
+    public function testWillRefuseToAuthenticateWhenInvalidInstanceIsFound(): void
     {
         $this->expectException('Laminas\Authentication\Adapter\Exception\UnexpectedValueException');
 
@@ -260,7 +261,7 @@ class ObjectRepositoryTest extends BaseTestCase
         $adapter->authenticate();
     }
 
-    public function testWillNotCastAuthCredentialValue() : void
+    public function testWillNotCastAuthCredentialValue(): void
     {
         $objectRepository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $adapter          = new ObjectRepositoryAdapter();

--- a/tests/DoctrineModuleTest/Authentication/Adapter/TestAsset/IdentityObject.php
+++ b/tests/DoctrineModuleTest/Authentication/Adapter/TestAsset/IdentityObject.php
@@ -20,22 +20,22 @@ class IdentityObject
     /**
      * @param mixed $password
      */
-    public function setPassword($password) : void
+    public function setPassword($password): void
     {
         $this->password = (string) $password;
     }
 
-    public function getPassword() : ?string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    public function setUsername(string $username) : void
+    public function setUsername(string $username): void
     {
         $this->username = (string) $username;
     }
 
-    public function getUsername() : ?string
+    public function getUsername(): ?string
     {
         return $this->username;
     }

--- a/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
+++ b/tests/DoctrineModuleTest/Authentication/Storage/ObjectRepositoryTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 class ObjectRepositoryTest extends BaseTestCase
 {
-    public function testCanRetrieveEntityFromObjectRepositoryStorage() : void
+    public function testCanRetrieveEntityFromObjectRepositoryStorage(): void
     {
         // Identifier is considered to be username here
         $entity = new IdentityObject();

--- a/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
+++ b/tests/DoctrineModuleTest/Cache/DoctrineCacheStorageTest.php
@@ -11,6 +11,7 @@ use Laminas\Cache\Storage\StorageInterface;
 use Laminas\Stdlib\ErrorHandler;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
 use function array_keys;
 use function count;
 use function fopen;
@@ -51,7 +52,7 @@ class DoctrineCacheStorageTest extends TestCase
      */
     protected $phpDatatypes = ['NULL', 'boolean', 'integer', 'double', 'string', 'array', 'object', 'resource'];
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->options = new AdapterOptions();
         // @todo fix constructor as it is messy
@@ -69,7 +70,7 @@ class DoctrineCacheStorageTest extends TestCase
         );
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         // be sure the error handler has been stopped
         if (! ErrorHandler::started()) {
@@ -80,7 +81,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->fail('ErrorHandler not stopped');
     }
 
-    public function testOptionNamesValid() : void
+    public function testOptionNamesValid(): void
     {
         $options = $this->storage->getOptions()->toArray();
         foreach ($options as $name => $value) {
@@ -95,7 +96,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testGettersAndSettersOfOptionsExists() : void
+    public function testGettersAndSettersOfOptionsExists(): void
     {
         $options = $this->storage->getOptions();
         foreach ($options->toArray() as $option => $value) {
@@ -125,14 +126,14 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testOptionsGetAndSetDefault() : void
+    public function testOptionsGetAndSetDefault(): void
     {
         $options = $this->storage->getOptions();
         $this->storage->setOptions($options);
         $this->assertSame($options, $this->storage->getOptions());
     }
 
-    public function testOptionsFluentInterface() : void
+    public function testOptionsFluentInterface(): void
     {
         $options = $this->storage->getOptions();
         foreach ($options->toArray() as $option => $value) {
@@ -155,13 +156,13 @@ class DoctrineCacheStorageTest extends TestCase
         );
     }
 
-    public function testGetCapabilities() : void
+    public function testGetCapabilities(): void
     {
         $capabilities = $this->storage->getCapabilities();
         $this->assertInstanceOf('Laminas\Cache\Storage\Capabilities', $capabilities);
     }
 
-    public function testDatatypesCapability() : void
+    public function testDatatypesCapability(): void
     {
         $capabilities = $this->storage->getCapabilities();
         $datatypes    = $capabilities->getSupportedDatatypes();
@@ -178,7 +179,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testSupportedMetadataCapability() : void
+    public function testSupportedMetadataCapability(): void
     {
         $capabilities = $this->storage->getCapabilities();
         $metadata     = $capabilities->getSupportedMetadata();
@@ -189,7 +190,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testTtlCapabilities() : void
+    public function testTtlCapabilities(): void
     {
         $capabilities = $this->storage->getCapabilities();
 
@@ -204,7 +205,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertIsBool($capabilities->getStaticTtl());
     }
 
-    public function testKeyCapabilities() : void
+    public function testKeyCapabilities(): void
     {
         $capabilities = $this->storage->getCapabilities();
 
@@ -216,18 +217,18 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertIsString($capabilities->getNamespaceSeparator());
     }
 
-    public function testHasItemReturnsTrueOnValidItem() : void
+    public function testHasItemReturnsTrueOnValidItem(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
         $this->assertTrue($this->storage->hasItem('key'));
     }
 
-    public function testHasItemReturnsFalseOnMissingItem() : void
+    public function testHasItemReturnsFalseOnMissingItem(): void
     {
         $this->assertFalse($this->storage->hasItem('key'));
     }
 
-    public function testHasItemNonReadable() : void
+    public function testHasItemNonReadable(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
 
@@ -235,7 +236,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->hasItem('key'));
     }
 
-    public function testHasItemsReturnsKeysOfFoundItems() : void
+    public function testHasItemsReturnsKeysOfFoundItems(): void
     {
         $this->assertTrue($this->storage->setItem('key1', 'value1'));
         $this->assertTrue($this->storage->setItem('key2', 'value2'));
@@ -247,7 +248,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testHasItemsReturnsEmptyArrayIfNonReadable() : void
+    public function testHasItemsReturnsEmptyArrayIfNonReadable(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
 
@@ -255,12 +256,12 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals([], $this->storage->hasItems(['key']));
     }
 
-    public function testGetItemReturnsNullOnMissingItem() : void
+    public function testGetItemReturnsNullOnMissingItem(): void
     {
         $this->assertNull($this->storage->getItem('unknown'));
     }
 
-    public function testGetItemSetsSuccessFlag() : void
+    public function testGetItemSetsSuccessFlag(): void
     {
         $success = null;
 
@@ -274,7 +275,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertTrue($success);
     }
 
-    public function testGetItemReturnsNullIfNonReadable() : void
+    public function testGetItemReturnsNullIfNonReadable(): void
     {
         $this->options->setReadable(false);
 
@@ -282,7 +283,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertNull($this->storage->getItem('key'));
     }
 
-    public function testGetItemsReturnsKeyValuePairsOfFoundItems() : void
+    public function testGetItemsReturnsKeyValuePairsOfFoundItems(): void
     {
         $this->assertTrue($this->storage->setItem('key1', 'value1'));
         $this->assertTrue($this->storage->setItem('key2', 'value2'));
@@ -297,7 +298,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testGetItemsReturnsEmptyArrayIfNonReadable() : void
+    public function testGetItemsReturnsEmptyArrayIfNonReadable(): void
     {
         $this->options->setReadable(false);
 
@@ -305,7 +306,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals([], $this->storage->getItems(['key']));
     }
 
-    public function testGetMetadata() : void
+    public function testGetMetadata(): void
     {
         $capabilities       = $this->storage->getCapabilities();
         $supportedMetadatas = $capabilities->getSupportedMetadata();
@@ -319,12 +320,12 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testGetMetadataReturnsFalseOnMissingItem() : void
+    public function testGetMetadataReturnsFalseOnMissingItem(): void
     {
         $this->assertFalse($this->storage->getMetadata('unknown'));
     }
 
-    public function testGetMetadataReturnsFalseIfNonReadable() : void
+    public function testGetMetadataReturnsFalseIfNonReadable(): void
     {
         $this->options->setReadable(false);
 
@@ -332,7 +333,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->getMetadata('key'));
     }
 
-    public function testGetMetadatas() : void
+    public function testGetMetadatas(): void
     {
         $capabilities       = $this->storage->getCapabilities();
         $supportedMetadatas = $capabilities->getSupportedMetadata();
@@ -354,7 +355,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testGetMetadatasReturnsEmptyArrayIfNonReadable() : void
+    public function testGetMetadatasReturnsEmptyArrayIfNonReadable(): void
     {
         $this->options->setReadable(false);
 
@@ -362,7 +363,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals([], $this->storage->getMetadatas(['key']));
     }
 
-    public function testSetGetHasAndRemoveItem() : void
+    public function testSetGetHasAndRemoveItem(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
         $this->assertEquals('value', $this->storage->getItem('key'));
@@ -373,7 +374,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertNull($this->storage->getItem('key'));
     }
 
-    public function testSetGetHasAndRemoveItems() : void
+    public function testSetGetHasAndRemoveItems(): void
     {
         $items = [
             'key1' => 'value1',
@@ -415,7 +416,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testSetGetHasAndRemoveItemWithNamespace() : void
+    public function testSetGetHasAndRemoveItemWithNamespace(): void
     {
         // write "key" to default namespace
         $this->options->setNamespace('defaultns1');
@@ -445,7 +446,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->hasItem('key'));
     }
 
-    public function testSetGetHasAndRemoveItemsWithNamespace() : void
+    public function testSetGetHasAndRemoveItemsWithNamespace(): void
     {
         $items = [
             'key1' => 'value1',
@@ -493,7 +494,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testSetAndGetItemOfDifferentTypes() : void
+    public function testSetAndGetItemOfDifferentTypes(): void
     {
         $capabilities = $this->storage->getCapabilities();
 
@@ -535,7 +536,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
     }
 
-    public function testSetItemReturnsFalseIfNonWritable() : void
+    public function testSetItemReturnsFalseIfNonWritable(): void
     {
         $this->options->setWritable(false);
 
@@ -543,19 +544,19 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->hasItem('key'));
     }
 
-    public function testAddNewItem() : void
+    public function testAddNewItem(): void
     {
         $this->assertTrue($this->storage->addItem('key', 'value'));
         $this->assertTrue($this->storage->hasItem('key'));
     }
 
-    public function testAddItemReturnsFalseIfItemAlreadyExists() : void
+    public function testAddItemReturnsFalseIfItemAlreadyExists(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
         $this->assertFalse($this->storage->addItem('key', 'newValue'));
     }
 
-    public function testAddItemReturnsFalseIfNonWritable() : void
+    public function testAddItemReturnsFalseIfNonWritable(): void
     {
         $this->options->setWritable(false);
 
@@ -563,7 +564,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->hasItem('key'));
     }
 
-    public function testAddItemsReturnsFailedKeys() : void
+    public function testAddItemsReturnsFailedKeys(): void
     {
         $this->assertTrue($this->storage->setItem('key1', 'value1'));
 
@@ -577,19 +578,19 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertTrue($this->storage->hasItem('key2'));
     }
 
-    public function testReplaceExistingItem() : void
+    public function testReplaceExistingItem(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
         $this->assertTrue($this->storage->replaceItem('key', 'anOtherValue'));
         $this->assertEquals('anOtherValue', $this->storage->getItem('key'));
     }
 
-    public function testReplaceItemReturnsFalseOnMissingItem() : void
+    public function testReplaceItemReturnsFalseOnMissingItem(): void
     {
         $this->assertFalse($this->storage->replaceItem('missingKey', 'value'));
     }
 
-    public function testReplaceItemReturnsFalseIfNonWritable() : void
+    public function testReplaceItemReturnsFalseIfNonWritable(): void
     {
         $this->storage->setItem('key', 'value');
         $this->options->setWritable(false);
@@ -598,7 +599,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals('value', $this->storage->getItem('key'));
     }
 
-    public function testReplaceItemsReturnsFailedKeys() : void
+    public function testReplaceItemsReturnsFailedKeys(): void
     {
         $this->assertTrue($this->storage->setItem('key1', 'value1'));
 
@@ -612,18 +613,18 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertFalse($this->storage->hasItem('key2'));
     }
 
-    public function testRemoveItemReturnsFalseOnMissingItem() : void
+    public function testRemoveItemReturnsFalseOnMissingItem(): void
     {
         $this->assertFalse($this->storage->removeItem('missing'));
     }
 
-    public function testRemoveItemsReturnsMissingKeys() : void
+    public function testRemoveItemsReturnsMissingKeys(): void
     {
         $this->storage->setItem('key', 'value');
         $this->assertSame(['missing'], $this->storage->removeItems(['key', 'missing']));
     }
 
-    public function testCheckAndSetItem() : void
+    public function testCheckAndSetItem(): void
     {
         $this->assertTrue($this->storage->setItem('key', 'value'));
 
@@ -637,20 +638,20 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals('newValue', $this->storage->getItem('key'));
     }
 
-    public function testIncrementItem() : void
+    public function testIncrementItem(): void
     {
         $this->assertTrue($this->storage->setItem('counter', 10));
         $this->assertEquals(15, $this->storage->incrementItem('counter', 5));
         $this->assertEquals(15, $this->storage->getItem('counter'));
     }
 
-    public function testIncrementItemInitialValue() : void
+    public function testIncrementItemInitialValue(): void
     {
         $this->assertEquals(5, $this->storage->incrementItem('counter', 5));
         $this->assertEquals(5, $this->storage->getItem('counter'));
     }
 
-    public function testIncrementItemReturnsFalseIfNonWritable() : void
+    public function testIncrementItemReturnsFalseIfNonWritable(): void
     {
         $this->storage->setItem('key', 10);
         $this->options->setWritable(false);
@@ -659,7 +660,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals(10, $this->storage->getItem('key'));
     }
 
-    public function testIncrementItemsReturnsKeyValuePairsOfWrittenItems() : void
+    public function testIncrementItemsReturnsKeyValuePairsOfWrittenItems(): void
     {
         $this->assertTrue($this->storage->setItem('key1', 10));
 
@@ -670,7 +671,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertSame(['key1' => 20, 'key2' => 10], $result);
     }
 
-    public function testIncrementItemsReturnsEmptyArrayIfNonWritable() : void
+    public function testIncrementItemsReturnsEmptyArrayIfNonWritable(): void
     {
         $this->storage->setItem('key', 10);
         $this->options->setWritable(false);
@@ -679,20 +680,20 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals(10, $this->storage->getItem('key'));
     }
 
-    public function testDecrementItem() : void
+    public function testDecrementItem(): void
     {
         $this->assertTrue($this->storage->setItem('counter', 30));
         $this->assertEquals(25, $this->storage->decrementItem('counter', 5));
         $this->assertEquals(25, $this->storage->getItem('counter'));
     }
 
-    public function testDecrementItemInitialValue() : void
+    public function testDecrementItemInitialValue(): void
     {
         $this->assertEquals(-5, $this->storage->decrementItem('counter', 5));
         $this->assertEquals(-5, $this->storage->getItem('counter'));
     }
 
-    public function testDecrementItemReturnsFalseIfNonWritable() : void
+    public function testDecrementItemReturnsFalseIfNonWritable(): void
     {
         $this->storage->setItem('key', 10);
         $this->options->setWritable(false);
@@ -701,7 +702,7 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals(10, $this->storage->getItem('key'));
     }
 
-    public function testDecrementItemsReturnsEmptyArrayIfNonWritable() : void
+    public function testDecrementItemsReturnsEmptyArrayIfNonWritable(): void
     {
         $this->storage->setItem('key', 10);
         $this->options->setWritable(false);
@@ -710,25 +711,25 @@ class DoctrineCacheStorageTest extends TestCase
         $this->assertEquals(10, $this->storage->getItem('key'));
     }
 
-    public function testTouchItemReturnsFalseOnMissingItem() : void
+    public function testTouchItemReturnsFalseOnMissingItem(): void
     {
         $this->assertFalse($this->storage->touchItem('missing'));
     }
 
-    public function testTouchItemReturnsFalseIfNonWritable() : void
+    public function testTouchItemReturnsFalseIfNonWritable(): void
     {
         $this->options->setWritable(false);
 
         $this->assertFalse($this->storage->touchItem('key'));
     }
 
-    public function testTouchItemsReturnsGivenKeysIfNonWritable() : void
+    public function testTouchItemsReturnsGivenKeysIfNonWritable(): void
     {
         $this->options->setWritable(false);
         $this->assertSame(['key'], $this->storage->touchItems(['key']));
     }
 
-    public function testSetItemAndSetItemsCallSaveWithTtl() : void
+    public function testSetItemAndSetItemsCallSaveWithTtl(): void
     {
         $ttl = rand();
 

--- a/tests/DoctrineModuleTest/Cache/LaminasStorageCacheTest.php
+++ b/tests/DoctrineModuleTest/Cache/LaminasStorageCacheTest.php
@@ -17,12 +17,12 @@ use PHPUnit\Framework\TestCase;
  */
 class LaminasStorageCacheTest extends TestCase
 {
-    protected function getCacheDriver() : LaminasStorageCache
+    protected function getCacheDriver(): LaminasStorageCache
     {
         return new LaminasStorageCache(new Memory());
     }
 
-    public function testBasics() : void
+    public function testBasics(): void
     {
         $cache = $this->getCacheDriver();
 
@@ -45,7 +45,7 @@ class LaminasStorageCacheTest extends TestCase
         $this->assertInstanceOf('ArrayObject', $cache->fetch('test_object_key'));
     }
 
-    public function testDeleteAll() : void
+    public function testDeleteAll(): void
     {
         $cache = $this->getCacheDriver();
         $cache->save('test_key1', '1');
@@ -56,7 +56,7 @@ class LaminasStorageCacheTest extends TestCase
         $this->assertFalse($cache->contains('test_key2'));
     }
 
-    public function testFlushAll() : void
+    public function testFlushAll(): void
     {
         $cache = $this->getCacheDriver();
         $cache->save('test_key1', '1');
@@ -67,7 +67,7 @@ class LaminasStorageCacheTest extends TestCase
         $this->assertFalse($cache->contains('test_key2'));
     }
 
-    public function testNamespace() : void
+    public function testNamespace(): void
     {
         $cache = $this->getCacheDriver();
         $cache->setNamespace('test_');
@@ -80,7 +80,7 @@ class LaminasStorageCacheTest extends TestCase
         $this->assertFalse($cache->contains('key1'));
     }
 
-    public function testGetStats() : void
+    public function testGetStats(): void
     {
         $cache = $this->getCacheDriver();
         $stats = $cache->getStats();

--- a/tests/DoctrineModuleTest/Component/Console/Input/RequestInputTest.php
+++ b/tests/DoctrineModuleTest/Component/Console/Input/RequestInputTest.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Component\Console\Input;
 use DoctrineModule\Component\Console\Input\RequestInput;
 use Laminas\Console\Request;
 use PHPUnit\Framework\TestCase;
+
 use function array_shift;
 
 /**
@@ -17,7 +18,7 @@ class RequestInputTest extends TestCase
     /**
      * @covers \DoctrineModule\Component\Console\Input\RequestInput
      */
-    public function testParamsCorrectlySetted() : void
+    public function testParamsCorrectlySetted(): void
     {
         $params = [
             'scriptname.php',

--- a/tests/DoctrineModuleTest/Component/Console/Output/PropertyOutputTest.php
+++ b/tests/DoctrineModuleTest/Component/Console/Output/PropertyOutputTest.php
@@ -6,6 +6,7 @@ namespace DoctrineModuleTest\Component\Console\Output;
 
 use DoctrineModule\Component\Console\Output\PropertyOutput;
 use PHPUnit\Framework\TestCase;
+
 use const PHP_EOL;
 
 /**
@@ -16,7 +17,7 @@ class PropertyOutputTest extends TestCase
     /**
      * @covers \DoctrineModule\Component\Console\Output\PropertyOutput
      */
-    public function testWrite() : void
+    public function testWrite(): void
     {
         $message = 'message';
 
@@ -28,7 +29,7 @@ class PropertyOutputTest extends TestCase
     /**
      * @covers \DoctrineModule\Component\Console\Output\PropertyOutput
      */
-    public function testWriteConcat() : void
+    public function testWriteConcat(): void
     {
         $message  = 'message';
         $message2 = 'message2';

--- a/tests/DoctrineModuleTest/ConfigProviderTest.php
+++ b/tests/DoctrineModuleTest/ConfigProviderTest.php
@@ -6,6 +6,7 @@ namespace DoctrineModuleTest;
 
 use DoctrineModule\ConfigProvider;
 use PHPUnit\Framework\TestCase;
+
 use function serialize;
 use function unserialize;
 
@@ -16,7 +17,7 @@ use function unserialize;
  */
 class ConfigProviderTest extends TestCase
 {
-    public function testInvokeHasCorrectKeys() : void
+    public function testInvokeHasCorrectKeys(): void
     {
         $config = (new ConfigProvider())->__invoke();
 

--- a/tests/DoctrineModuleTest/Controller/CliControllerTest.php
+++ b/tests/DoctrineModuleTest/Controller/CliControllerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  */
 class CliControllerTest extends AbstractConsoleControllerTestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->setApplicationConfig(ServiceManagerFactory::getConfiguration());
         parent::setUp();
@@ -35,7 +35,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
     /**
      * Verifies that the controller handling the DoctrineModule CLI functionality can be reached
      */
-    public function testIndexActionCanBeAccessed() : void
+    public function testIndexActionCanBeAccessed(): void
     {
         $this->dispatch(new Request(['scriptname.php', 'list']));
 
@@ -47,14 +47,14 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
         $this->assertMatchedRouteName('doctrine_cli');
     }
 
-    public function testNonZeroExitCode() : void
+    public function testNonZeroExitCode(): void
     {
         $this->dispatch(new Request(['scriptname.php', 'fail']));
 
         $this->assertNotResponseStatusCode(0);
     }
 
-    public function testException() : void
+    public function testException(): void
     {
         $this->dispatch(new Request(['scriptname.php', '-q', 'fail', '--exception']));
 

--- a/tests/DoctrineModuleTest/Controller/Mock/FailingCommand.php
+++ b/tests/DoctrineModuleTest/Controller/Mock/FailingCommand.php
@@ -11,13 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class FailingCommand extends Command
 {
-    protected function configure() : void
+    protected function configure(): void
     {
         $this->setName('fail')
             ->addOption('exception', null, null, 'fail with an exception');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output) : int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('exception')) {
             throw new RuntimeException();

--- a/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectMultiCheckboxTest.php
@@ -6,6 +6,7 @@ namespace DoctrineModuleTest\Form\Element;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Form\Element\ObjectMultiCheckbox;
+
 use function get_class;
 
 /**
@@ -26,7 +27,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new ObjectMultiCheckbox();
@@ -34,7 +35,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
         $this->prepareProxy();
     }
 
-    public function testSetValueWithCollection() : void
+    public function testSetValueWithCollection(): void
     {
         $this->element->setValue(
             $this->values
@@ -46,7 +47,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
         );
     }
 
-    public function testSetValueWithArray() : void
+    public function testSetValueWithArray(): void
     {
         $this->element->setValue(
             $this->values->toArray()
@@ -58,7 +59,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
         );
     }
 
-    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized() : void
+    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized(): void
     {
         $element = $this->createPartialMock(get_class($this->element), ['setValueOptions']);
 
@@ -77,7 +78,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $element->getValueOptions());
     }
 
-    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty() : void
+    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty(): void
     {
         $options = ['foo' => 'bar'];
 
@@ -92,7 +93,7 @@ class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $this->element->getValueOptions());
     }
 
-    public function testOptionsCanBeSetSingle() : void
+    public function testOptionsCanBeSetSingle(): void
     {
         $proxy = $this->createMock('DoctrineModule\Form\Element\Proxy');
         $proxy->expects($this->once())->method('setOptions')->with(['is_method' => true]);

--- a/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectRadioTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModuleTest\Form\Element;
 
 use DoctrineModule\Form\Element\ObjectRadio;
+
 use function get_class;
 
 /**
@@ -20,13 +21,13 @@ class ObjectRadioTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new ObjectRadio();
     }
 
-    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized() : void
+    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized(): void
     {
         $element = $this->createPartialMock(get_class($this->element), ['setValueOptions']);
 
@@ -45,7 +46,7 @@ class ObjectRadioTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $element->getValueOptions());
     }
 
-    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty() : void
+    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty(): void
     {
         $options = ['foo' => 'bar'];
 
@@ -60,7 +61,7 @@ class ObjectRadioTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $this->element->getValueOptions());
     }
 
-    public function testOptionsCanBeSetSingle() : void
+    public function testOptionsCanBeSetSingle(): void
     {
         $proxy = $this->createMock('DoctrineModule\Form\Element\Proxy');
         $proxy->expects($this->once())->method('setOptions')->with(['is_method' => true]);

--- a/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ObjectSelectTest.php
@@ -6,6 +6,7 @@ namespace DoctrineModuleTest\Form\Element;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Form\Element\ObjectSelect;
+
 use function get_class;
 
 /**
@@ -26,7 +27,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->element = new ObjectSelect();
@@ -34,7 +35,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         $this->prepareProxy();
     }
 
-    public function testSetValueWithCollection() : void
+    public function testSetValueWithCollection(): void
     {
         $this->element->setAttribute('multiple', true);
 
@@ -48,7 +49,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         );
     }
 
-    public function testSetValueWithArray() : void
+    public function testSetValueWithArray(): void
     {
         $this->element->setAttribute('multiple', true);
 
@@ -62,7 +63,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         );
     }
 
-    public function testSetValueSingleValue() : void
+    public function testSetValueSingleValue(): void
     {
         $value = $this->values->toArray();
 
@@ -76,7 +77,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         );
     }
 
-    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized() : void
+    public function testGetValueOptionsDoesntCauseInfiniteLoopIfProxyReturnsEmptyArrayAndValidatorIsInitialized(): void
     {
         $element = $this->createPartialMock(get_class($this->element), ['setValueOptions']);
 
@@ -95,7 +96,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $element->getValueOptions());
     }
 
-    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty() : void
+    public function testGetValueOptionsDoesntInvokeProxyIfOptionsNotEmpty(): void
     {
         $options = ['foo' => 'bar'];
 
@@ -110,7 +111,7 @@ class ObjectSelectTest extends ProxyAwareElementTestCase
         $this->assertEquals($options, $this->element->getValueOptions());
     }
 
-    public function testOptionsCanBeSetSingle() : void
+    public function testOptionsCanBeSetSingle(): void
     {
         $proxy = $this->createMock('DoctrineModule\Form\Element\Proxy');
         $proxy->expects($this->once())->method('setOptions')->with(['is_method' => true]);

--- a/tests/DoctrineModuleTest/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyAwareElementTestCase.php
@@ -9,6 +9,7 @@ use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+
 use function array_shift;
 use function func_get_args;
 use function get_class;
@@ -18,7 +19,7 @@ class ProxyAwareElementTestCase extends TestCase
     /** @var MockObject */
     protected $element;
 
-    protected function prepareProxy() : void
+    protected function prepareProxy(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject();
@@ -92,7 +93,7 @@ class ProxyAwareElementTestCase extends TestCase
     /**
      * Proxy should stay read only, use with care
      */
-    protected function setProxyViaReflection(MockObject $proxy, ?MockObject $element = null) : void
+    protected function setProxyViaReflection(MockObject $proxy, ?MockObject $element = null): void
     {
         if (! $element) {
             $element = $this->element;

--- a/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
+++ b/tests/DoctrineModuleTest/Form/Element/ProxyTest.php
@@ -11,6 +11,7 @@ use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
+
 use function array_shift;
 use function func_get_args;
 use function get_class;
@@ -33,13 +34,13 @@ class ProxyTest extends TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->proxy = new Proxy();
     }
 
-    public function testExceptionThrownForMissingObjectManager() : void
+    public function testExceptionThrownForMissingObjectManager(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No object manager was set');
@@ -48,7 +49,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testExceptionThrownForMissingTargetClass() : void
+    public function testExceptionThrownForMissingTargetClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No target class was set');
@@ -59,7 +60,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testExceptionThrownForMissingFindMethodName() : void
+    public function testExceptionThrownForMissingFindMethodName(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No method name was set');
@@ -82,7 +83,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testExceptionFindMethodNameNotExistentInRepository() : void
+    public function testExceptionFindMethodNameNotExistentInRepository(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $metadata    = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
@@ -116,7 +117,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testExceptionThrownForMissingRequiredParameter() : void
+    public function testExceptionThrownForMissingRequiredParameter(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $metadata    = $this->createMock('Doctrine\Persistence\Mapping\ClassMetadata');
@@ -154,7 +155,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testToStringIsUsedForGetValueOptions() : void
+    public function testToStringIsUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -165,7 +166,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[1]['value'], 2);
     }
 
-    public function testPropertyGetterUsedForGetValueOptions() : void
+    public function testPropertyGetterUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -183,7 +184,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[1]['value'], 2);
     }
 
-    public function testPublicPropertyUsedForGetValueOptions() : void
+    public function testPublicPropertyUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -203,7 +204,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[1]['value'], 2);
     }
 
-    public function testIsMethodOptionUsedForGetValueOptions() : void
+    public function testIsMethodOptionUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -222,7 +223,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[1]['value'], 2);
     }
 
-    public function testDisplayEmptyItemAndEmptyItemLabelOptionsUsedForGetValueOptions() : void
+    public function testDisplayEmptyItemAndEmptyItemLabelOptionsUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -236,7 +237,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[''], '---');
     }
 
-    public function testLabelGeneratorUsedForGetValueOptions() : void
+    public function testLabelGeneratorUsedForGetValueOptions(): void
     {
         $this->prepareProxy();
 
@@ -256,7 +257,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($result[1]['value'], 2);
     }
 
-    public function testExceptionThrownForNonCallableLabelGenerator() : void
+    public function testExceptionThrownForNonCallableLabelGenerator(): void
     {
         $this->prepareProxy();
 
@@ -270,7 +271,7 @@ class ProxyTest extends TestCase
         $this->proxy->setOptions(['label_generator' => 'I throw an invalid type error']);
     }
 
-    public function testUsingOptionAttributesOfTypeString() : void
+    public function testUsingOptionAttributesOfTypeString(): void
     {
         $this->prepareProxy();
 
@@ -297,7 +298,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($expectedAttributes, $options[1]['attributes']);
     }
 
-    public function testUsingOptionAttributesOfTypeCallableReturningString() : void
+    public function testUsingOptionAttributesOfTypeCallableReturningString(): void
     {
         $this->prepareProxy();
 
@@ -320,7 +321,7 @@ class ProxyTest extends TestCase
         $this->assertEquals(['data-id' => 2], $options[1]['attributes']);
     }
 
-    public function testRuntimeExceptionOnWrongOptionAttributesValue() : void
+    public function testRuntimeExceptionOnWrongOptionAttributesValue(): void
     {
         $this->prepareProxy();
 
@@ -335,7 +336,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testCanWorkWithEmptyTables() : void
+    public function testCanWorkWithEmptyTables(): void
     {
         $this->prepareEmptyProxy();
 
@@ -343,7 +344,7 @@ class ProxyTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testCanWorkWithEmptyDataReturnedAsArray() : void
+    public function testCanWorkWithEmptyDataReturnedAsArray(): void
     {
         $this->prepareEmptyProxy([]);
 
@@ -351,7 +352,7 @@ class ProxyTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testExceptionThrownForNonTraversableResults() : void
+    public function testExceptionThrownForNonTraversableResults(): void
     {
         $this->prepareEmptyProxy(new stdClass());
 
@@ -365,7 +366,7 @@ class ProxyTest extends TestCase
         $this->proxy->getValueOptions();
     }
 
-    public function testUsingFindMethod() : void
+    public function testUsingFindMethod(): void
     {
         $this->prepareFilteredProxy();
 
@@ -376,7 +377,7 @@ class ProxyTest extends TestCase
      * A \RuntimeException should be thrown when the optgroup_identifier option does not reflect an existing method
      * within the target object
      */
-    public function testExceptionThrownWhenOptgroupIdentifiesNotCallable() : void
+    public function testExceptionThrownWhenOptgroupIdentifiesNotCallable(): void
     {
         $this->prepareProxyWithOptgroupPreset();
 
@@ -396,7 +397,7 @@ class ProxyTest extends TestCase
      *
      * Entries should be grouped accordingly under the respective keys.
      */
-    public function testValueOptionsGeneratedProperlyWithOptgroups() : void
+    public function testValueOptionsGeneratedProperlyWithOptgroups(): void
     {
         $this->prepareProxyWithOptgroupPreset();
 
@@ -444,7 +445,7 @@ class ProxyTest extends TestCase
      *
      * Both entries should be grouped under the optgroup_default key.
      */
-    public function testEmptyOptgroupValueBelongsToOptgroupDefaultIfConfigured() : void
+    public function testEmptyOptgroupValueBelongsToOptgroupDefaultIfConfigured(): void
     {
         $this->prepareProxy();
 
@@ -486,7 +487,7 @@ class ProxyTest extends TestCase
      *
      * Entry one should be grouped, entry two shouldn't be.
      */
-    public function testEmptyOptgroupValueBelongsToNoOptgroupIfNotConfigured() : void
+    public function testEmptyOptgroupValueBelongsToNoOptgroupIfNotConfigured(): void
     {
         $this->prepareProxyWithOptgroupPresetThatHasPartiallyEmptyOptgroupValues();
 
@@ -515,7 +516,7 @@ class ProxyTest extends TestCase
         $this->assertEquals($expectedOutput, $valueOptions);
     }
 
-    protected function prepareProxy() : void
+    protected function prepareProxy(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject();
@@ -585,7 +586,7 @@ class ProxyTest extends TestCase
         $this->metadata = $metadata;
     }
 
-    protected function prepareProxyWithOptgroupPreset() : void
+    protected function prepareProxyWithOptgroupPreset(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject();
@@ -670,7 +671,7 @@ class ProxyTest extends TestCase
         $this->metadata = $metadata;
     }
 
-    protected function prepareProxyWithOptgroupPresetThatHasPartiallyEmptyOptgroupValues() : void
+    protected function prepareProxyWithOptgroupPresetThatHasPartiallyEmptyOptgroupValues(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject();
@@ -741,7 +742,7 @@ class ProxyTest extends TestCase
         $this->metadata = $metadata;
     }
 
-    protected function prepareFilteredProxy() : void
+    protected function prepareFilteredProxy(): void
     {
         $objectClass = 'DoctrineModuleTest\Form\Element\TestAsset\FormObject';
         $objectOne   = new FormObject();
@@ -821,7 +822,7 @@ class ProxyTest extends TestCase
     /**
      * @param mixed $result
      */
-    public function prepareEmptyProxy($result = null) : void
+    public function prepareEmptyProxy($result = null): void
     {
         if ($result === null) {
             $result = new ArrayCollection();

--- a/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
+++ b/tests/DoctrineModuleTest/Form/Element/TestAsset/FormObject.php
@@ -34,96 +34,96 @@ class FormObject
     /** @var string|null */
     protected $optgroup;
 
-    public function __toString() : string
+    public function __toString(): string
     {
         assert($this->username !== null);
 
         return $this->username;
     }
 
-    public function setId(int $id) : self
+    public function setId(int $id): self
     {
         $this->id = (int) $id;
 
         return $this;
     }
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setEmail(string $email) : self
+    public function setEmail(string $email): self
     {
         $this->email = (string) $email;
 
         return $this;
     }
 
-    public function getEmail() : ?string
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    public function setPassword(string $password) : self
+    public function setPassword(string $password): self
     {
         $this->password = (string) $password;
 
         return $this;
     }
 
-    public function getPassword() : ?string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    public function setUsername(string $username) : self
+    public function setUsername(string $username): self
     {
         $this->username = (string) $username;
 
         return $this;
     }
 
-    public function getUsername() : ?string
+    public function getUsername(): ?string
     {
         return $this->username;
     }
 
-    public function setFirstname(string $firstname) : self
+    public function setFirstname(string $firstname): self
     {
         $this->firstname = (string) $firstname;
 
         return $this;
     }
 
-    public function getFirstname() : ?string
+    public function getFirstname(): ?string
     {
         return $this->firstname;
     }
 
-    public function setSurname(string $surname) : self
+    public function setSurname(string $surname): self
     {
         $this->surname = (string) $surname;
 
         return $this;
     }
 
-    public function getSurname() : ?string
+    public function getSurname(): ?string
     {
         return $this->surname;
     }
 
-    public function getName() : ?string
+    public function getName(): ?string
     {
         return isset($this->firstname) && isset($this->surname) ? $this->firstname . ' ' . $this->surname : null;
     }
 
-    public function getOptgroup() : ?string
+    public function getOptgroup(): ?string
     {
         return $this->optgroup;
     }
 
-    public function setOptgroup(?string $optgroup) : void
+    public function setOptgroup(?string $optgroup): void
     {
         $this->optgroup = $optgroup;
     }

--- a/tests/DoctrineModuleTest/ModuleTest.php
+++ b/tests/DoctrineModuleTest/ModuleTest.php
@@ -11,6 +11,7 @@ use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use function serialize;
 use function unserialize;
 
@@ -32,7 +33,7 @@ class ModuleTest extends TestCase
     /** @var PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Console\Application */
     private $cli;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->application    = $this->getMockBuilder('Laminas\Mvc\Application')
             ->disableOriginalConstructor()
@@ -64,7 +65,7 @@ class ModuleTest extends TestCase
     /**
      * @covers \DoctrineModule\Module::getConfig
      */
-    public function testGetConfig() : void
+    public function testGetConfig(): void
     {
         $module = new Module();
 
@@ -86,7 +87,7 @@ class ModuleTest extends TestCase
      *
      * @covers \DoctrineModule\Module::getConsoleUsage
      */
-    public function testGetConsoleUsage() : void
+    public function testGetConsoleUsage(): void
     {
         $this
             ->cli
@@ -96,7 +97,7 @@ class ModuleTest extends TestCase
                 $this->isInstanceOf('Symfony\Component\Console\Input\InputInterface'),
                 $this->isInstanceOf('Symfony\Component\Console\Output\OutputInterface')
             )
-            ->will($this->returnCallback(static function (InputInterface $input, OutputInterface $output) : void {
+            ->will($this->returnCallback(static function (InputInterface $input, OutputInterface $output): void {
                 $output->write($input->getFirstArgument() . ' - TEST');
                 $output->write(' - More output');
             }));

--- a/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
+++ b/tests/DoctrineModuleTest/Mvc/Router/Console/SymfonyCliTest.php
@@ -20,12 +20,12 @@ class SymfonyCliTest extends TestCase
     /** @var SymfonyCli */
     protected $route;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->route = new SymfonyCli(new Application());
     }
 
-    public function testMatching() : void
+    public function testMatching(): void
     {
         $this->assertInstanceOf(
             RouteMatch::class,
@@ -33,7 +33,7 @@ class SymfonyCliTest extends TestCase
         );
     }
 
-    public function testMatchingWithParams() : void
+    public function testMatchingWithParams(): void
     {
         $this->assertInstanceOf(
             RouteMatch::class,
@@ -41,7 +41,7 @@ class SymfonyCliTest extends TestCase
         );
     }
 
-    public function testNotMatching() : void
+    public function testNotMatching(): void
     {
         $this->assertNull($this->route->match(new Request(['scriptname.php', 'unknowncommand'])));
     }

--- a/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/DoctrineModuleTest/Paginator/Adapter/CollectionAdapterTest.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Paginator\Adapter;
 use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Paginator\Adapter\Collection as CollectionAdapter;
 use PHPUnit\Framework\TestCase;
+
 use function range;
 
 /**
@@ -22,32 +23,32 @@ class CollectionAdapterTest extends TestCase
     /**
      * {@inheritDoc}.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->adapter = new CollectionAdapter(new ArrayCollection(range(1, 101)));
     }
 
-    public function testGetsItemsAtOffsetZero() : void
+    public function testGetsItemsAtOffsetZero(): void
     {
         $expected = range(1, 10);
         $actual   = $this->adapter->getItems(0, 10);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsItemsAtOffsetTen() : void
+    public function testGetsItemsAtOffsetTen(): void
     {
         $expected = range(11, 20);
         $actual   = $this->adapter->getItems(10, 10);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testReturnsCorrectCount() : void
+    public function testReturnsCorrectCount(): void
     {
         $this->assertEquals(101, $this->adapter->count());
     }
 
-    public function testEmptySet() : void
+    public function testEmptySet(): void
     {
         $adapter = new CollectionAdapter(new ArrayCollection());
         $actual  = $adapter->getItems(0, 10);

--- a/tests/DoctrineModuleTest/Paginator/Adapter/SelectableAdapterTest.php
+++ b/tests/DoctrineModuleTest/Paginator/Adapter/SelectableAdapterTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use DoctrineModule\Paginator\Adapter\Selectable as SelectableAdapter;
 use PHPUnit\Framework\TestCase;
+
 use function range;
 
 /**
@@ -20,7 +21,7 @@ class SelectableAdapterTest extends TestCase
     /**
      * @covers \DoctrineModule\Paginator\Adapter\Selectable::getItems
      */
-    public function testGetItemsAtOffsetZeroWithEmptyCriteria() : void
+    public function testGetItemsAtOffsetZeroWithEmptyCriteria(): void
     {
         $selectable = $this->createMock('Doctrine\Common\Collections\Selectable');
         $adapter    = new SelectableAdapter($selectable);
@@ -51,7 +52,7 @@ class SelectableAdapterTest extends TestCase
     /**
      * @covers \DoctrineModule\Paginator\Adapter\Selectable::getItems
      */
-    public function testGetItemsAtOffsetZeroWithNonEmptyCriteria() : void
+    public function testGetItemsAtOffsetZeroWithNonEmptyCriteria(): void
     {
         $selectable = $this->createMock('Doctrine\Common\Collections\Selectable');
         $criteria   = new Criteria(Criteria::expr()->eq('foo', 'bar'));
@@ -85,7 +86,7 @@ class SelectableAdapterTest extends TestCase
     /**
      * @covers \DoctrineModule\Paginator\Adapter\Selectable::getItems
      */
-    public function testGetItemsAtOffsetTenWithEmptyCriteria() : void
+    public function testGetItemsAtOffsetTenWithEmptyCriteria(): void
     {
         $selectable = $this->createMock('Doctrine\Common\Collections\Selectable');
         $adapter    = new SelectableAdapter($selectable);
@@ -115,7 +116,7 @@ class SelectableAdapterTest extends TestCase
     /**
      * @covers \DoctrineModule\Paginator\Adapter\Selectable::getItems
      */
-    public function testGetItemsAtOffsetTenWithNonEmptyCriteria() : void
+    public function testGetItemsAtOffsetTenWithNonEmptyCriteria(): void
     {
         $selectable = $this->createMock('Doctrine\Common\Collections\Selectable');
         $criteria   = new Criteria(Criteria::expr()->eq('foo', 'bar'));
@@ -149,7 +150,7 @@ class SelectableAdapterTest extends TestCase
     /**
      * @covers \DoctrineModule\Paginator\Adapter\Selectable::count
      */
-    public function testReturnsCorrectCount() : void
+    public function testReturnsCorrectCount(): void
     {
         $selectable = $this->createMock('Doctrine\Common\Collections\Selectable');
         $expression = Criteria::expr()->eq('foo', 'bar');

--- a/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AdapterFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class AdapterFactoryTest extends BaseTestCase
 {
-    public function testWillInstantiateFromFQCN() : void
+    public function testWillInstantiateFromFQCN(): void
     {
         $name           = 'testFactory';
         $factory        = new AdapterFactory($name);

--- a/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class AuthenticationServiceFactoryTest extends BaseTestCase
 {
-    public function testWillInstantiateFromFQCN() : void
+    public function testWillInstantiateFromFQCN(): void
     {
         $name    = 'testFactory';
         $factory = new AuthenticationServiceFactory($name);

--- a/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/Authentication/StorageFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class StorageFactoryTest extends BaseTestCase
 {
-    public function testWillInstantiateFromFQCN() : void
+    public function testWillInstantiateFromFQCN(): void
     {
         $name    = 'testFactory';
         $factory = new StorageFactory($name);
@@ -42,7 +42,7 @@ class StorageFactoryTest extends BaseTestCase
         $this->assertInstanceOf('DoctrineModule\Authentication\Storage\ObjectRepository', $adapter);
     }
 
-    public function testCanInstantiateStorageFromServiceLocator() : void
+    public function testCanInstantiateStorageFromServiceLocator(): void
     {
         $factory        = new StorageFactory('testFactory');
         $serviceManager = $this->createMock('Laminas\ServiceManager\ServiceManager');

--- a/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/CacheFactoryTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Cache\ChainCache;
 use DoctrineModule\Service\CacheFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+
 use function assert;
 
 /**
@@ -19,7 +20,7 @@ class CacheFactoryTest extends BaseTestCase
     /**
      * @covers \DoctrineModule\Service\CacheFactory::createService
      */
-    public function testWillSetNamespace() : void
+    public function testWillSetNamespace(): void
     {
         $factory        = new CacheFactory('foo');
         $serviceManager = new ServiceManager();
@@ -45,7 +46,7 @@ class CacheFactoryTest extends BaseTestCase
      * @covers \DoctrineModule\Service\CacheFactory::createService
      * @group 547
      */
-    public function testCreateLaminasCache() : void
+    public function testCreateLaminasCache(): void
     {
         $factory        = new CacheFactory('phpunit');
         $serviceManager = new ServiceManager();
@@ -75,7 +76,7 @@ class CacheFactoryTest extends BaseTestCase
         $this->assertInstanceOf('DoctrineModule\Cache\LaminasStorageCache', $cache);
     }
 
-    public function testCreatePredisCache() : void
+    public function testCreatePredisCache(): void
     {
         $factory        = new CacheFactory('predis');
         $serviceManager = new ServiceManager();
@@ -102,7 +103,7 @@ class CacheFactoryTest extends BaseTestCase
         $this->assertInstanceOf('Doctrine\Common\Cache\PredisCache', $cache);
     }
 
-    public function testUseServiceFactory() : void
+    public function testUseServiceFactory(): void
     {
         $factory        = new CacheFactory('chain');
         $serviceManager = new ServiceManager();

--- a/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/DriverFactoryTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 class DriverFactoryTest extends BaseTestCase
 {
-    public function testCreateDriver() : void
+    public function testCreateDriver(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
@@ -32,7 +32,7 @@ class DriverFactoryTest extends BaseTestCase
         $this->assertInstanceOf('DoctrineModuleTest\Service\Mock\MetadataDriverMock', $driver);
     }
 
-    public function testCreateDriverChain() : void
+    public function testCreateDriverChain(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(

--- a/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
+++ b/tests/DoctrineModuleTest/Service/EventManagerFactoryTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 class EventManagerFactoryTest extends BaseTestCase
 {
-    public function testWillInstantiateFromFQCN() : void
+    public function testWillInstantiateFromFQCN(): void
     {
         $name           = 'eventManagerFactory';
         $factory        = new EventManagerFactory($name);
@@ -42,7 +42,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testWillAttachEventListenersFromConfiguredInstances() : void
+    public function testWillAttachEventListenersFromConfiguredInstances(): void
     {
         $name           = 'eventManagerFactory';
         $factory        = new EventManagerFactory($name);
@@ -71,7 +71,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $this->assertContains($subscriber, $listeners);
     }
 
-    public function testWillAttachEventListenersFromServiceManagerAlias() : void
+    public function testWillAttachEventListenersFromServiceManagerAlias(): void
     {
         $name           = 'eventManagerFactory';
         $factory        = new EventManagerFactory($name);
@@ -101,7 +101,7 @@ class EventManagerFactoryTest extends BaseTestCase
         $this->assertContains($subscriber, $listeners);
     }
 
-    public function testWillRefuseNonExistingSubscriber() : void
+    public function testWillRefuseNonExistingSubscriber(): void
     {
         $name           = 'eventManagerFactory';
         $factory        = new EventManagerFactory($name);

--- a/tests/DoctrineModuleTest/Service/Mock/MetadataDriverMock.php
+++ b/tests/DoctrineModuleTest/Service/Mock/MetadataDriverMock.php
@@ -12,14 +12,14 @@ class MetadataDriverMock implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata) : void
+    public function loadMetadataForClass($className, ClassMetadata $metadata): void
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function isTransient($className) : bool
+    public function isTransient($className): bool
     {
         return false;
     }
@@ -27,7 +27,7 @@ class MetadataDriverMock implements MappingDriver
     /**
      * @return string[]
      */
-    public function getAllClassNames() : array
+    public function getAllClassNames(): array
     {
         return [];
     }

--- a/tests/DoctrineModuleTest/Service/TestAsset/DummyEventSubscriber.php
+++ b/tests/DoctrineModuleTest/Service/TestAsset/DummyEventSubscriber.php
@@ -14,7 +14,7 @@ class DummyEventSubscriber implements EventSubscriber
     /**
      * Empty callback method
      */
-    public function dummy() : void
+    public function dummy(): void
     {
     }
 

--- a/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/DoctrineModuleTest/ServiceFactory/ModuleDefinedServicesTest.php
@@ -18,7 +18,7 @@ class ModuleDefinedServicesTest extends TestCase
     /** @var ServiceLocatorInterface */
     protected $serviceManager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->serviceManager = ServiceManagerFactory::getServiceManager();
     }
@@ -28,7 +28,7 @@ class ModuleDefinedServicesTest extends TestCase
      *
      * @dataProvider getServicesThatShouldBeDefined
      */
-    public function testModuleDefinedServices(string $serviceName, bool $defined) : void
+    public function testModuleDefinedServices(string $serviceName, bool $defined): void
     {
         $this->assertSame($defined, $this->serviceManager->has($serviceName));
     }
@@ -38,7 +38,7 @@ class ModuleDefinedServicesTest extends TestCase
      *
      * @dataProvider getServicesThatCanBeFetched
      */
-    public function testModuleFetchedService(string $serviceName, string $expectedClass) : void
+    public function testModuleFetchedService(string $serviceName, string $expectedClass): void
     {
         $this->assertInstanceOf($expectedClass, $this->serviceManager->get($serviceName));
     }
@@ -48,7 +48,7 @@ class ModuleDefinedServicesTest extends TestCase
      *
      * @dataProvider getServicesThatCannotBeFetched
      */
-    public function testModuleInvalidService(string $serviceName) : void
+    public function testModuleInvalidService(string $serviceName): void
     {
         $this->expectException('Laminas\ServiceManager\Exception\ServiceNotFoundException');
 
@@ -58,7 +58,7 @@ class ModuleDefinedServicesTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function getServicesThatShouldBeDefined() : array
+    public function getServicesThatShouldBeDefined(): array
     {
         return [
             ['doctrine.cache.array', true],
@@ -90,7 +90,7 @@ class ModuleDefinedServicesTest extends TestCase
     /**
      * @return string[][]
      */
-    public function getServicesThatCanBeFetched() : array
+    public function getServicesThatCanBeFetched(): array
     {
         return [
             ['doctrine.cache.array', 'Doctrine\Common\Cache\ArrayCache'],
@@ -100,7 +100,7 @@ class ModuleDefinedServicesTest extends TestCase
     /**
      * @return string[][]
      */
-    public function getServicesThatCannotBeFetched() : array
+    public function getServicesThatCannotBeFetched(): array
     {
         return [
             ['foo'],

--- a/tests/DoctrineModuleTest/ServiceManagerFactory.php
+++ b/tests/DoctrineModuleTest/ServiceManagerFactory.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest;
 use Laminas\ModuleManager\ModuleManagerInterface;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;
+
 use function assert;
 
 /**
@@ -17,7 +18,7 @@ class ServiceManagerFactory
     /**
      * @return mixed[]
      */
-    public static function getConfiguration() : array
+    public static function getConfiguration(): array
     {
         return include __DIR__ . '/../TestConfiguration.php';
     }
@@ -27,7 +28,7 @@ class ServiceManagerFactory
      *
      * @param mixed[]|null $configuration
      */
-    public static function getServiceManager(?array $configuration = null) : ServiceManager
+    public static function getServiceManager(?array $configuration = null): ServiceManager
     {
         $configuration        = $configuration ?: static::getConfiguration();
         $serviceManager       = new ServiceManager();

--- a/tests/DoctrineModuleTest/Validator/NoObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/NoObjectExistsTest.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Validator\Adapter;
 use DoctrineModule\Validator\NoObjectExists;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use stdClass;
+
 use function str_replace;
 
 /**
@@ -16,7 +17,7 @@ use function str_replace;
  */
 class NoObjectExistsTest extends BaseTestCase
 {
-    public function testCanValidateWithNoAvailableObjectInRepository() : void
+    public function testCanValidateWithNoAvailableObjectInRepository(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
@@ -30,7 +31,7 @@ class NoObjectExistsTest extends BaseTestCase
         $this->assertTrue($validator->isValid('matchValue'));
     }
 
-    public function testCannotValidateWithAvailableObjectInRepository() : void
+    public function testCannotValidateWithAvailableObjectInRepository(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
@@ -44,7 +45,7 @@ class NoObjectExistsTest extends BaseTestCase
         $this->assertFalse($validator->isValid('matchValue'));
     }
 
-    public function testErrorMessageIsStringInsteadArray() : void
+    public function testErrorMessageIsStringInsteadArray(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository

--- a/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
+++ b/tests/DoctrineModuleTest/Validator/ObjectExistsTest.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Validator\Adapter;
 use DoctrineModule\Validator\ObjectExists;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use stdClass;
+
 use function str_replace;
 
 /**
@@ -18,7 +19,7 @@ use function str_replace;
  */
 class ObjectExistsTest extends BaseTestCase
 {
-    public function testCanValidateWithSingleField() : void
+    public function testCanValidateWithSingleField(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
@@ -34,7 +35,7 @@ class ObjectExistsTest extends BaseTestCase
         $this->assertTrue($validator->isValid(['matchKey' => 'matchValue']));
     }
 
-    public function testCanValidateWithMultipleFields() : void
+    public function testCanValidateWithMultipleFields(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
@@ -59,7 +60,7 @@ class ObjectExistsTest extends BaseTestCase
         $this->assertTrue($validator->isValid(['firstMatchValue', 'secondMatchValue']));
     }
 
-    public function testCanValidateFalseOnNoResult() : void
+    public function testCanValidateFalseOnNoResult(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
@@ -74,28 +75,28 @@ class ObjectExistsTest extends BaseTestCase
         $this->assertFalse($validator->isValid('value'));
     }
 
-    public function testWillRefuseMissingRepository() : void
+    public function testWillRefuseMissingRepository(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['fields' => 'field']);
     }
 
-    public function testWillRefuseNonObjectRepository() : void
+    public function testWillRefuseNonObjectRepository(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['object_repository' => 'invalid', 'fields' => 'field']);
     }
 
-    public function testWillRefuseInvalidRepository() : void
+    public function testWillRefuseInvalidRepository(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
         new ObjectExists(['object_repository' => new stdClass(), 'fields' => 'field']);
     }
 
-    public function testWillRefuseMissingFields() : void
+    public function testWillRefuseMissingFields(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
@@ -104,7 +105,7 @@ class ObjectExistsTest extends BaseTestCase
         ]);
     }
 
-    public function testWillRefuseEmptyFields() : void
+    public function testWillRefuseEmptyFields(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
 
@@ -114,7 +115,7 @@ class ObjectExistsTest extends BaseTestCase
         ]);
     }
 
-    public function testWillRefuseNonStringFields() : void
+    public function testWillRefuseNonStringFields(): void
     {
         $this->expectException('Laminas\Validator\Exception\InvalidArgumentException');
         new ObjectExists([
@@ -123,7 +124,7 @@ class ObjectExistsTest extends BaseTestCase
         ]);
     }
 
-    public function testWillNotValidateOnFieldsCountMismatch() : void
+    public function testWillNotValidateOnFieldsCountMismatch(): void
     {
         $this->expectException(
             'Laminas\Validator\Exception\RuntimeException'
@@ -138,7 +139,7 @@ class ObjectExistsTest extends BaseTestCase
         $validator->isValid(['field1Value']);
     }
 
-    public function testWillNotValidateOnFieldKeysMismatch() : void
+    public function testWillNotValidateOnFieldKeysMismatch(): void
     {
         $this->expectException(
             'Laminas\Validator\Exception\RuntimeException'
@@ -155,7 +156,7 @@ class ObjectExistsTest extends BaseTestCase
         $validator->isValid(['field1' => 'field1Value']);
     }
 
-    public function testErrorMessageIsStringInsteadArray() : void
+    public function testErrorMessageIsStringInsteadArray(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $validator  = new ObjectExists([

--- a/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/NoObjectExistsFactoryTest.php
@@ -12,6 +12,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorAwareInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase;
+
 use function interface_exists;
 
 /**
@@ -29,7 +30,7 @@ class NoObjectExistsFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->object = new NoObjectExistsFactory();
     }
@@ -37,7 +38,7 @@ class NoObjectExistsFactoryTest extends TestCase
     /**
      * @coversNothing
      */
-    public function testCallable() : void
+    public function testCallable(): void
     {
         $this->assertIsCallable($this->object);
     }
@@ -49,7 +50,7 @@ class NoObjectExistsFactoryTest extends TestCase
      * @covers ::getObjectManager
      * @covers ::getFields
      */
-    public function testInvoke() : void
+    public function testInvoke(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',
@@ -82,7 +83,7 @@ class NoObjectExistsFactoryTest extends TestCase
      * @covers ::getObjectManager
      * @covers ::getFields
      */
-    public function testInvokeWithObjectManagerGiven() : void
+    public function testInvokeWithObjectManagerGiven(): void
     {
         $repository    = $this->prophesize(ObjectRepository::class);
         $objectManager = $this->prophesize(ObjectManager::class);
@@ -111,7 +112,7 @@ class NoObjectExistsFactoryTest extends TestCase
     /**
      * @covers ::merge
      */
-    public function testInvokeWithMerge() : void
+    public function testInvokeWithMerge(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',
@@ -143,7 +144,7 @@ class NoObjectExistsFactoryTest extends TestCase
     /**
      * @covers ::getRepository
      */
-    public function testInvokeWithoutTargetClass() : void
+    public function testInvokeWithoutTargetClass(): void
     {
         $this->expectException(ServiceCreationException::class);
 
@@ -159,7 +160,7 @@ class NoObjectExistsFactoryTest extends TestCase
      * @covers ::createService
      * @covers ::setCreationOptions
      */
-    public function testCreateService() : void
+    public function testCreateService(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',
@@ -185,7 +186,7 @@ class NoObjectExistsFactoryTest extends TestCase
     /**
      * @covers ::container
      */
-    public function testCreateServiceWithServiceLocatorAwareInterface() : void
+    public function testCreateServiceWithServiceLocatorAwareInterface(): void
     {
         if (! interface_exists(ServiceLocatorAwareInterface::class)) {
             $this->markTestSkipped('ServiceLocatorAwareInterface not defined');

--- a/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/ObjectExistsFactoryTest.php
@@ -25,7 +25,7 @@ class ObjectExistsFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->object = new ObjectExistsFactory();
     }
@@ -33,7 +33,7 @@ class ObjectExistsFactoryTest extends TestCase
     /**
      * @covers ::__invoke
      */
-    public function testInvoke() : void
+    public function testInvoke(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',

--- a/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
+++ b/tests/DoctrineModuleTest/Validator/Service/UniqueObjectFactoryTest.php
@@ -25,7 +25,7 @@ class UniqueObjectFactoryTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->object = new UniqueObjectFactory();
     }
@@ -33,7 +33,7 @@ class UniqueObjectFactoryTest extends TestCase
     /**
      * @covers ::__invoke
      */
-    public function testInvoke() : void
+    public function testInvoke(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',

--- a/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
+++ b/tests/DoctrineModuleTest/Validator/UniqueObjectTest.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use Laminas\Validator\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use stdClass;
+
 use function sprintf;
 use function str_replace;
 
@@ -21,7 +22,7 @@ use function str_replace;
  */
 class UniqueObjectTest extends BaseTestCase
 {
-    public function testCanValidateWithNotAvailableObjectInRepository() : void
+    public function testCanValidateWithNotAvailableObjectInRepository(): void
     {
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
         $repository
@@ -40,7 +41,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertTrue($validator->isValid('matchValue'));
     }
 
-    public function testCanValidateIfThereIsTheSameObjectInTheRepository() : void
+    public function testCanValidateIfThereIsTheSameObjectInTheRepository(): void
     {
         $match = new stdClass();
 
@@ -80,7 +81,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertTrue($validator->isValid(['matchKey' => 'matchValue', 'id' => 'identifier']));
     }
 
-    public function testCannotValidateIfThereIsAnotherObjectWithTheSameValueInTheRepository() : void
+    public function testCannotValidateIfThereIsAnotherObjectWithTheSameValueInTheRepository(): void
     {
         $match = new stdClass();
 
@@ -120,7 +121,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertFalse($validator->isValid(['matchKey' => 'matchValue', 'id' => 'another identifier']));
     }
 
-    public function testCanFetchIdentifierFromContext() : void
+    public function testCanFetchIdentifierFromContext(): void
     {
         $match = new stdClass();
 
@@ -161,7 +162,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertTrue($validator->isValid('matchValue', ['id' => 'identifier']));
     }
 
-    public function testThrowsAnExceptionOnUsedButMissingContext() : void
+    public function testThrowsAnExceptionOnUsedButMissingContext(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expected context to be an array but is null');
@@ -186,7 +187,7 @@ class UniqueObjectTest extends BaseTestCase
         $validator->isValid('matchValue');
     }
 
-    public function testThrowsAnExceptionOnMissingIdentifier() : void
+    public function testThrowsAnExceptionOnMissingIdentifier(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expected context to contain id');
@@ -224,7 +225,7 @@ class UniqueObjectTest extends BaseTestCase
         $validator->isValid('matchValue');
     }
 
-    public function testThrowsAnExceptionOnMissingIdentifierInContext() : void
+    public function testThrowsAnExceptionOnMissingIdentifierInContext(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expected context to contain id');
@@ -263,7 +264,7 @@ class UniqueObjectTest extends BaseTestCase
         $validator->isValid('matchValue', []);
     }
 
-    public function testThrowsAnExceptionOnMissingObjectManager() : void
+    public function testThrowsAnExceptionOnMissingObjectManager(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
@@ -279,7 +280,7 @@ class UniqueObjectTest extends BaseTestCase
         ]);
     }
 
-    public function testThrowsAnExceptionOnWrongObjectManager() : void
+    public function testThrowsAnExceptionOnWrongObjectManager(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
@@ -298,7 +299,7 @@ class UniqueObjectTest extends BaseTestCase
         ]);
     }
 
-    public function testCanValidateWithNotAvailableObjectInRepositoryByDateTimeObject() : void
+    public function testCanValidateWithNotAvailableObjectInRepositoryByDateTimeObject(): void
     {
         $date       = new DateTime('17 March 2014');
         $repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
@@ -319,7 +320,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertTrue($validator->isValid($date));
     }
 
-    public function testCanFetchIdentifierFromObjectContext() : void
+    public function testCanFetchIdentifierFromObjectContext(): void
     {
         $context     = new stdClass();
         $context->id = 'identifier';
@@ -365,7 +366,7 @@ class UniqueObjectTest extends BaseTestCase
         $this->assertTrue($validator->isValid('matchValue', $context));
     }
 
-    public function testErrorMessageIsStringInsteadArray() : void
+    public function testErrorMessageIsStringInsteadArray(): void
     {
         $match = new stdClass();
 


### PR DESCRIPTION
Update coding standard and use phpcbf to update code to the coding standard.