### PR TITLE
Add missing dependencies to composer.json to prevent unwanted soft dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,12 +52,15 @@
         "doctrine/persistence": "^2.2.2",
         "laminas/laminas-authentication": "^2.8.0",
         "laminas/laminas-cache": "^2.13.0",
+        "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-form": "^2.17.0 || ^3.0.1",
+        "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc": "^3.3.0",
         "laminas/laminas-paginator": "^2.11.0",
         "laminas/laminas-servicemanager": "^3.7.0",
         "laminas/laminas-stdlib": "^3.6.0",
         "laminas/laminas-validator": "^2.15.0",
+        "container-interop/container-interop": "^1.2.0",
         "symfony/console": "^5.3.7"
     },
     "require-dev": {
@@ -66,7 +69,6 @@
         "jangregor/phpstan-prophecy": "^0.8.1",
         "laminas/laminas-i18n": "^2.11.3",
         "laminas/laminas-log": "^2.13.1",
-        "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc-console": "^1.3.0",
         "laminas/laminas-serializer": "^2.11.0",
         "laminas/laminas-session": "^2.12.0",


### PR DESCRIPTION
Using [composer-require-checker](https://github.com/maglnet/ComposerRequireChecker) I checked for symbols of libraries which are not in our `require` section of `composer.json`. Such dependencies are called soft dependencies and are usually a bad thing, because their version might change because of changes in upstream libraries, hence, causing bugs for end users. 

To prevent such scenarios, this PR turns the following soft dependencies into hard dependencies:
- container-interop/container-interop
- laminas/laminas-eventmanager
- laminas/laminas-servicemanager