### PR TITLE
Fixed broken require_once in Module.php

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,6 +2,6 @@
 /**
  * This file is placed here for compatibility with Laminas's ModuleManager.
  * It allows usage of this module even without composer.
- * The original Module.php is in 'src/DoctrineModule' in order to respect PSR-0
+ * The original Module.php is in 'src/' in order to respect PSR-4
  */
-require_once __DIR__ . '/src/DoctrineModule/Module.php';
+require_once __DIR__ . '/src/Module.php';


### PR DESCRIPTION
This issue comes from the switch of PSR-0 to PSR-4, where this file has not been updated accordingly.

The file `Module.php` in the root directory is only used in some cases by laminas/laminas-loader when autoloading via composer is not in place. Nevertheless, this should be fixed anyways.