### PR TITLE
removed unneeded laminas/laminas-hydrator dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "laminas/laminas-authentication": "^2.5.3",
         "laminas/laminas-cache": "^2.7.1",
         "laminas/laminas-form": "^2.11",
-        "laminas/laminas-hydrator": "^3.0",
         "laminas/laminas-mvc": "^3.1",
         "laminas/laminas-paginator": "^2.8",
         "laminas/laminas-servicemanager": "^3.3",

--- a/tests/TestConfiguration.php
+++ b/tests/TestConfiguration.php
@@ -6,7 +6,6 @@ return [
     'modules' => [
         'Laminas\Cache',
         'Laminas\Form',
-        'Laminas\Hydrator',
         'Laminas\Mvc\Console',
         'Laminas\Paginator',
         'Laminas\Router',


### PR DESCRIPTION
In #677 the hydrator-related code was removed from this module and moved into [doctrine/doctrine-laminas-hydrator](https://github.com/doctrine/doctrine-laminas-hydrator). Consequently, in e420353f46c995f1301ff50d31d6bb6e5ebbce90 a dependency to `doctrine/doctrine-laminas-hydrator` was added.

However, the dependency to `laminas/laminas-hydator` has not been removed back then, even though code from the Laminas module is never refered to in DoctrineModule. Even in the test cases, where the module `Laminas\Hydrator` is currently still loaded, no tests refer to that module. Code that is not needed should not be required, as current requirement of `^3.0` prevents users from upgrading to `laminas/laminas-hydrator:^4.0`.

This PR removes the dependency from `composer.json` and the module from `TestConfiguration.php`.