### PR TITLE
Added missing direct dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,9 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
+        "doctrine/annotations": "^1.11",
         "doctrine/cache": "^1.7",
+        "doctrine/collections": "^1.6",
         "doctrine/doctrine-laminas-hydrator": "^2.0.3",
         "doctrine/event-manager": "^1.0.0",
         "doctrine/inflector": "^2.0",


### PR DESCRIPTION
Some classes are used but not required and not mentioned in the suggest section

```
Targets
    Occurrences of 'Doctrine\Common' in Directory /projects/github/DoctrineModule/src
Found Occurrences 
    Unclassified  (14 usages found)
        DoctrineModule  (14 usages found)
            src/DoctrineModule  (1 usage found)
                Module.php  (1 usage found)
                    7 use Doctrine\Common\Annotations\AnnotationRegistry;
            src/DoctrineModule/Form/Element  (1 usage found)
                Proxy.php  (1 usage found)
                    7 use Doctrine\Common\Collections\Collection;
            src/DoctrineModule/Paginator/Adapter  (3 usages found)
                Collection.php  (1 usage found)
                    7 use Doctrine\Common\Collections\Collection as DoctrineCollection;
                Selectable.php  (2 usages found)
                    7 use Doctrine\Common\Collections\Criteria;
                    8 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
            src/DoctrineModule/Service 
                DriverFactory.php  (1 usage found)
                    7 use Doctrine\Common\Annotations;
```