### PR TITLE
Simplified build matrix for continuous integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,8 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
+          - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         laminas-form-version:
@@ -28,22 +30,6 @@ jobs:
             laminas-form-version: "2.17.0"
           - php-version: "7.3"
             dependencies: "lowest"
-            laminas-form-version: "3.0.0"
-          - php-version: "8.0"
-            composer-options: "--ignore-platform-req=php"
-            dependencies: "highest"
-            laminas-form-version: "2.17.0"
-          - php-version: "8.0"
-            composer-options: "--ignore-platform-req=php"
-            dependencies: "highest"
-            laminas-form-version: "3.0.0"
-          - php-version: "8.1"
-            composer-options: "--ignore-platform-req=php"
-            dependencies: "highest"
-            laminas-form-version: "2.17.0"
-          - php-version: "8.1"
-            composer-options: "--ignore-platform-req=php"
-            dependencies: "highest"
             laminas-form-version: "3.0.0"
 
     steps:
@@ -60,14 +46,26 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Require specific laminas-form version"
+        if: "! startsWith(matrix.php-version, '8')"
         run: "composer require laminas/laminas-form ^${{ matrix.laminas-form-version }} --no-update"
-        if: "${{ matrix.laminas-form-version != 'default' }}"
+
+      - name: "Require specific laminas-form version (--ignore-platform-req=php)"
+        if: "startsWith(matrix.php-version, '8')"
+        run: "composer require laminas/laminas-form ^${{ matrix.laminas-form-version }} --no-update --ignore-platform-req=php"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        if: "! startsWith(matrix.php-version, '8')"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist ${{ matrix.composer-options }}"
+          composer-options: "--prefer-dist"
+
+      - name: "Install dependencies with Composer (--ignore-platform-req=php)"
+        uses: "ramsey/composer-install@v1"
+        if: "startsWith(matrix.php-version, '8')"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--prefer-dist --ignore-platform-req=php"
 
       - name: "Run PHPUnit"
         run: "composer test-coverage"


### PR DESCRIPTION
The amount of jobs and the type of jobs executed remains the same, but the build matrix is simplified and easier to read.

As a downside, the steps in the job get more complex. I still see this change as a benefit, as the log of the action will directly show when `--ignore-platform-req=php` was used, which was not the case before. Furthermore, adding new PHP versions is much easier and cleaner now. So if there will be PHP 8.2, complexity will remain the same with this approach, while previously each additional PHP version causing troubles with laminas-cache would have further complexified the build matrix.