### PR TITLE
Added static analysis with Psalm and PhpStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@
 /phpcs.xml.dist export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
-/psalm.xml export-ignore
+/psalm.xml.dist export-ignore
 /tests/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,5 @@
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
 /psalm.xml.dist export-ignore
+/psalm-baseline.xml export-ignore
 /tests/ export-ignore

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   phpunit:
-    name: "Unit Tests"
+    name: "PHPUnit"
     runs-on: "ubuntu-20.04"
 
     strategy:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,16 @@
+name: "Static Analysis"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+  push:
+    branches:
+      - "*.x"
+
+jobs:
+  static-analysis:
+    name: "Static Analysis"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.1.1"
+    with:
+      php-version: '7.4'

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /composer.lock
 /phpcs.xml
 /phpunit.xml
+/psalm.xml
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -62,17 +62,20 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
-        "doctrine/orm": "^2.10.1",
+        "doctrine/orm": "^2.10.2",
         "laminas/laminas-i18n": "^2.11.3",
         "laminas/laminas-log": "^2.13.1",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc-console": "^1.3.0",
-        "laminas/laminas-serializer": "^2.10.1",
+        "laminas/laminas-serializer": "^2.11.0",
         "laminas/laminas-session": "^2.12.0",
         "laminas/laminas-test": "^3.5.1",
+        "jangregor/phpstan-prophecy": "^0.8.1",
         "phpspec/prophecy-phpunit": "^2.0.1",
+        "phpstan/phpstan": "^0.12.99",
         "phpunit/phpunit": "^9.5.10",
-        "predis/predis": "^1.1.9"
+        "predis/predis": "^1.1.9",
+        "vimeo/psalm": "^4.11.2"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
         "doctrine/orm": "^2.10.2",
+        "jangregor/phpstan-prophecy": "^0.8.1",
         "laminas/laminas-i18n": "^2.11.3",
         "laminas/laminas-log": "^2.13.1",
         "laminas/laminas-modulemanager": "^2.11.0",
@@ -70,9 +71,9 @@
         "laminas/laminas-serializer": "^2.11.0",
         "laminas/laminas-session": "^2.12.0",
         "laminas/laminas-test": "^3.5.1",
-        "jangregor/phpstan-prophecy": "^0.8.1",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^0.12.99",
+        "phpstan/phpstan-phpunit": "^0.12.22",
         "phpunit/phpunit": "^9.5.10",
         "predis/predis": "^1.1.9",
         "vimeo/psalm": "^4.11.2"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
     paths:
         - src
         - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+parameters:
+    level: 3
+    paths:
+        - src
+        - tests
+    excludePaths:
+        - src/Form/Element/ObjectMultiCheckboxV2Polyfill.php
+        - src/Form/Element/ObjectRadioV2Polyfill.php
+        - src/Form/Element/ObjectSelectV2Polyfill.php
+includes:
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.11.2@6fba5eb554f9507b72932f9c75533d8af593688d">
+  <file src="src/Module.php">
+    <ParseError occurrences="1"/>
+  </file>
+  <file src="vendor/laminas/laminas-servicemanager/src/Exception/CyclicAliasException.php">
+    <ParseError occurrences="7">
+      <code>)</code>
+      <code>,</code>
+      <code>,</code>
+      <code>:</code>
+      <code>=&gt;</code>
+      <code>fn</code>
+      <code>fn</code>
+    </ParseError>
+  </file>
+  <file src="vendor/laminas/laminas-servicemanager/src/ServiceManager.php">
+    <ParseError occurrences="2">
+      <code>=&gt;</code>
+      <code>fn</code>
+    </ParseError>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,7 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.11.2@6fba5eb554f9507b72932f9c75533d8af593688d">
+  <file src="src/Form/Element/ObjectMultiCheckboxV3Polyfill.php">
+    <LessSpecificImplementedReturnType occurrences="2">
+      <code>self</code>
+      <code>self</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Form/Element/ObjectRadioV3Polyfill.php">
+    <LessSpecificImplementedReturnType occurrences="2">
+      <code>self</code>
+      <code>self</code>
+    </LessSpecificImplementedReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$options</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="src/Form/Element/ObjectSelectV3Polyfill.php">
+    <LessSpecificImplementedReturnType occurrences="2">
+      <code>self</code>
+      <code>self</code>
+    </LessSpecificImplementedReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$options</code>
+    </MoreSpecificImplementedParamType>
+  </file>
   <file src="src/Module.php">
     <ParseError occurrences="1"/>
+  </file>
+  <file src="src/Service/DriverFactory.php">
+    <UndefinedClass occurrences="1">
+      <code>'Doctrine\Persistence\Mapping\Driver\AnnotationDriver'</code>
+    </UndefinedClass>
   </file>
   <file src="vendor/laminas/laminas-servicemanager/src/Exception/CyclicAliasException.php">
     <ParseError occurrences="7">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="6"
+    errorLevel="5"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="6"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <file name="src/Form/Element/ObjectMultiCheckboxV2Polyfill.php" />
+            <file name="src/Form/Element/ObjectRadioV2Polyfill.php" />
+            <file name="src/Form/Element/ObjectSelectV2Polyfill.php" />
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+    <issueHandlers>
+        <DuplicateClass>
+            <errorLevel type="suppress">
+                <!-- These files contain a php 7 and a php 8 version of the same trait -->
+                <file name="src/GetConsoleUsage.php"/>
+            </errorLevel>
+        </DuplicateClass>
+    </issueHandlers>
+</psalm>

--- a/src/Authentication/Storage/ObjectRepository.php
+++ b/src/Authentication/Storage/ObjectRepository.php
@@ -72,12 +72,12 @@ class ObjectRepository implements StorageInterface
     }
 
     /**
-     * @param mixed $identity
+     * @param mixed $contents
      */
-    public function write($identity): void
+    public function write($contents): void
     {
         $metadataInfo     = $this->options->getClassMetadata();
-        $identifierValues = $metadataInfo->getIdentifierValues($identity);
+        $identifierValues = $metadataInfo->getIdentifierValues($contents);
 
         $this->options->getStorage()->write($identifierValues);
     }

--- a/src/Cache/DoctrineCacheStorage.php
+++ b/src/Cache/DoctrineCacheStorage.php
@@ -53,7 +53,7 @@ class DoctrineCacheStorage extends AbstractAdapter
     protected function internalSetItem(&$normalizedKey, &$value)
     {
         $key = $this->getOptions()->getNamespace() . $normalizedKey;
-        $ttl = $this->getOptions()->getTtl();
+        $ttl = (int) $this->getOptions()->getTtl();
 
         return $this->cache->save($key, $value, $ttl);
     }

--- a/src/Cache/LaminasStorageCache.php
+++ b/src/Cache/LaminasStorageCache.php
@@ -47,7 +47,7 @@ class LaminasStorageCache extends CacheProvider
     /**
      * {@inheritDoc}
      */
-    protected function doSave($id, $data, $lifeTime = false)
+    protected function doSave($id, $data, $lifeTime = 0)
     {
         // @todo check if lifetime can be set
         return $this->storage->setItem($id, $data);

--- a/src/Controller/CliController.php
+++ b/src/Controller/CliController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\Controller;
 
 use DoctrineModule\Component\Console\Input\RequestInput;
+use Laminas\Console\Request;
 use Laminas\Mvc\Console\View\ViewModel as ConsoleViewModel;
 use Laminas\Mvc\Controller\AbstractActionController;
 use RuntimeException;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function class_exists;
+use function get_class;
 use function is_numeric;
 use function sprintf;
 
@@ -50,6 +52,14 @@ class CliController extends AbstractActionController
             throw new RuntimeException(sprintf(
                 'Using %s requires the package laminas/laminas-mvc-console, which is currently not installed.',
                 __METHOD__
+            ));
+        }
+
+        if (! $this->getRequest() instanceof Request) {
+            throw new RuntimeException(sprintf(
+                'Expected request of type %s, received %s.',
+                Request::class,
+                get_class($this->getRequest())
             ));
         }
 

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -215,6 +215,10 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function getObjectManager(): ObjectManager
     {
+        if (! $this->objectManager) {
+            throw new RuntimeException('No object manager was set');
+        }
+
         return $this->objectManager;
     }
 
@@ -233,6 +237,10 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function getTargetClass(): string
     {
+        if (! $this->targetClass) {
+            throw new RuntimeException('No target class was set');
+        }
+
         return $this->targetClass;
     }
 
@@ -346,14 +354,6 @@ class Proxy implements ObjectManagerAwareInterface
      */
     public function getValue($value)
     {
-        if (! $this->getObjectManager()) {
-            throw new RuntimeException('No object manager was set');
-        }
-
-        if (! $this->getTargetClass()) {
-            throw new RuntimeException('No target class was set');
-        }
-
         $metadata = $this->getObjectManager()->getClassMetadata($this->getTargetClass());
 
         if (is_object($value)) {
@@ -460,14 +460,6 @@ class Proxy implements ObjectManagerAwareInterface
      */
     protected function loadValueOptions(): void
     {
-        if (! $this->objectManager) {
-            throw new RuntimeException('No object manager was set');
-        }
-
-        if (! $this->targetClass) {
-            throw new RuntimeException('No target class was set');
-        }
-
         $metadata         = $this->getObjectManager()->getClassMetadata($this->getTargetClass());
         $identifier       = $metadata->getIdentifierFieldNames();
         $objects          = $this->getObjects();

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -38,7 +38,7 @@ class Proxy implements ObjectManagerAwareInterface
     /** @var mixed[]|Traversable */
     protected $objects;
 
-    /** @var string */
+    /** @var ?string */
     protected $targetClass;
 
     /** @var mixed[] */
@@ -59,7 +59,7 @@ class Proxy implements ObjectManagerAwareInterface
     /** @var bool|null */
     protected $isMethod;
 
-    /** @var ObjectManager */
+    /** @var ?ObjectManager */
     protected $objectManager;
 
     /** @var bool */

--- a/src/GetConsoleUsage.php
+++ b/src/GetConsoleUsage.php
@@ -29,13 +29,15 @@ if (PHP_VERSION_ID > 80000) {
      * @internal
      * @deprecated 4.2.0 Usage of laminas/laminas-mvc-console is deprecated, integration will be removed in 5.0.0.
      *                   Please use ./vendor/bin/doctrine-module instead.
+     *
+     * @psalm-suppress DuplicateClass
      */
     trait GetConsoleUsage
     {
         /**
-         * {@inheritDoc}
+         * Prints console usage information for laminas-mvc-console
          */
-        public function getConsoleUsage(Console $console)
+        public function getConsoleUsage(Console $console): string
         {
             if (! interface_exists(Console::class)) {
                 trigger_error(sprintf(

--- a/src/Module.php
+++ b/src/Module.php
@@ -10,6 +10,7 @@ use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\InitProviderInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
+use Laminas\Mvc\Application;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function class_exists;
@@ -43,6 +44,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
      */
     public function onBootstrap(EventInterface $event)
     {
+        assert($event->getTarget() instanceof Application);
         $this->serviceManager = $event->getTarget()->getServiceManager();
     }
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -13,6 +13,7 @@ use Laminas\ModuleManager\ModuleManagerInterface;
 use Laminas\Mvc\Application;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+use function assert;
 use function class_exists;
 
 /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -28,10 +28,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
     /** @var ServiceLocatorInterface */
     private $serviceManager;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function init(ModuleManagerInterface $moduleManager)
+    public function init(ModuleManagerInterface $manager): void
     {
         AnnotationRegistry::registerLoader(
             static function ($className) {
@@ -40,19 +37,16 @@ class Module implements ConfigProviderInterface, InitProviderInterface, Bootstra
         );
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function onBootstrap(EventInterface $event)
+    public function onBootstrap(EventInterface $e): void
     {
-        assert($event->getTarget() instanceof Application);
-        $this->serviceManager = $event->getTarget()->getServiceManager();
+        assert($e->getTarget() instanceof Application);
+        $this->serviceManager = $e->getTarget()->getServiceManager();
     }
 
     /**
-     * {@inheritDoc}
+     * @return array<string, mixed>
      */
-    public function getConfig()
+    public function getConfig(): array
     {
         $provider = new ConfigProvider();
 

--- a/src/Options/Authentication.php
+++ b/src/Options/Authentication.php
@@ -63,7 +63,7 @@ class Authentication extends AbstractOptions
     /**
      * A valid object implementing ObjectRepository interface (or ObjectManager/identityClass)
      *
-     * @var ObjectRepository
+     * @var ?ObjectRepository
      */
     protected $objectRepository;
 
@@ -99,7 +99,7 @@ class Authentication extends AbstractOptions
      * If an objectManager is not supplied, this metadata will be used
      * by DoctrineModule/Authentication/Storage/ObjectRepository
      *
-     * @var ClassMetadata
+     * @var ?ClassMetadata
      */
     protected $classMetadata;
 

--- a/src/Paginator/Adapter/Collection.php
+++ b/src/Paginator/Adapter/Collection.php
@@ -10,13 +10,17 @@ use Laminas\Paginator\Adapter\AdapterInterface;
 use function array_values;
 use function count;
 
+/**
+ * @psalm-template TKey of array-key
+ * @psalm-template T
+ */
 class Collection implements AdapterInterface
 {
-    /** @var DoctrineCollection */
+    /** @var DoctrineCollection<TKey,T> */
     protected $collection;
 
     /**
-     * @param DoctrineCollection $collection
+     * @param DoctrineCollection<TKey,T> $collection
      */
     public function __construct(DoctrineCollection $collection)
     {

--- a/src/Paginator/Adapter/Collection.php
+++ b/src/Paginator/Adapter/Collection.php
@@ -12,11 +12,11 @@ use function count;
 
 class Collection implements AdapterInterface
 {
-    /** @var Doctrine\Common\Collections\Collection */
+    /** @var DoctrineCollection */
     protected $collection;
 
     /**
-     * @param mixed[] $collection
+     * @param DoctrineCollection $collection
      */
     public function __construct(DoctrineCollection $collection)
     {

--- a/src/Service/Authentication/AdapterFactory.php
+++ b/src/Service/Authentication/AdapterFactory.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Adapter\ObjectRepository;
+use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+use RuntimeException;
 use function is_string;
+use function sprintf;
 
 /**
  * Factory to create authentication adapter object.
@@ -25,6 +28,14 @@ class AdapterFactory extends AbstractFactory
     {
         $options = $this->getOptions($container, 'authentication');
 
+        if (!$options instanceof Authentication) {
+            throw new RuntimeException(sprintf(
+                'Invalid options received, expected %s, got %s.',
+                Authentication::class,
+                get_class($options)
+            ));
+        }
+
         $objectManager = $options->getObjectManager();
         if (is_string($objectManager)) {
             $options->setObjectManager($container->get($objectManager));
@@ -36,6 +47,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
@@ -45,6 +57,6 @@ class AdapterFactory extends AbstractFactory
 
     public function getOptionsClass(): string
     {
-        return 'DoctrineModule\Options\Authentication';
+        return Authentication::class;
     }
 }

--- a/src/Service/Authentication/AdapterFactory.php
+++ b/src/Service/Authentication/AdapterFactory.php
@@ -9,8 +9,9 @@ use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
-
 use RuntimeException;
+
+use function get_class;
 use function is_string;
 use function sprintf;
 
@@ -28,7 +29,7 @@ class AdapterFactory extends AbstractFactory
     {
         $options = $this->getOptions($container, 'authentication');
 
-        if (!$options instanceof Authentication) {
+        if (! $options instanceof Authentication) {
             throw new RuntimeException(sprintf(
                 'Invalid options received, expected %s, got %s.',
                 Authentication::class,
@@ -48,6 +49,7 @@ class AdapterFactory extends AbstractFactory
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $serviceLocator)

--- a/src/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/Service/Authentication/AuthenticationServiceFactory.php
@@ -28,6 +28,11 @@ class AuthenticationServiceFactory extends AbstractFactory
         );
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     */
     public function createService(ServiceLocatorInterface $container): AuthenticationService
     {
         return $this($container, AuthenticationService::class);

--- a/src/Service/Authentication/StorageFactory.php
+++ b/src/Service/Authentication/StorageFactory.php
@@ -9,8 +9,9 @@ use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
-
 use RuntimeException;
+
+use function get_class;
 use function is_string;
 use function sprintf;
 
@@ -28,7 +29,7 @@ class StorageFactory extends AbstractFactory
     {
         $options = $this->getOptions($container, 'authentication');
 
-        if (!$options instanceof Authentication) {
+        if (! $options instanceof Authentication) {
             throw new RuntimeException(sprintf(
                 'Invalid options received, expected %s, got %s.',
                 Authentication::class,
@@ -53,6 +54,7 @@ class StorageFactory extends AbstractFactory
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/Authentication/StorageFactory.php
+++ b/src/Service/Authentication/StorageFactory.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace DoctrineModule\Service\Authentication;
 
 use DoctrineModule\Authentication\Storage\ObjectRepository;
+use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+use RuntimeException;
 use function is_string;
+use function sprintf;
 
 /**
  * Factory to create authentication storage object.
@@ -24,6 +27,14 @@ class StorageFactory extends AbstractFactory
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options = $this->getOptions($container, 'authentication');
+
+        if (!$options instanceof Authentication) {
+            throw new RuntimeException(sprintf(
+                'Invalid options received, expected %s, got %s.',
+                Authentication::class,
+                get_class($options)
+            ));
+        }
 
         $objectManager = $options->getObjectManager();
         if (is_string($objectManager)) {
@@ -41,6 +52,7 @@ class StorageFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      * @return ObjectRepository
      */
     public function createService(ServiceLocatorInterface $container)
@@ -50,6 +62,6 @@ class StorageFactory extends AbstractFactory
 
     public function getOptionsClass(): string
     {
-        return 'DoctrineModule\Options\Authentication';
+        return Authentication::class;
     }
 }

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -7,11 +7,13 @@ namespace DoctrineModule\Service;
 use Doctrine\Common\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use DoctrineModule\Cache\LaminasStorageCache;
+use DoctrineModule\Options\Cache as CacheOptions;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function is_string;
+use function sprintf;
 
 /**
  * Cache ServiceManager factory
@@ -23,13 +25,21 @@ class CacheFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return \Doctrine\Common\Cache\Cache
-     *
+     * @return Cache\Cache
      * @throws RuntimeException
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options = $this->getOptions($container, 'cache');
+
+        if (!$options instanceof CacheOptions) {
+            throw new RuntimeException(sprintf(
+                'Invalid options received, expected %s, got %s.',
+                CacheOptions::class,
+                get_class($options)
+            ));
+        }
+
         $class   = $options->getClass();
 
         if (! $class) {
@@ -82,17 +92,17 @@ class CacheFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return \Doctrine\Common\Cache\Cache
-     *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     * @return Cache\Cache
      * @throws RuntimeException
      */
     public function createService(ServiceLocatorInterface $container)
     {
-        return $this($container, \Doctrine\Common\Cache\Cache::class);
+        return $this($container, Cache\Cache::class);
     }
 
     public function getOptionsClass(): string
     {
-        return 'DoctrineModule\Options\Cache';
+        return CacheOptions::class;
     }
 }

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -12,6 +12,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
+use function get_class;
 use function is_string;
 use function sprintf;
 
@@ -26,13 +27,14 @@ class CacheFactory extends AbstractFactory
      * {@inheritDoc}
      *
      * @return Cache\Cache
+     *
      * @throws RuntimeException
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options = $this->getOptions($container, 'cache');
 
-        if (!$options instanceof CacheOptions) {
+        if (! $options instanceof CacheOptions) {
             throw new RuntimeException(sprintf(
                 'Invalid options received, expected %s, got %s.',
                 CacheOptions::class,
@@ -40,7 +42,7 @@ class CacheFactory extends AbstractFactory
             ));
         }
 
-        $class   = $options->getClass();
+        $class = $options->getClass();
 
         if (! $class) {
             throw new RuntimeException('Cache must have a class name to instantiate');
@@ -93,7 +95,9 @@ class CacheFactory extends AbstractFactory
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return Cache\Cache
+     *
      * @throws RuntimeException
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/CliControllerFactory.php
+++ b/src/Service/CliControllerFactory.php
@@ -6,9 +6,6 @@ namespace DoctrineModule\Service;
 
 use DoctrineModule\Controller\CliController;
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
-use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
@@ -34,6 +31,7 @@ class CliControllerFactory implements FactoryInterface
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return CliController
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/CliControllerFactory.php
+++ b/src/Service/CliControllerFactory.php
@@ -15,18 +15,13 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 /**
  * Factory responsible of instantiating an {@see \DoctrineModule\Controller\CliController}
  *
- * @link    http://www.doctrine-project.org/
+ * @deprecated 4.2.0 Through the deprecation of \DoctrineModule\Controller\CliController, this class is not needed
+ *                   anymore and will be removed in 5.0.0.
  */
 class CliControllerFactory implements FactoryInterface
 {
     /**
-     * Create an object
-     *
      * {@inheritDoc}
-     *
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when creating a service.
-     * @throws ContainerException if any other error occurs.
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): object
     {
@@ -38,10 +33,11 @@ class CliControllerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      * @return CliController
      */
     public function createService(ServiceLocatorInterface $container)
     {
-        return $this($container->getServiceLocator(), CliController::class);
+        return $this($container, CliController::class);
     }
 }

--- a/src/Service/CliControllerFactory.php
+++ b/src/Service/CliControllerFactory.php
@@ -34,8 +34,8 @@ class CliControllerFactory implements FactoryInterface
      *
      * @return CliController
      */
-    public function createService(ServiceLocatorInterface $container)
+    public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($container, CliController::class);
+        return $this($serviceLocator, CliController::class);
     }
 }

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -62,6 +62,7 @@ class CliFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      * @return Application
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -66,8 +66,8 @@ class CliFactory implements FactoryInterface
      *
      * @return Application
      */
-    public function createService(ServiceLocatorInterface $container)
+    public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($container, Application::class);
+        return $this($serviceLocator, Application::class);
     }
 }

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -63,6 +63,7 @@ class CliFactory implements FactoryInterface
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return Application
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -10,10 +10,10 @@ use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Options\Driver;
-use DoctrineModule\Options\Driver as DriverOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use RuntimeException;
 
 use function class_exists;
 use function get_class;
@@ -38,6 +38,14 @@ class DriverFactory extends AbstractFactory
     {
         $options = $this->getOptions($container, 'driver');
 
+        if (! $options instanceof Driver) {
+            throw new RuntimeException(sprintf(
+                'Invalid options received, expected %s, got %s.',
+                Driver::class,
+                get_class($options)
+            ));
+        }
+
         return $this->createDriver($container, $options);
     }
 
@@ -45,6 +53,7 @@ class DriverFactory extends AbstractFactory
      * {@inheritDoc}
      *
      * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return MappingDriver
      */
     public function createService(ServiceLocatorInterface $container)
@@ -60,7 +69,7 @@ class DriverFactory extends AbstractFactory
     /**
      * @throws InvalidArgumentException
      */
-    protected function createDriver(ContainerInterface $container, DriverOptions $options): MappingDriver
+    protected function createDriver(ContainerInterface $container, Driver $options): MappingDriver
     {
         $class = $options->getClass();
 
@@ -122,6 +131,15 @@ class DriverFactory extends AbstractFactory
                 }
 
                 $options = $this->getOptions($container, 'driver', $driverName);
+
+                if (! $options instanceof Driver) {
+                    throw new RuntimeException(sprintf(
+                        'Invalid options received, expected %s, got %s.',
+                        Driver::class,
+                        get_class($options)
+                    ));
+                }
+
                 $driver->addDriver($this->createDriver($container, $options), $namespace);
             }
         }

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use DoctrineModule\Options\Driver;
 use DoctrineModule\Options\Driver as DriverOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
@@ -43,6 +44,7 @@ class DriverFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      * @return MappingDriver
      */
     public function createService(ServiceLocatorInterface $container)
@@ -52,7 +54,7 @@ class DriverFactory extends AbstractFactory
 
     public function getOptionsClass(): string
     {
-        return 'DoctrineModule\Options\Driver';
+        return Driver::class;
     }
 
     /**

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -6,9 +6,11 @@ namespace DoctrineModule\Service;
 
 use Doctrine\Common\EventManager;
 use Doctrine\Common\EventSubscriber;
+use DoctrineModule\Options\EventManager as EventManagerOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use RuntimeException;
 
 use function class_exists;
 use function get_class;
@@ -28,6 +30,15 @@ class EventManagerFactory extends AbstractFactory
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options      = $this->getOptions($container, 'eventmanager');
+
+        if (!$options instanceof EventManagerOptions) {
+            throw new RuntimeException(sprintf(
+                'Invalid options received, expected %s, got %s.',
+                EventManagerOptions::class,
+                get_class($options)
+            ));
+        }
+
         $eventManager = new EventManager();
 
         foreach ($options->getSubscribers() as $subscriberName) {
@@ -62,6 +73,8 @@ class EventManagerFactory extends AbstractFactory
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $container)
     {
@@ -73,6 +86,6 @@ class EventManagerFactory extends AbstractFactory
      */
     public function getOptionsClass(): string
     {
-        return 'DoctrineModule\Options\EventManager';
+        return EventManagerOptions::class;
     }
 }

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -29,9 +29,9 @@ class EventManagerFactory extends AbstractFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $options      = $this->getOptions($container, 'eventmanager');
+        $options = $this->getOptions($container, 'eventmanager');
 
-        if (!$options instanceof EventManagerOptions) {
+        if (! $options instanceof EventManagerOptions) {
             throw new RuntimeException(sprintf(
                 'Invalid options received, expected %s, got %s.',
                 EventManagerOptions::class,

--- a/src/Service/SymfonyCliRouteFactory.php
+++ b/src/Service/SymfonyCliRouteFactory.php
@@ -32,9 +32,11 @@ class SymfonyCliRouteFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator->getServiceLocator(), SymfonyCli::class);
+        return $this($serviceLocator, SymfonyCli::class);
     }
 }

--- a/src/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DoctrineModule\ServiceFactory;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function preg_match;

--- a/src/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModule\ServiceFactory;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\AbstractFactoryInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
@@ -47,7 +47,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @deprecated
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
     {
@@ -57,7 +57,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @deprecated
+     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {

--- a/src/Validator/ObjectExists.php
+++ b/src/Validator/ObjectExists.php
@@ -124,7 +124,7 @@ class ObjectExists extends AbstractValidator
     }
 
     /**
-     * @param string|mixed[] $value a field value or an array of field values if more fields have been configured to be
+     * @param string|object|mixed[] $value a field value or an array of field values if more fields have been configured to be
      *                      matched
      *
      * @return mixed[]

--- a/tests/Cache/DoctrineCacheStorageTest.php
+++ b/tests/Cache/DoctrineCacheStorageTest.php
@@ -346,6 +346,7 @@ class DoctrineCacheStorageTest extends TestCase
 
         $metadatas = $this->storage->getMetadatas(array_keys($items));
         $this->assertIsArray($metadatas);
+        /** @phpstan-ignore-next-line */
         $this->assertSame(count($items), count($metadatas));
         foreach ($metadatas as $metadata) {
             $this->assertIsArray($metadata);

--- a/tests/Controller/CliControllerTest.php
+++ b/tests/Controller/CliControllerTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Output\BufferedOutput;
  */
 class CliControllerTest extends AbstractConsoleControllerTestCase
 {
+    /** @var BufferedOutput */
+    private $output;
+
     protected function setUp(): void
     {
         $this->setApplicationConfig(ServiceManagerFactory::getConfiguration());

--- a/tests/Controller/CliControllerTest.php
+++ b/tests/Controller/CliControllerTest.php
@@ -40,6 +40,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
      */
     public function testIndexActionCanBeAccessed(): void
     {
+        /** @phpstan-ignore-next-line */
         $this->dispatch(new Request(['scriptname.php', 'list']));
 
         $this->assertResponseStatusCode(0);
@@ -52,6 +53,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
 
     public function testNonZeroExitCode(): void
     {
+        /** @phpstan-ignore-next-line */
         $this->dispatch(new Request(['scriptname.php', 'fail']));
 
         $this->assertNotResponseStatusCode(0);
@@ -59,6 +61,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
 
     public function testException(): void
     {
+        /** @phpstan-ignore-next-line */
         $this->dispatch(new Request(['scriptname.php', '-q', 'fail', '--exception']));
 
         $this->assertNotResponseStatusCode(0);

--- a/tests/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/Form/Element/ProxyAwareElementTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModuleTest\Form\Element;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -16,8 +17,14 @@ use function get_class;
 
 class ProxyAwareElementTestCase extends TestCase
 {
+    /** @var MockObject&ClassMetadata */
+    protected $metadata;
+
     /** @var MockObject */
     protected $element;
+
+    /** @var ArrayCollection */
+    protected $values;
 
     protected function prepareProxy(): void
     {
@@ -81,6 +88,10 @@ class ProxyAwareElementTestCase extends TestCase
             ->method('getRepository')
             ->with($this->equalTo($objectClass))
             ->will($this->returnValue($objectRepository));
+
+        if (!method_exists($this->element, 'getProxy')) {
+            throw new \RuntimeException('Element must implement getProxy().');
+        }
 
         $this->element->getProxy()->setOptions([
             'object_manager' => $objectManager,

--- a/tests/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/Form/Element/ProxyAwareElementTestCase.php
@@ -10,10 +10,12 @@ use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+use RuntimeException;
 
 use function array_shift;
 use function func_get_args;
 use function get_class;
+use function method_exists;
 
 class ProxyAwareElementTestCase extends TestCase
 {
@@ -89,8 +91,8 @@ class ProxyAwareElementTestCase extends TestCase
             ->with($this->equalTo($objectClass))
             ->will($this->returnValue($objectRepository));
 
-        if (!method_exists($this->element, 'getProxy')) {
-            throw new \RuntimeException('Element must implement getProxy().');
+        if (! method_exists($this->element, 'getProxy')) {
+            throw new RuntimeException('Element must implement getProxy().');
         }
 
         $this->element->getProxy()->setOptions([

--- a/tests/Form/Element/ProxyTest.php
+++ b/tests/Form/Element/ProxyTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use DoctrineModule\Form\Element\Proxy;
 use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -27,7 +28,7 @@ use const PHP_VERSION_ID;
  */
 class ProxyTest extends TestCase
 {
-    /** @var ClassMetadata */
+    /** @var MockObject&ClassMetadata */
     protected $metadata;
 
     /** @var Proxy */
@@ -329,9 +330,12 @@ class ProxyTest extends TestCase
     {
         $this->prepareProxy();
 
+        $stdClass = new stdClass();
+        $stdClass->id = 1;
+
         $this->proxy->setOptions([
             'option_attributes' => [
-                'data-id' => new stdClass(['id' => 1]),
+                'data-id' => $stdClass,
             ],
         ]);
 

--- a/tests/Form/Element/ProxyTest.php
+++ b/tests/Form/Element/ProxyTest.php
@@ -330,13 +330,11 @@ class ProxyTest extends TestCase
     {
         $this->prepareProxy();
 
-        $stdClass = new stdClass();
+        $stdClass     = new stdClass();
         $stdClass->id = 1;
 
         $this->proxy->setOptions([
-            'option_attributes' => [
-                'data-id' => $stdClass,
-            ],
+            'option_attributes' => ['data-id' => $stdClass],
         ]);
 
         $this->expectException('RuntimeException');

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -8,7 +8,9 @@ use DoctrineModule\Module;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -22,17 +24,16 @@ use const PHP_VERSION_ID;
  */
 class ModuleTest extends TestCase
 {
-    /** @var PHPUnit_Framework_MockObject_MockObject|Application */
+    /** @var MockObject&Application */
     private $application;
 
-    /** @var PHPUnit_Framework_MockObject_MockObject|MvcEvent */
+    /** @var MockObject&MvcEvent */
     private $event;
 
-
-    /** @var PHPUnit_Framework_MockObject_MockObject|ServiceManager */
+    /** @var MockObject&ServiceManager */
     private $serviceManager;
 
-    /** @var PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Console\Application */
+    /** @var MockObject&SymfonyApplication */
     private $cli;
 
     protected function setUp(): void

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service;
 
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Service\DriverFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+
+use function assert;
 
 /**
  * Base test case to be used when a service manager instance is required
@@ -56,7 +59,7 @@ class DriverFactoryTest extends BaseTestCase
         $factory = new DriverFactory('testChainDriver');
         $driver  = $factory->createService($serviceManager);
         $this->assertInstanceOf('Doctrine\Persistence\Mapping\Driver\MappingDriverChain', $driver);
-        assert($driver instanceof \Doctrine\Persistence\Mapping\Driver\MappingDriverChain);
+        assert($driver instanceof MappingDriverChain);
         $drivers = $driver->getDrivers();
         $this->assertCount(1, $drivers);
         $this->assertArrayHasKey('Foo\Bar', $drivers);

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -56,6 +56,7 @@ class DriverFactoryTest extends BaseTestCase
         $factory = new DriverFactory('testChainDriver');
         $driver  = $factory->createService($serviceManager);
         $this->assertInstanceOf('Doctrine\Persistence\Mapping\Driver\MappingDriverChain', $driver);
+        assert($driver instanceof \Doctrine\Persistence\Mapping\Driver\MappingDriverChain);
         $drivers = $driver->getDrivers();
         $this->assertCount(1, $drivers);
         $this->assertArrayHasKey('Foo\Bar', $drivers);


### PR DESCRIPTION
This PR integrates Psalm and PhpStan. There were some really weird errors of Psalm, where a ParseError occured. The message was as follows:

```
ERROR: ParseError - src/Module.php:40:17 - Problem loading method: 
    $storage should not be null for DoctrineModule\GetConsoleUsage::getconsoleusage (see https://psalm.dev/173)
```

I think this is rather a bug in Psalm, might be related to https://github.com/vimeo/psalm/issues/4899. Anyways, I have suppressed that error by using a baseline.