### PR TITLE
Set 4.2.x as current stable

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,19 +6,20 @@
     {
       "name": "4.2",
       "branchName": "4.2.x",
-      "slug": "latest",
-      "upcoming": true
+      "slug": "4.2",
+      "aliases": [
+        "current",
+        "stable",
+        "latest"
+      ],
+      "current": true,
+      "maintained": true
     },
     {
       "name": "4.1",
       "branchName": "4.1.x",
       "slug": "4.1",
-      "aliases": [
-        "current",
-        "stable"
-      ],
-      "current": true,
-      "maintained": true
+      "maintained": false
     },
     {
       "name": "4.0",


### PR DESCRIPTION
With the release of [4.2.0](https://github.com/doctrine/DoctrineModule/releases/tag/4.2.0) we should update `.doctrine-project.json` accordingly.