### PR TITLE
Removed signatures related to laminas-servicemanager 2.x

### DIFF
--- a/src/Service/Authentication/AdapterFactory.php
+++ b/src/Service/Authentication/AdapterFactory.php
@@ -8,7 +8,6 @@ use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function get_class;
@@ -43,18 +42,6 @@ class AdapterFactory extends AbstractFactory
         }
 
         return new ObjectRepository($options);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return ObjectRepository
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ObjectRepository::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/Service/Authentication/AuthenticationServiceFactory.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory to create authentication service object.
@@ -26,16 +25,6 @@ class AuthenticationServiceFactory extends AbstractFactory
             $container->get('doctrine.authenticationstorage.' . $this->getName()),
             $container->get('doctrine.authenticationadapter.' . $this->getName())
         );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $container): AuthenticationService
-    {
-        return $this($container, AuthenticationService::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/Authentication/StorageFactory.php
+++ b/src/Service/Authentication/StorageFactory.php
@@ -8,7 +8,6 @@ use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Options\Authentication;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function get_class;
@@ -48,18 +47,6 @@ class StorageFactory extends AbstractFactory
         }
 
         return new ObjectRepository($options);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return ObjectRepository
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, ObjectRepository::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Cache\CacheProvider;
 use DoctrineModule\Cache\LaminasStorageCache;
 use DoctrineModule\Options\Cache as CacheOptions;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function get_class;
@@ -89,20 +88,6 @@ class CacheFactory extends AbstractFactory
         }
 
         return $cache;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return Cache\Cache
-     *
-     * @throws RuntimeException
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, Cache\Cache::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -6,8 +6,7 @@ namespace DoctrineModule\Service;
 
 use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -57,17 +56,5 @@ class CliFactory implements FactoryInterface
         $this->getEventManager($container)->trigger('loadCli.post', $cli, ['ServiceManager' => $container]);
 
         return $cli;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return Application
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, Application::class);
     }
 }

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -12,7 +12,6 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Options\Driver;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function class_exists;
@@ -47,18 +46,6 @@ class DriverFactory extends AbstractFactory
         }
 
         return $this->createDriver($container, $options);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return MappingDriver
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, MappingDriver::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -9,7 +9,6 @@ use Doctrine\Common\EventSubscriber;
 use DoctrineModule\Options\EventManager as EventManagerOptions;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 
 use function class_exists;
@@ -69,16 +68,6 @@ class EventManagerFactory extends AbstractFactory
         }
 
         return $eventManager;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, EventManager::class);
     }
 
     /**

--- a/src/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -7,7 +7,6 @@ namespace DoctrineModule\ServiceFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function preg_match;
 
@@ -41,27 +40,7 @@ class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
         $factoryClass = $mappings['factoryClass'];
         $factory      = new $factoryClass($mappings['serviceName']);
 
-        return $factory->createService($container);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this->canCreate($container, $requestedName);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
-        return $this($serviceLocator, $requestedName);
+        return $factory->__invoke($container, $requestedName);
     }
 
     /**

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -9,7 +9,6 @@ use Doctrine\Persistence\ObjectRepository;
 use DoctrineModule\Validator\Service\Exception\ServiceCreationException;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Stdlib\ArrayUtils;
 
 use function interface_exists;
@@ -94,39 +93,6 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     protected function merge(array $previousOptions, array $newOptions): array
     {
         return ArrayUtils::merge($previousOptions, $newOptions, true);
-    }
-
-    /**
-     * Helper method for Laminas compatiblity.
-     *
-     * In Laminas v2 the plugin manager instance if passed to `createService`
-     * instead of the global service manager instance (as in Laminas v3).
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    protected function container(ContainerInterface $container): ContainerInterface
-    {
-        return $container;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, $this->validatorClass, $this->creationOptions);
-    }
-
-    /**
-     * @deprecated 4.2.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @param mixed[] $options
-     */
-    public function setCreationOptions(array $options): void
-    {
-        $this->creationOptions = $options;
     }
 }
 

--- a/tests/Service/Authentication/AdapterFactoryTest.php
+++ b/tests/Service/Authentication/AdapterFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service\Authentication;
 
+use DoctrineModule\Authentication\Adapter\ObjectRepository;
 use DoctrineModule\Service\Authentication\AdapterFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -32,7 +33,7 @@ class AdapterFactoryTest extends BaseTestCase
             ]
         );
 
-        $adapter = $factory->createService($serviceManager);
-        $this->assertInstanceOf('DoctrineModule\Authentication\Adapter\ObjectRepository', $adapter);
+        $adapter = $factory->__invoke($serviceManager, ObjectRepository::class);
+        $this->assertInstanceOf(ObjectRepository::class, $adapter);
     }
 }

--- a/tests/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/tests/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Service\Authentication;
 use DoctrineModule\Service\Authentication\AdapterFactory;
 use DoctrineModule\Service\Authentication\AuthenticationServiceFactory;
 use DoctrineModule\Service\Authentication\StorageFactory;
+use Laminas\Authentication\AuthenticationService;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -42,7 +43,7 @@ class AuthenticationServiceFactoryTest extends BaseTestCase
         $serviceManager->setFactory('doctrine.authenticationadapter.' . $name, new AdapterFactory($name));
         $serviceManager->setFactory('doctrine.authenticationstorage.' . $name, new StorageFactory($name));
 
-        $authenticationService = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Laminas\Authentication\AuthenticationService', $authenticationService);
+        $authenticationService = $factory->__invoke($serviceManager, AuthenticationService::class);
+        $this->assertInstanceOf(AuthenticationService::class, $authenticationService);
     }
 }

--- a/tests/Service/Authentication/StorageFactoryTest.php
+++ b/tests/Service/Authentication/StorageFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service\Authentication;
 
+use DoctrineModule\Authentication\Storage\ObjectRepository;
 use DoctrineModule\Service\Authentication\StorageFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -38,8 +39,8 @@ class StorageFactoryTest extends BaseTestCase
             ]
         );
 
-        $adapter = $factory->createService($serviceManager);
-        $this->assertInstanceOf('DoctrineModule\Authentication\Storage\ObjectRepository', $adapter);
+        $adapter = $factory->__invoke($serviceManager, ObjectRepository::class);
+        $this->assertInstanceOf(ObjectRepository::class, $adapter);
     }
 
     public function testCanInstantiateStorageFromServiceLocator(): void
@@ -63,9 +64,7 @@ class StorageFactoryTest extends BaseTestCase
                 ['some_storage', $storage],
             ]);
 
-        $this->assertInstanceOf(
-            'DoctrineModule\Authentication\Storage\ObjectRepository',
-            $factory->createService($serviceManager)
-        );
+        $adapter = $factory->__invoke($serviceManager, ObjectRepository::class);
+        $this->assertInstanceOf(ObjectRepository::class, $adapter);
     }
 }

--- a/tests/Service/CacheFactoryTest.php
+++ b/tests/Service/CacheFactoryTest.php
@@ -6,6 +6,7 @@ namespace DoctrineModuleTest\Service;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\ChainCache;
+use Doctrine\Common\Cache\PredisCache;
 use DoctrineModule\Cache\LaminasStorageCache;
 use DoctrineModule\Service\CacheFactory;
 use Laminas\Cache\ConfigProvider;
@@ -41,10 +42,10 @@ class CacheFactoryTest extends BaseTestCase
             ]
         );
 
-        $service = $factory->createService($serviceManager);
+        $service = $factory->__invoke($serviceManager, ArrayCache::class);
         assert($service instanceof ArrayCache);
 
-        $this->assertInstanceOf('Doctrine\\Common\\Cache\\ArrayCache', $service);
+        $this->assertInstanceOf(ArrayCache::class, $service);
         $this->assertSame('bar', $service->getNamespace());
     }
 
@@ -118,9 +119,9 @@ class CacheFactoryTest extends BaseTestCase
             'my_predis_alias',
             $this->createMock('Predis\ClientInterface')
         );
-        $cache = $factory->createService($serviceManager);
+        $cache = $factory->__invoke($serviceManager, PredisCache::class);
 
-        $this->assertInstanceOf('Doctrine\Common\Cache\PredisCache', $cache);
+        $this->assertInstanceOf(PredisCache::class, $cache);
     }
 
     public function testUseServiceFactory(): void
@@ -146,7 +147,7 @@ class CacheFactoryTest extends BaseTestCase
             return $mock;
         });
 
-        $cache = $factory->createService($serviceManager);
+        $cache = $factory->__invoke($serviceManager, ChainCache::class);
 
         $this->assertSame($mock, $cache);
     }

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service;
 
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Service\DriverFactory;
+use DoctrineModuleTest\Service\Mock\MetadataDriverMock;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -24,15 +26,15 @@ class DriverFactoryTest extends BaseTestCase
             [
                 'doctrine' => [
                     'driver' => [
-                        'testDriver' => ['class' => 'DoctrineModuleTest\Service\Mock\MetadataDriverMock'],
+                        'testDriver' => ['class' => MetadataDriverMock::class],
                     ],
                 ],
             ]
         );
 
         $factory = new DriverFactory('testDriver');
-        $driver  = $factory->createService($serviceManager);
-        $this->assertInstanceOf('DoctrineModuleTest\Service\Mock\MetadataDriverMock', $driver);
+        $driver  = $factory->__invoke($serviceManager, MetadataDriverMock::class);
+        $this->assertInstanceOf(MetadataDriverMock::class, $driver);
     }
 
     public function testCreateDriverChain(): void
@@ -43,9 +45,9 @@ class DriverFactoryTest extends BaseTestCase
             [
                 'doctrine' => [
                     'driver' => [
-                        'testDriver' => ['class' => 'DoctrineModuleTest\Service\Mock\MetadataDriverMock'],
+                        'testDriver' => ['class' => MetadataDriverMock::class],
                         'testChainDriver' => [
-                            'class' => 'Doctrine\Persistence\Mapping\Driver\MappingDriverChain',
+                            'class' => MappingDriverChain::class,
                             'drivers' => [
                                 'Foo\Bar' => 'testDriver',
                                 'Foo\Baz' => null,
@@ -57,13 +59,14 @@ class DriverFactoryTest extends BaseTestCase
         );
 
         $factory = new DriverFactory('testChainDriver');
-        $driver  = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\Persistence\Mapping\Driver\MappingDriverChain', $driver);
+        $driver  = $factory->__invoke($serviceManager, MappingDriverChain::class);
+        $this->assertInstanceOf(MappingDriverChain::class, $driver);
         assert($driver instanceof MappingDriverChain);
+
         $drivers = $driver->getDrivers();
         $this->assertCount(1, $drivers);
         $this->assertArrayHasKey('Foo\Bar', $drivers);
-        $this->assertInstanceOf('DoctrineModuleTest\Service\Mock\MetadataDriverMock', $drivers['Foo\Bar']);
+        $this->assertInstanceOf(MetadataDriverMock::class, $drivers['Foo\Bar']);
     }
 
     /**
@@ -77,14 +80,14 @@ class DriverFactoryTest extends BaseTestCase
             [
                 'doctrine' => [
                     'driver' => [
-                        'testDriver' => ['class' => 'Doctrine\ORM\Mapping\Driver\AttributeDriver'],
+                        'testDriver' => ['class' => AttributeDriver::class],
                     ],
                 ],
             ]
         );
 
         $factory = new DriverFactory('testDriver');
-        $driver  = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AttributeDriver', $driver);
+        $driver  = $factory->__invoke($serviceManager, AttributeDriver::class);
+        $this->assertInstanceOf(AttributeDriver::class, $driver);
     }
 }

--- a/tests/Service/EventManagerFactoryTest.php
+++ b/tests/Service/EventManagerFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service;
 
+use Doctrine\Common\EventManager;
 use DoctrineModule\Service\EventManagerFactory;
 use DoctrineModuleTest\Service\TestAsset\DummyEventSubscriber;
 use Laminas\ServiceManager\ServiceManager;
@@ -34,9 +35,9 @@ class EventManagerFactoryTest extends BaseTestCase
             ]
         );
 
-        /* $var $eventManager \Doctrine\Common\EventManager */
-        $eventManager = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+        /* $var $eventManager EventManager */
+        $eventManager = $factory->__invoke($serviceManager, EventManager::class);
+        $this->assertInstanceOf(EventManager::class, $eventManager);
 
         $listeners = $eventManager->getListeners('dummy');
         $this->assertCount(1, $listeners);
@@ -61,9 +62,9 @@ class EventManagerFactoryTest extends BaseTestCase
             ]
         );
 
-        /* $var $eventManager \Doctrine\Common\EventManager */
-        $eventManager = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+        /* $var $eventManager EventManager */
+        $eventManager = $factory->__invoke($serviceManager, EventManager::class);
+        $this->assertInstanceOf(EventManager::class, $eventManager);
 
         $listeners = $eventManager->getListeners();
         $this->assertArrayHasKey('dummy', $listeners);
@@ -91,9 +92,9 @@ class EventManagerFactoryTest extends BaseTestCase
             ]
         );
 
-        /* $var $eventManager \Doctrine\Common\EventManager */
-        $eventManager = $factory->createService($serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\EventManager', $eventManager);
+        /* $var $eventManager EventManager */
+        $eventManager = $factory->__invoke($serviceManager, EventManager::class);
+        $this->assertInstanceOf(EventManager::class, $eventManager);
 
         $listeners = $eventManager->getListeners();
         $this->assertArrayHasKey('dummy', $listeners);
@@ -120,6 +121,6 @@ class EventManagerFactoryTest extends BaseTestCase
         );
 
         $this->expectException('InvalidArgumentException');
-        $factory->createService($serviceManager);
+        $factory->__invoke($serviceManager, EventManager::class);
     }
 }

--- a/tests/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/Validator/Service/NoObjectExistsFactoryTest.php
@@ -157,11 +157,7 @@ class NoObjectExistsFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::createService
-     * @covers ::setCreationOptions
-     */
-    public function testCreateService(): void
+    public function testInvokeWithOptions(): void
     {
         $options = [
             'target_class' => 'Foo\Bar',
@@ -179,8 +175,11 @@ class NoObjectExistsFactoryTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($objectManager->reveal());
 
-        $this->object->setCreationOptions($options);
-        $instance = $this->object->createService($container->reveal());
+        $instance = $this->object->__invoke(
+            $container->reveal(),
+            NoObjectExists::class,
+            $options
+        );
         $this->assertInstanceOf(NoObjectExists::class, $instance);
     }
 }


### PR DESCRIPTION
In laminas-servicemanager 2.x, the `FactoryInterface` included the following methods:
 - `public function createService(ServiceLocatorInterface $serviceLocator)`
 - `public function setCreationOptions(array $options)`

These methods are replaced by the following method in laminas-servicemanager 3.x:
 - `public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)`

Since DoctrineModule already requires laminas-servicemanager 3.x since version 3.0.0, i.e. for nearly two years, it is time to drop the obsolete functions `createService()` and `setCreationOptions()` in all factories. All factories already implement a `__invoke()` method.
