### PR TITLE
Add missing provide in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
         "laminas/laminas-validator": "^2.15.0",
         "symfony/console": "^5.3.7"
     },
+    "provide": {
+        "laminas/laminas-cache-storage-implementation": "1.0"
+    },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
         "doctrine/orm": "^2.10.2",


### PR DESCRIPTION
Without this section user cannot install laminas-cache alone (this package provide implementation)