### PR TITLE
Update upstream workflows and update PhpStan to 1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,6 @@
 /phpcs.xml.dist export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
-/psalm.xml.dist export-ignore
+/psalm.xml export-ignore
 /psalm-baseline.xml export-ignore
 /tests/ export-ignore

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
     with:
-      php-version: '7.4'
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.3.0"
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.3.0"
     with:
-      php-version: '7.4'
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 /composer.lock
 /phpcs.xml
 /phpunit.xml
-/psalm.xml
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
         "doctrine/orm": "^2.10.2",
-        "jangregor/phpstan-prophecy": "^0.8.1",
+        "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-i18n": "^2.11.3",
         "laminas/laminas-log": "^2.13.1",
         "laminas/laminas-mvc-console": "^1.3.0",
@@ -74,8 +74,8 @@
         "laminas/laminas-session": "^2.12.0",
         "laminas/laminas-test": "^3.5.1",
         "phpspec/prophecy-phpunit": "^2.0.1",
-        "phpstan/phpstan": "^0.12.99",
-        "phpstan/phpstan-phpunit": "^0.12.22",
+        "phpstan/phpstan": "^1.1.2",
+        "phpstan/phpstan-phpunit": "^1.0.0",
         "phpunit/phpunit": "^9.5.10",
         "predis/predis": "^1.1.9",
         "vimeo/psalm": "^4.11.2"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,10 @@ parameters:
         - src/Form/Element/ObjectMultiCheckboxV2Polyfill.php
         - src/Form/Element/ObjectRadioV2Polyfill.php
         - src/Form/Element/ObjectSelectV2Polyfill.php
+    ignoreErrors:
+        -
+            message: '#Property DoctrineModule\\Module::\$serviceManager is never read, only written.#'
+            path: src/Module.php
 includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/jangregor/phpstan-prophecy/extension.neon

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="5"
+    phpVersion="8.0"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -12,7 +12,6 @@ use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use Laminas\Stdlib\Guard\ArrayOrTraversableGuardTrait;
 use ReflectionMethod;
 use RuntimeException;
-use Traversable;
 
 use function array_change_key_case;
 use function array_key_exists;
@@ -35,7 +34,7 @@ class Proxy implements ObjectManagerAwareInterface
 {
     use ArrayOrTraversableGuardTrait;
 
-    /** @var mixed[]|Traversable */
+    /** @var mixed[] */
     protected $objects;
 
     /** @var ?string */

--- a/tests/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/Form/Element/ProxyAwareElementTestCase.php
@@ -22,7 +22,7 @@ class ProxyAwareElementTestCase extends TestCase
     /** @var MockObject&ClassMetadata */
     protected $metadata;
 
-    /** @var MockObject */
+    /** @var object */
     protected $element;
 
     /** @var ArrayCollection */

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function assert;
+use function method_exists;
 use function serialize;
 use function unserialize;
 
@@ -110,6 +112,7 @@ class ModuleTest extends TestCase
             }));
 
         $module = new Module();
+        assert(method_exists($module, 'getConsoleUsage'));
 
         $module->onBootstrap($this->event);
 


### PR DESCRIPTION
This PR updates the upstream workflows to 1.3.0, see https://github.com/doctrine/.github/pull/27.

Since running PhpStan and Psalm with 8.0 instead of 7.4 brought one new issue with PhpStan, I immediatly updated PhpStan from 0.8 to 1.0 and fixed all newly occurring issues.

Following the discussion in https://github.com/doctrine/doctrine-laminas-hydrator/pull/41, `psalm.xml.dist` is renamed to `psalm.xml` to match the respositories [doctrine-laminas-hydrator](https://github.com/doctrine/doctrine-laminas-hydrator) and [DoctrineORMModule](https://github.com/doctrine/DoctrineORMModule) .