### PR TITLE
Introduce typed properties where possible

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.3) -->
-    <config name="php_version" value="70300"/>
+    <!-- set minimal required PHP version (7.4) -->
+    <config name="php_version" value="70400"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-    <testsuites>
-        <testsuite name="DoctrineModule Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="DoctrineModule Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Authentication/Adapter/ObjectRepository.php
+++ b/src/Authentication/Adapter/ObjectRepository.php
@@ -31,7 +31,7 @@ class ObjectRepository extends AbstractAdapter
      *
      * @var mixed[]
      */
-    protected array $authenticationResultInfo = null;
+    protected ?array $authenticationResultInfo = null;
 
     protected Inflector $inflector;
 

--- a/src/Authentication/Adapter/ObjectRepository.php
+++ b/src/Authentication/Adapter/ObjectRepository.php
@@ -24,18 +24,16 @@ use function sprintf;
  */
 class ObjectRepository extends AbstractAdapter
 {
-    /** @var AuthenticationOptions */
-    protected $options;
+    protected AuthenticationOptions $options;
 
     /**
      * Contains the authentication results.
      *
      * @var mixed[]
      */
-    protected $authenticationResultInfo = null;
+    protected array $authenticationResultInfo = null;
 
-    /** @var Inflector */
-    protected $inflector;
+    protected Inflector $inflector;
 
     /**
      * Constructor

--- a/src/Authentication/Storage/ObjectRepository.php
+++ b/src/Authentication/Storage/ObjectRepository.php
@@ -14,8 +14,7 @@ use Laminas\Authentication\Storage\StorageInterface;
  */
 class ObjectRepository implements StorageInterface
 {
-    /** @var AuthenticationOptions */
-    protected $options;
+    protected AuthenticationOptions $options;
 
     /**
      * @param mixed[]|AuthenticationOptions $options

--- a/src/Cache/DoctrineCacheStorage.php
+++ b/src/Cache/DoctrineCacheStorage.php
@@ -14,8 +14,7 @@ use Laminas\Cache\Storage\Adapter\AbstractAdapter;
  */
 class DoctrineCacheStorage extends AbstractAdapter
 {
-    /** @var Cache */
-    protected $cache;
+    protected Cache $cache;
 
     /**
      * {@inheritDoc}

--- a/src/Cache/LaminasStorageCache.php
+++ b/src/Cache/LaminasStorageCache.php
@@ -18,8 +18,7 @@ use Laminas\Cache\Storage\TotalSpaceCapableInterface;
  */
 class LaminasStorageCache extends CacheProvider
 {
-    /** @var StorageInterface */
-    protected $storage;
+    protected StorageInterface $storage;
 
     public function __construct(StorageInterface $storage)
     {

--- a/src/Form/Element/GetProxy.php
+++ b/src/Form/Element/GetProxy.php
@@ -6,7 +6,7 @@ namespace DoctrineModule\Form\Element;
 
 trait GetProxy
 {
-    protected Proxy $proxy;
+    protected ?Proxy $proxy = null;
 
     public function getProxy(): Proxy
     {

--- a/src/Form/Element/GetProxy.php
+++ b/src/Form/Element/GetProxy.php
@@ -6,8 +6,7 @@ namespace DoctrineModule\Form\Element;
 
 trait GetProxy
 {
-    /** @var Proxy */
-    protected $proxy;
+    protected Proxy $proxy;
 
     public function getProxy(): Proxy
     {

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -36,8 +36,8 @@ class Proxy implements ObjectManagerAwareInterface
 {
     use ArrayOrTraversableGuardTrait;
 
-    /** @var mixed[] */
-    protected array $objects;
+    /** @var iterable<object>|null */
+    protected ?iterable $objects = null;
 
     protected ?string $targetClass = null;
 

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -37,46 +37,38 @@ class Proxy implements ObjectManagerAwareInterface
     use ArrayOrTraversableGuardTrait;
 
     /** @var mixed[] */
-    protected $objects;
+    protected array $objects;
 
-    /** @var ?string */
-    protected $targetClass;
-
-    /** @var mixed[] */
-    protected $valueOptions = [];
+    protected ?string $targetClass = null;
 
     /** @var mixed[] */
-    protected $findMethod = [];
+    protected array $valueOptions = [];
+
+    /** @var mixed[] */
+    protected array $findMethod = [];
 
     /** @var mixed */
     protected $property;
 
     /** @var mixed[] */
-    protected $optionAttributes = [];
+    protected array $optionAttributes = [];
 
     /** @var callable $labelGenerator A callable used to create a label based on an item in the collection an Entity */
     protected $labelGenerator;
 
-    /** @var bool|null */
-    protected $isMethod;
+    protected ?bool $isMethod = null;
 
-    /** @var ?ObjectManager */
-    protected $objectManager;
+    protected ?ObjectManager $objectManager = null;
 
-    /** @var bool */
-    protected $displayEmptyItem = false;
+    protected bool $displayEmptyItem = false;
 
-    /** @var string */
-    protected $emptyItemLabel = '';
+    protected string $emptyItemLabel = '';
 
-    /** @var string|null */
-    protected $optgroupIdentifier;
+    protected ?string $optgroupIdentifier = null;
 
-    /** @var string|null */
-    protected $optgroupDefault;
+    protected ?string $optgroupDefault = null;
 
-    /** @var Inflector */
-    protected $inflector;
+    protected Inflector $inflector;
 
     public function __construct(?Inflector $inflector = null)
     {

--- a/src/Options/Authentication.php
+++ b/src/Options/Authentication.php
@@ -62,31 +62,23 @@ class Authentication extends AbstractOptions
 
     /**
      * A valid object implementing ObjectRepository interface (or ObjectManager/identityClass)
-     *
-     * @var ?ObjectRepository
      */
-    protected $objectRepository;
+    protected ?ObjectRepository $objectRepository = null;
 
     /**
      * Entity's class name
-     *
-     * @var string
      */
-    protected $identityClass;
+    protected string $identityClass;
 
     /**
      * Property to use for the identity
-     *
-     * @var string
      */
-    protected $identityProperty;
+    protected string $identityProperty;
 
     /**
      * Property to use for the credential
-     *
-     * @var string
      */
-    protected $credentialProperty;
+    protected string $credentialProperty;
 
     /**
      * Callable function to check if a credential is valid
@@ -98,10 +90,8 @@ class Authentication extends AbstractOptions
     /**
      * If an objectManager is not supplied, this metadata will be used
      * by DoctrineModule/Authentication/Storage/ObjectRepository
-     *
-     * @var ?ClassMetadata
      */
-    protected $classMetadata;
+    protected ?ClassMetadata $classMetadata = null;
 
     /**
      * When using this options class to create a DoctrineModule/Authentication/Storage/ObjectRepository

--- a/src/Options/Cache.php
+++ b/src/Options/Cache.php
@@ -15,32 +15,24 @@ class Cache extends AbstractOptions
 {
     /**
      * Class used to instantiate the cache.
-     *
-     * @var string
      */
-    protected $class = 'Doctrine\Common\Cache\ArrayCache';
+    protected string $class = 'Doctrine\Common\Cache\ArrayCache';
 
     /**
      * Namespace to prefix all cache ids with.
-     *
-     * @var string
      */
-    protected $namespace = '';
+    protected string $namespace = '';
 
     /**
      * Directory for file-based caching
-     *
-     * @var string
      */
-    protected $directory;
+    protected string $directory;
 
     /**
      * Key to use for fetching the memcache, memcached, or redis instance from
      * the service locator. Used only with Memcache. Memcached, and Redis.
-     *
-     * @var string|null
      */
-    protected $instance = null;
+    protected ?string $instance = null;
 
     public function setClass(string $class): self
     {

--- a/src/Options/Driver.php
+++ b/src/Options/Driver.php
@@ -15,10 +15,8 @@ class Driver extends AbstractOptions
 {
     /**
      * The class name of the Driver.
-     *
-     * @var string
      */
-    protected $class;
+    protected string $class;
 
     /**
      * All drivers (except DriverChain) require paths to work on. You
@@ -27,25 +25,21 @@ class Driver extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $paths = [];
+    protected array $paths = [];
 
     /**
      * Set the cache key for the annotation cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator. This option is only valid for the
      * AnnotationDriver.
-     *
-     * @var string
      */
-    protected $cache = 'array';
+    protected string $cache = 'array';
 
     /**
      * Set the file extension to use. This option is only
      * valid for FileDrivers (XmlDriver, YamlDriver, PHPDriver, etc).
-     *
-     * @var string|null
      */
-    protected $extension = null;
+    protected ?string $extension = null;
 
     /**
      * Set the driver keys to use which are assembled as
@@ -54,7 +48,7 @@ class Driver extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $drivers = [];
+    protected array $drivers = [];
 
     public function setCache(string $cache): void
     {

--- a/src/Options/EventManager.php
+++ b/src/Options/EventManager.php
@@ -20,7 +20,7 @@ class EventManager extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $subscribers = [];
+    protected array $subscribers = [];
 
     /**
      * @param mixed[] $subscribers

--- a/src/Paginator/Adapter/Collection.php
+++ b/src/Paginator/Adapter/Collection.php
@@ -18,7 +18,7 @@ use function count;
 class Collection implements AdapterInterface
 {
     /** @var DoctrineCollection<TKey,T> */
-    protected $collection;
+    protected DoctrineCollection $collection;
 
     /**
      * @param DoctrineCollection<TKey,T> $collection

--- a/src/Paginator/Adapter/Selectable.php
+++ b/src/Paginator/Adapter/Selectable.php
@@ -18,11 +18,9 @@ use function count;
  */
 class Selectable implements AdapterInterface
 {
-    /** @var DoctrineSelectable */
-    protected $selectable;
+    protected DoctrineSelectable $selectable;
 
-    /** @var Criteria */
-    protected $criteria;
+    protected Criteria $criteria;
 
     /**
      * Create a paginator around a Selectable object. You can also provide an optional Criteria object with

--- a/src/Persistence/ProvidesObjectManager.php
+++ b/src/Persistence/ProvidesObjectManager.php
@@ -13,8 +13,7 @@ use function interface_exists;
  */
 trait ProvidesObjectManager
 {
-    /** @var ObjectManager */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
 
     /**
      * Set the object manager

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -21,11 +21,11 @@ abstract class AbstractFactory implements FactoryInterface
     /**
      * Would normally be set to orm | odm
      */
-    protected string $mappingType;
+    protected ?string $mappingType = null;
 
     protected string $name;
 
-    protected AbstractOptions $options;
+    protected ?AbstractOptions $options = null;
 
     public function __construct(string $name)
     {

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -20,16 +20,12 @@ abstract class AbstractFactory implements FactoryInterface
 // phpcs:enable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
     /**
      * Would normally be set to orm | odm
-     *
-     * @var string
      */
-    protected $mappingType;
+    protected string $mappingType;
 
-    /** @var string */
-    protected $name;
+    protected string $name;
 
-    /** @var AbstractOptions */
-    protected $options;
+    protected AbstractOptions $options;
 
     public function __construct(string $name)
     {

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Helper\HelperSet;
  */
 class CliFactory implements FactoryInterface
 {
-    protected EventManagerInterface $events;
+    protected ?EventManagerInterface $events = null;
 
     protected HelperSet $helperSet;
 

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -17,14 +17,12 @@ use Symfony\Component\Console\Helper\HelperSet;
  */
 class CliFactory implements FactoryInterface
 {
-    /** @var EventManagerInterface */
-    protected $events;
+    protected EventManagerInterface $events;
 
-    /** @var HelperSet */
-    protected $helperSet;
+    protected HelperSet $helperSet;
 
     /** @var mixed[] */
-    protected $commands = [];
+    protected array $commands = [];
 
     public function getEventManager(ContainerInterface $container): EventManagerInterface
     {

--- a/src/Validator/NoObjectExists.php
+++ b/src/Validator/NoObjectExists.php
@@ -19,7 +19,7 @@ class NoObjectExists extends ObjectExists
     public const ERROR_OBJECT_FOUND = 'objectFound';
 
     /** @var mixed[] Message templates */
-    protected $messageTemplates = [self::ERROR_OBJECT_FOUND => "An object matching '%value%' was found"];
+    protected array $messageTemplates = [self::ERROR_OBJECT_FOUND => "An object matching '%value%' was found"];
 
     /**
      * {@inheritDoc}

--- a/src/Validator/ObjectExists.php
+++ b/src/Validator/ObjectExists.php
@@ -33,21 +33,19 @@ class ObjectExists extends AbstractValidator
     public const ERROR_NO_OBJECT_FOUND = 'noObjectFound';
 
     /** @var mixed[] Message templates */
-    protected $messageTemplates = [self::ERROR_NO_OBJECT_FOUND => "No object matching '%value%' was found"];
+    protected array $messageTemplates = [self::ERROR_NO_OBJECT_FOUND => "No object matching '%value%' was found"];
 
     /**
      * ObjectRepository from which to search for entities
-     *
-     * @var ObjectRepository
      */
-    protected $objectRepository;
+    protected ObjectRepository $objectRepository;
 
     /**
      * Fields to be checked
      *
      * @var mixed[]
      */
-    protected $fields;
+    protected array $fields;
 
     /**
      * Constructor

--- a/src/Validator/ObjectExists.php
+++ b/src/Validator/ObjectExists.php
@@ -43,9 +43,9 @@ class ObjectExists extends AbstractValidator
     /**
      * Fields to be checked
      *
-     * @var mixed[]
+     * @var mixed[]|string
      */
-    protected array $fields;
+    protected $fields = null;
 
     /**
      * Constructor

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -27,10 +27,9 @@ abstract class AbstractValidatorFactory implements FactoryInterface
     public const DEFAULT_OBJECTMANAGER_KEY = 'doctrine.entitymanager.orm_default';
 
     /** @var mixed[] */
-    protected $creationOptions = [];
+    protected array $creationOptions = [];
 
-    /** @var string $validatorClass */
-    protected $validatorClass;
+    protected string $validatorClass;
 
     /**
      * @param mixed[] $options

--- a/src/Validator/Service/NoObjectExistsFactory.php
+++ b/src/Validator/Service/NoObjectExistsFactory.php
@@ -14,8 +14,7 @@ use Interop\Container\ContainerInterface;
  */
 class NoObjectExistsFactory extends AbstractValidatorFactory
 {
-    /** @var string */
-    protected $validatorClass = NoObjectExists::class;
+    protected string $validatorClass = NoObjectExists::class;
 
     /**
      * {@inheritDoc}

--- a/src/Validator/Service/ObjectExistsFactory.php
+++ b/src/Validator/Service/ObjectExistsFactory.php
@@ -14,8 +14,7 @@ use Interop\Container\ContainerInterface;
  */
 class ObjectExistsFactory extends AbstractValidatorFactory
 {
-    /** @var string */
-    protected $validatorClass = ObjectExists::class;
+    protected string $validatorClass = ObjectExists::class;
 
     /**
      * {@inheritDoc}

--- a/src/Validator/Service/UniqueObjectFactory.php
+++ b/src/Validator/Service/UniqueObjectFactory.php
@@ -9,8 +9,7 @@ use Interop\Container\ContainerInterface;
 
 class UniqueObjectFactory extends AbstractValidatorFactory
 {
-    /** @var string */
-    protected $validatorClass = UniqueObject::class;
+    protected string $validatorClass = UniqueObject::class;
 
     /**
      * {@inheritDoc}

--- a/src/Validator/UniqueObject.php
+++ b/src/Validator/UniqueObject.php
@@ -27,14 +27,12 @@ class UniqueObject extends ObjectExists
 
     // phpcs:disable Generic.Files.LineLength
     /** @var mixed[] */
-    protected $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
+    protected array $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
     // phpcs:enable Generic.Files.LineLength
 
-    /** @var ObjectManager */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
 
-    /** @var bool */
-    protected $useContext;
+    protected bool $useContext;
 
     /***
      * Constructor

--- a/tests/Authentication/Adapter/TestAsset/IdentityObject.php
+++ b/tests/Authentication/Adapter/TestAsset/IdentityObject.php
@@ -11,11 +11,9 @@ namespace DoctrineModuleTest\Authentication\Adapter\TestAsset;
  */
 class IdentityObject
 {
-    /** @var string|null */
-    protected $username;
+    protected ?string $username = null;
 
-    /** @var string|null */
-    protected $password;
+    protected ?string $password = null;
 
     /**
      * @param mixed $password

--- a/tests/Authentication/Adapter/TestAsset/PublicPropertiesIdentityObject.php
+++ b/tests/Authentication/Adapter/TestAsset/PublicPropertiesIdentityObject.php
@@ -11,9 +11,7 @@ namespace DoctrineModuleTest\Authentication\Adapter\TestAsset;
  */
 class PublicPropertiesIdentityObject
 {
-    /** @var string|null */
-    public $username;
+    public ?string $username = null;
 
-    /** @var string|null */
-    public $password;
+    public ?string $password = null;
 }

--- a/tests/Cache/DoctrineCacheStorageTest.php
+++ b/tests/Cache/DoctrineCacheStorageTest.php
@@ -35,22 +35,19 @@ use function ucwords;
  */
 class DoctrineCacheStorageTest extends TestCase
 {
-    /** @var AdapterOptions */
-    protected $options;
+    protected AdapterOptions $options;
 
     /**
      * The storage adapter
-     *
-     * @var StorageInterface
      */
-    protected $storage;
+    protected StorageInterface $storage;
 
     /**
      * All datatypes of PHP
      *
      * @var string[]
      */
-    protected $phpDatatypes = ['NULL', 'boolean', 'integer', 'double', 'string', 'array', 'object', 'resource'];
+    protected array $phpDatatypes = ['NULL', 'boolean', 'integer', 'double', 'string', 'array', 'object', 'resource'];
 
     protected function setUp(): void
     {

--- a/tests/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/Form/Element/ObjectMultiCheckboxTest.php
@@ -18,11 +18,9 @@ use function get_class;
  */
 class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
 {
-    /** @var ArrayCollection */
-    protected $values;
+    protected ArrayCollection $values;
 
-    /** @var ObjectMultiCheckbox */
-    protected $element;
+    protected ObjectMultiCheckbox $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/Form/Element/ObjectMultiCheckboxTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Form\Element;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Form\Element\ObjectMultiCheckbox;
+use Laminas\Form\Element;
 
 use function get_class;
 
@@ -18,9 +18,8 @@ use function get_class;
  */
 class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase
 {
-    protected ArrayCollection $values;
-
-    protected ObjectMultiCheckbox $element;
+    /** @var ObjectMultiCheckbox  */
+    protected Element $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ObjectRadioTest.php
+++ b/tests/Form/Element/ObjectRadioTest.php
@@ -15,8 +15,7 @@ use function get_class;
  */
 class ObjectRadioTest extends ProxyAwareElementTestCase
 {
-    /** @var ObjectRadio */
-    protected $element;
+    protected ObjectRadio $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ObjectRadioTest.php
+++ b/tests/Form/Element/ObjectRadioTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineModuleTest\Form\Element;
 
 use DoctrineModule\Form\Element\ObjectRadio;
+use Laminas\Form\Element;
 
 use function get_class;
 
@@ -15,7 +16,8 @@ use function get_class;
  */
 class ObjectRadioTest extends ProxyAwareElementTestCase
 {
-    protected ObjectRadio $element;
+    /** @var ObjectRadio  */
+    protected Element $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ObjectSelectTest.php
+++ b/tests/Form/Element/ObjectSelectTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Form\Element;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use DoctrineModule\Form\Element\ObjectSelect;
+use Laminas\Form\Element;
 
 use function get_class;
 
@@ -18,9 +18,8 @@ use function get_class;
  */
 class ObjectSelectTest extends ProxyAwareElementTestCase
 {
-    protected ArrayCollection $values;
-
-    protected ObjectSelect $element;
+    /** @var ObjectSelect  */
+    protected Element $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ObjectSelectTest.php
+++ b/tests/Form/Element/ObjectSelectTest.php
@@ -18,11 +18,9 @@ use function get_class;
  */
 class ObjectSelectTest extends ProxyAwareElementTestCase
 {
-    /** @var ArrayCollection */
-    protected $values;
+    protected ArrayCollection $values;
 
-    /** @var ObjectSelect */
-    protected $element;
+    protected ObjectSelect $element;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/Form/Element/ProxyAwareElementTestCase.php
@@ -22,11 +22,9 @@ class ProxyAwareElementTestCase extends TestCase
     /** @var MockObject&ClassMetadata */
     protected $metadata;
 
-    /** @var object */
-    protected $element;
+    protected object $element;
 
-    /** @var ArrayCollection */
-    protected $values;
+    protected ArrayCollection $values;
 
     protected function prepareProxy(): void
     {

--- a/tests/Form/Element/ProxyAwareElementTestCase.php
+++ b/tests/Form/Element/ProxyAwareElementTestCase.php
@@ -7,6 +7,7 @@ namespace DoctrineModuleTest\Form\Element;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use DoctrineModuleTest\Form\Element\TestAsset\FormObject;
+use Laminas\Form\Element;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -22,7 +23,7 @@ class ProxyAwareElementTestCase extends TestCase
     /** @var MockObject&ClassMetadata */
     protected $metadata;
 
-    protected object $element;
+    protected Element $element;
 
     protected ArrayCollection $values;
 

--- a/tests/Form/Element/ProxyTest.php
+++ b/tests/Form/Element/ProxyTest.php
@@ -31,8 +31,7 @@ class ProxyTest extends TestCase
     /** @var MockObject&ClassMetadata */
     protected $metadata;
 
-    /** @var Proxy */
-    protected $proxy;
+    protected Proxy $proxy;
 
     /**
      * {@inheritDoc}.

--- a/tests/Form/Element/TestAsset/FormObject.php
+++ b/tests/Form/Element/TestAsset/FormObject.php
@@ -13,26 +13,19 @@ use function assert;
  */
 class FormObject
 {
-    /** @var int|null */
-    protected $id;
+    protected ?int $id = null;
 
-    /** @var string|null */
-    public $email;
+    public ?string $email = null;
 
-    /** @var string|null */
-    protected $username;
+    protected ?string $username = null;
 
-    /** @var string|null */
-    protected $firstname;
+    protected ?string $firstname = null;
 
-    /** @var string|null */
-    protected $surname;
+    protected ?string $surname = null;
 
-    /** @var string|null */
-    protected $password;
+    protected ?string $password = null;
 
-    /** @var string|null */
-    protected $optgroup;
+    protected ?string $optgroup = null;
 
     public function __toString(): string
     {

--- a/tests/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/Paginator/Adapter/CollectionAdapterTest.php
@@ -17,8 +17,7 @@ use function range;
  */
 class CollectionAdapterTest extends TestCase
 {
-    /** @var CollectionAdapter */
-    protected $adapter;
+    protected CollectionAdapter $adapter;
 
     /**
      * {@inheritDoc}.

--- a/tests/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/ServiceFactory/ModuleDefinedServicesTest.php
@@ -15,8 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ModuleDefinedServicesTest extends TestCase
 {
-    /** @var ServiceLocatorInterface */
-    protected $serviceManager;
+    protected ServiceLocatorInterface $serviceManager;
 
     protected function setUp(): void
     {

--- a/tests/Validator/Service/NoObjectExistsFactoryTest.php
+++ b/tests/Validator/Service/NoObjectExistsFactoryTest.php
@@ -24,8 +24,7 @@ class NoObjectExistsFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var NoObjectExistsFactory */
-    private $object;
+    private NoObjectExistsFactory $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/Validator/Service/ObjectExistsFactoryTest.php
+++ b/tests/Validator/Service/ObjectExistsFactoryTest.php
@@ -22,8 +22,7 @@ class ObjectExistsFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var ObjectExistsFactory */
-    protected $object;
+    protected ObjectExistsFactory $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/Validator/Service/UniqueObjectFactoryTest.php
+++ b/tests/Validator/Service/UniqueObjectFactoryTest.php
@@ -22,8 +22,7 @@ class UniqueObjectFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var UniqueObjectFactory */
-    private $object;
+    private UniqueObjectFactory $object;
 
     /**
      * Sets up the fixture, for example, opens a network connection.


### PR DESCRIPTION
**Caution:** BC Break

This PR is a follow-up on #764  updates the coding standards to PHP 7.4 as the minimum supported version. This introduced typed properties in many places.