### PR TITLE
Drop support for PHP 7.3 and update dependencies

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.0"
     with:
-      php-version: '8.0'
+      php-version: '8.1'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,16 +15,15 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
         dependencies:
           - "highest"
         include:
-          - php-version: "7.3"
+          - php-version: "7.4"
             dependencies: "lowest"
-          - php-version: "7.3"
+          - php-version: "7.4"
             dependencies: "lowest"
 
     steps:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.3.0"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.0"
     with:
-      php-version: '8.0'
+      php-version: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "doctrine/annotations": "^1.13.2",
         "doctrine/cache": "^1.12.1",
         "doctrine/collections": "^1.6.8",
-        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1 || ^3.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/inflector": "^2.0.4",
         "doctrine/persistence": "^2.2.3",

--- a/composer.json
+++ b/composer.json
@@ -42,46 +42,46 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "container-interop/container-interop": "^1.2.0",
         "doctrine/annotations": "^1.13.2",
         "doctrine/cache": "^1.12.1",
         "doctrine/collections": "^1.6.8",
-        "doctrine/doctrine-laminas-hydrator": "^2.2.0",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
         "doctrine/event-manager": "^1.1.1",
-        "doctrine/inflector": "^2.0.3",
-        "doctrine/persistence": "^2.2.2",
-        "laminas/laminas-authentication": "^2.8.0",
+        "doctrine/inflector": "^2.0.4",
+        "doctrine/persistence": "^2.2.3",
+        "laminas/laminas-authentication": "^2.9.0",
         "laminas/laminas-cache": "^3.1.2",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-form": "^3.0.1",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc": "^3.3.0",
-        "laminas/laminas-paginator": "^2.11.0",
-        "laminas/laminas-servicemanager": "^3.7.0",
-        "laminas/laminas-stdlib": "^3.6.0",
-        "laminas/laminas-validator": "^2.15.0",
-        "symfony/console": "^5.3.7 || ^6.0.0"
+        "laminas/laminas-paginator": "^2.12.1",
+        "laminas/laminas-servicemanager": "^3.10.0",
+        "laminas/laminas-stdlib": "^3.6.2",
+        "laminas/laminas-validator": "^2.15.1",
+        "symfony/console": "^5.4.1 || ^6.0.1"
     },
     "provide": {
-        "laminas/laminas-cache-storage-implementation": "1.0"
+        "laminas/laminas-cache-storage-implementation": "1.0.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
-        "doctrine/orm": "^2.10.2",
+        "doctrine/orm": "^2.10.4",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^2.0.0",
         "laminas/laminas-cache-storage-adapter-memory": "^2.0.0",
-        "laminas/laminas-i18n": "^2.11.3",
-        "laminas/laminas-log": "^2.13.1",
-        "laminas/laminas-serializer": "^2.11.0",
+        "laminas/laminas-i18n": "^2.13.0",
+        "laminas/laminas-log": "^2.15.0",
+        "laminas/laminas-serializer": "^2.12.0",
         "laminas/laminas-session": "^2.12.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
-        "phpstan/phpstan": "^1.1.2",
+        "phpstan/phpstan": "^1.2.0",
         "phpstan/phpstan-phpunit": "^1.0.0",
         "phpunit/phpunit": "^9.5.10",
         "predis/predis": "^1.1.9",
-        "vimeo/psalm": "^4.11.2"
+        "vimeo/psalm": "^4.15.0"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="5"
-    phpVersion="8.0"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Paginator/Adapter/Collection.php
+++ b/src/Paginator/Adapter/Collection.php
@@ -6,6 +6,7 @@ namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Laminas\Paginator\Adapter\AdapterInterface;
+use ReturnTypeWillChange;
 
 use function array_values;
 use function count;
@@ -38,6 +39,7 @@ class Collection implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->collection);

--- a/src/Paginator/Adapter/Selectable.php
+++ b/src/Paginator/Adapter/Selectable.php
@@ -7,6 +7,7 @@ namespace DoctrineModule\Paginator\Adapter;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
 use Laminas\Paginator\Adapter\AdapterInterface;
+use ReturnTypeWillChange;
 
 use function count;
 
@@ -46,6 +47,7 @@ class Selectable implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $criteria = clone $this->criteria;


### PR DESCRIPTION
This PR...
 - drops support for PHP 7.3 to allow typed properties (will follow in a next PR)
 - lets static analysis run with PHP 8.1 in CI pipelines
 - fixes two cases where an `ReturnTypeWillChage` annotation was missing
 - allows usage of doctrine-laminas-hydrator 3.0