### PR TITLE
Fix configuration for laminas-component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,9 @@
         }
     ],
     "extra": {
-        "zf": {
+        "laminas": {
             "config-provider": "DoctrineModule\\ConfigProvider",
             "module": "DoctrineModule"
-        },
-        "branch-alias": {
-            "dev-1.2-dev": "1.2-dev",
-            "dev-2.0-dev": "2.0-dev"
         }
     },
     "require": {


### PR DESCRIPTION
The `composer.json` currently still holds an extra configuration targeted at the Zend Framework component installer, which was not ported to Laminas correctly. This PR holds the changes for porting this extra configuration to Laminas.

Note that in contrast to DoctrineModule (this repository), DoctrineORMModule was updated correctly: https://github.com/doctrine/DoctrineORMModule/blob/4.0.x/composer.json#L44

Besides, the branch aliases for 1.2-dev and 2.0-dev are outdated and should removed.