### PR TITLE
Declare compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,6 +37,14 @@ jobs:
             composer-options: "--ignore-platform-req=php"
             dependencies: "highest"
             laminas-form-version: "3.0.0"
+          - php-version: "8.1"
+            composer-options: "--ignore-platform-req=php"
+            dependencies: "highest"
+            laminas-form-version: "2.17.0"
+          - php-version: "8.1"
+            composer-options: "--ignore-platform-req=php"
+            dependencies: "highest"
+            laminas-form-version: "3.0.0"
 
     steps:
       - name: "Checkout"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and [DoctrineMongoODMModule](https://github.com/doctrine/DoctrineMongoODMModule)
 Run the following to install this library using [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require doctrine/doctrine-module
+composer require doctrine/doctrine-module
 ```
 
 ### Note on PHP 8.0 or later

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "doctrine/annotations": "^1.13.2",
         "doctrine/cache": "^1.12.1",
         "doctrine/collections": "^1.6.8",

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,5 +1,5 @@
-DoctrineModule
-==============
+Introduction
+============
 
 DoctrineModule provides a bridge between Laminas and Doctrine 2. It
 gives you access to features that can be used across Doctrine 2 ORM as
@@ -55,30 +55,28 @@ Next Steps
 
 You can find more details about the features offered by DoctrineModule:
 
--  `Authentication
-   documentation <https://github.com/doctrine/DoctrineModule/blob/master/docs/authentication.md>`__:
+-  :doc:`Authentication documentation <authentication>`:
    this explains how you can use the DoctrineModule authentication
    adapter and authentication storage adapter to provide a simple way to
    authenticate users using Doctrine.
--  `Caching
-   documentation <https://github.com/doctrine/DoctrineModule/blob/master/docs/caching.md>`__:
+-  :doc:`Caching documentation <caching>`:
    DoctrineModule provides simple classes to allow easier caching using
    Doctrine.
--  `CLI
-   documentation <https://github.com/doctrine/DoctrineModule/blob/master/docs/cli.md>`__:
+-  :doc:`CLI documentation <cli>`:
    learn how to use the Doctrine 2 command line tool, and how to add
    your own command.
+-  :doc:`Form elements <form-element>`:
+   if you are using Laminas Forms, this module provides select, radio and
+   checkbox elements for selecting objects from relationships.
 -  `Hydrator
-   documentation <https://github.com/doctrine/doctrine-laminas-hydrator/blob/master/README.md>`__:
-   if you are using Laminas Forms (and I hope you are !),
-   doctrine-laminas-hydrator provides a powerful hydrator that allows
+   documentation <https://www.doctrine-project.org/projects/doctrine-laminas-hydrator.html>`__:
+   if you are using Laminas Forms,
+   ``doctrine-laminas-hydrator`` provides a powerful hydrator that allows
    you to easily deal with OneToOne, OneToMany and ManyToOne
    relationships when using forms.
--  `Paginator
-   documentation <https://github.com/doctrine/DoctrineModule/blob/master/docs/paginator.md>`__:
+-  :doc:`Paginator documentation <paginator>`:
    discover how to use the DoctrineModule Paginator adapter.
--  `Validator
-   documentation <https://github.com/doctrine/DoctrineModule/blob/master/docs/validator.md>`__:
+-  :doc:`Validator documentation <validator>`:
    this chapter explains how to use ObjectExists and NoObjectExists
    validator, that allow you to easily validate if a given entity exists
    or not.

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,0 +1,10 @@
+.. toctree::
+    :depth: 3
+
+    index
+    authentication
+    caching
+    cli
+    form-element
+    paginator
+    validator


### PR DESCRIPTION
This PR declares the module to be compatible with PHP 8.1 and enables unit test to run with PHP 8.1, both with laminas-form v2 and v3.

Please note: Some of our upstream dependencies (e.g. laminas-authentication and laminas-cache) are not yet compatible with PHP 8.1. However, this is kind of an chicken vs. egg problem. I suggest that, once our code sucessfully runs with PHP 8.1, we should declare 8.1-compatibility. This is the case now.

In Github actions the dependencies are installed with `--ignore-platform-arg=php`, which tells Composer to ignore (only) the PHP-compatibility declared by our upstream dependencies. This lets us test our module against PHP 8.1

End users will not yet be able to install the module with PHP 8.1 though.