### PR TITLE
Mark `Module`, `ConfigProvider`, option classes and factories as final

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,5 +17,10 @@
     <file>tests</file>
 
     <!-- Include full Doctrine Coding Standard -->
-    <rule ref="Doctrine"/>
+    <rule ref="Doctrine">
+        <!-- Not used for consistency with the Laminas project -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
+    </rule>
 </ruleset>

--- a/src/Authentication/Adapter/ObjectRepository.php
+++ b/src/Authentication/Adapter/ObjectRepository.php
@@ -19,8 +19,6 @@ use function sprintf;
 
 /**
  * Authentication adapter that uses a Doctrine object for verification.
- *
- * @link    http://www.doctrine-project.org/
  */
 class ObjectRepository extends AbstractAdapter
 {

--- a/src/Authentication/Storage/ObjectRepository.php
+++ b/src/Authentication/Storage/ObjectRepository.php
@@ -9,8 +9,6 @@ use Laminas\Authentication\Storage\StorageInterface;
 
 /**
  * This class implements StorageInterface and allow to save the result of an authentication against an object repository
- *
- * @link    http://www.doctrine-project.org/
  */
 class ObjectRepository implements StorageInterface
 {

--- a/src/Cache/DoctrineCacheStorage.php
+++ b/src/Cache/DoctrineCacheStorage.php
@@ -9,8 +9,6 @@ use Laminas\Cache\Storage\Adapter\AbstractAdapter;
 
 /**
  * Bridge class that allows usage of a Doctrine Cache Storage as a Laminas Cache Storage
- *
- * @link    http://www.doctrine-project.org/
  */
 class DoctrineCacheStorage extends AbstractAdapter
 {

--- a/src/Cache/LaminasStorageCache.php
+++ b/src/Cache/LaminasStorageCache.php
@@ -13,8 +13,6 @@ use Laminas\Cache\Storage\TotalSpaceCapableInterface;
 
 /**
  * Bridge class that allows usage of a Laminas Cache Storage as a Doctrine Cache
- *
- * @link    http://www.doctrine-project.org/
  */
 class LaminasStorageCache extends CacheProvider
 {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,7 +9,7 @@ namespace DoctrineModule;
  *
  * @link    www.doctrine-project.org
  */
-class ConfigProvider
+final class ConfigProvider
 {
     /**
      * @return mixed[]

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,8 +6,6 @@ namespace DoctrineModule;
 
 /**
  * Config provider for DoctrineORMModule config
- *
- * @link    www.doctrine-project.org
  */
 final class ConfigProvider
 {

--- a/src/Form/Element/Exception/InvalidRepositoryResultException.php
+++ b/src/Form/Element/Exception/InvalidRepositoryResultException.php
@@ -6,8 +6,6 @@ namespace DoctrineModule\Form\Element\Exception;
 
 use InvalidArgumentException;
 
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming
 class InvalidRepositoryResultException extends InvalidArgumentException
 {
 }
-// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming

--- a/src/Module.php
+++ b/src/Module.php
@@ -13,8 +13,6 @@ use function class_exists;
 
 /**
  * Base module for integration of Doctrine projects with Laminas applications
- *
- * @link    http://www.doctrine-project.org/
  */
 final class Module implements ConfigProviderInterface, InitProviderInterface
 {

--- a/src/Module.php
+++ b/src/Module.php
@@ -16,7 +16,7 @@ use function class_exists;
  *
  * @link    http://www.doctrine-project.org/
  */
-class Module implements ConfigProviderInterface, InitProviderInterface
+final class Module implements ConfigProviderInterface, InitProviderInterface
 {
     public function init(ModuleManagerInterface $manager): void
     {

--- a/src/Options/Authentication.php
+++ b/src/Options/Authentication.php
@@ -51,7 +51,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class Authentication extends AbstractOptions
+final class Authentication extends AbstractOptions
 {
     /**
      * A valid object implementing ObjectManager interface

--- a/src/Options/Authentication.php
+++ b/src/Options/Authentication.php
@@ -48,8 +48,6 @@ use function sprintf;
  * All remains the same using with DoctrineModule\Service\AuthenticationStorageFactory,
  * however, a string may be passed to $objectManager. This string must be a valid key to
  * retrieve an ObjectManager instance from the ServiceManager.
- *
- * @link    http://www.doctrine-project.org/
  */
 final class Authentication extends AbstractOptions
 {

--- a/src/Options/Cache.php
+++ b/src/Options/Cache.php
@@ -11,7 +11,7 @@ use Laminas\Stdlib\AbstractOptions;
  *
  * @link    http://www.doctrine-project.org/
  */
-class Cache extends AbstractOptions
+final class Cache extends AbstractOptions
 {
     /**
      * Class used to instantiate the cache.

--- a/src/Options/Cache.php
+++ b/src/Options/Cache.php
@@ -8,8 +8,6 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Cache options
- *
- * @link    http://www.doctrine-project.org/
  */
 final class Cache extends AbstractOptions
 {

--- a/src/Options/Driver.php
+++ b/src/Options/Driver.php
@@ -11,7 +11,7 @@ use Laminas\Stdlib\AbstractOptions;
  *
  * @link    http://www.doctrine-project.org/
  */
-class Driver extends AbstractOptions
+final class Driver extends AbstractOptions
 {
     /**
      * The class name of the Driver.

--- a/src/Options/Driver.php
+++ b/src/Options/Driver.php
@@ -8,8 +8,6 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * MappingDriver options
- *
- * @link    http://www.doctrine-project.org/
  */
 final class Driver extends AbstractOptions
 {

--- a/src/Options/EventManager.php
+++ b/src/Options/EventManager.php
@@ -11,7 +11,7 @@ use Laminas\Stdlib\AbstractOptions;
  *
  * @link    http://www.doctrine-project.org/
  */
-class EventManager extends AbstractOptions
+final class EventManager extends AbstractOptions
 {
     /**
      * An array of subscribers. The array can contain the FQN of the

--- a/src/Options/EventManager.php
+++ b/src/Options/EventManager.php
@@ -8,8 +8,6 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * EventManager options
- *
- * @link    http://www.doctrine-project.org/
  */
 final class EventManager extends AbstractOptions
 {

--- a/src/Paginator/Adapter/Selectable.php
+++ b/src/Paginator/Adapter/Selectable.php
@@ -13,8 +13,6 @@ use function count;
 
 /**
  * Provides a wrapper around a Selectable object
- *
- * @link    http://www.doctrine-project.org/
  */
 class Selectable implements AdapterInterface
 {

--- a/src/Persistence/ObjectManagerAwareInterface.php
+++ b/src/Persistence/ObjectManagerAwareInterface.php
@@ -8,11 +8,8 @@ use Doctrine\Persistence\ObjectManager;
 
 use function interface_exists;
 
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
 interface ObjectManagerAwareInterface
 {
-// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
-
     /**
      * Set the object manager
      */

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use function sprintf;
 
 /**
- * Base ServiceManager factory to be extended
+ * Base ServiceManager factory
  *
  * @interal
  */

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -13,6 +13,8 @@ use function sprintf;
 
 /**
  * Base ServiceManager factory to be extended
+ *
+ * @interal
  */
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractFactory implements FactoryInterface

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -16,10 +16,8 @@ use function sprintf;
  *
  * @interal
  */
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractFactory implements FactoryInterface
 {
-// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
     /**
      * Would normally be set to orm | odm
      */

--- a/src/Service/Authentication/AdapterFactory.php
+++ b/src/Service/Authentication/AdapterFactory.php
@@ -19,7 +19,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AdapterFactory extends AbstractFactory
+final class AdapterFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/Authentication/AdapterFactory.php
+++ b/src/Service/Authentication/AdapterFactory.php
@@ -16,8 +16,6 @@ use function sprintf;
 
 /**
  * Factory to create authentication adapter object.
- *
- * @link    http://www.doctrine-project.org/
  */
 final class AdapterFactory extends AbstractFactory
 {

--- a/src/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/Service/Authentication/AuthenticationServiceFactory.php
@@ -11,8 +11,6 @@ use Laminas\Authentication\AuthenticationService;
 
 /**
  * Factory to create authentication service object.
- *
- * @link    http://www.doctrine-project.org/
  */
 final class AuthenticationServiceFactory extends AbstractFactory
 {

--- a/src/Service/Authentication/AuthenticationServiceFactory.php
+++ b/src/Service/Authentication/AuthenticationServiceFactory.php
@@ -14,7 +14,7 @@ use Laminas\Authentication\AuthenticationService;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AuthenticationServiceFactory extends AbstractFactory
+final class AuthenticationServiceFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/Authentication/StorageFactory.php
+++ b/src/Service/Authentication/StorageFactory.php
@@ -19,7 +19,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class StorageFactory extends AbstractFactory
+final class StorageFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/Authentication/StorageFactory.php
+++ b/src/Service/Authentication/StorageFactory.php
@@ -16,8 +16,6 @@ use function sprintf;
 
 /**
  * Factory to create authentication storage object.
- *
- * @link    http://www.doctrine-project.org/
  */
 final class StorageFactory extends AbstractFactory
 {

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -20,7 +20,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class CacheFactory extends AbstractFactory
+final class CacheFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -17,8 +17,6 @@ use function sprintf;
 
 /**
  * Cache ServiceManager factory
- *
- * @link    http://www.doctrine-project.org/
  */
 final class CacheFactory extends AbstractFactory
 {

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Helper\HelperSet;
 
 /**
  * CLI Application ServiceManager factory responsible for instantiating a Symfony CLI application
- *
- * @link    http://www.doctrine-project.org/
  */
 final class CliFactory implements FactoryInterface
 {

--- a/src/Service/CliFactory.php
+++ b/src/Service/CliFactory.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Helper\HelperSet;
  *
  * @link    http://www.doctrine-project.org/
  */
-class CliFactory implements FactoryInterface
+final class CliFactory implements FactoryInterface
 {
     protected ?EventManagerInterface $events = null;
 

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -26,7 +26,7 @@ use function sprintf;
  *
  * @link    http://www.doctrine-project.org/
  */
-class DriverFactory extends AbstractFactory
+final class DriverFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -23,8 +23,6 @@ use function sprintf;
 
 /**
  * MappingDriver ServiceManager factory
- *
- * @link    http://www.doctrine-project.org/
  */
 final class DriverFactory extends AbstractFactory
 {

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -21,7 +21,7 @@ use function sprintf;
 /**
  * Factory responsible for creating EventManager instances
  */
-class EventManagerFactory extends AbstractFactory
+final class EventManagerFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -16,7 +16,7 @@ use function preg_match;
  *
  * @link    http://www.doctrine-project.org/
  */
-class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
+final class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/ServiceFactory/AbstractDoctrineServiceFactory.php
+++ b/src/ServiceFactory/AbstractDoctrineServiceFactory.php
@@ -13,8 +13,6 @@ use function preg_match;
 /**
  * Abstract service factory capable of instantiating services whose names match the
  * pattern <code>doctrine.$serviceType.$serviceName</doctrine>
- *
- * @link    http://www.doctrine-project.org/
  */
 final class AbstractDoctrineServiceFactory implements AbstractFactoryInterface
 {

--- a/src/Validator/NoObjectExists.php
+++ b/src/Validator/NoObjectExists.php
@@ -8,8 +8,6 @@ use function is_object;
 
 /**
  * Class that validates if objects does not exist in a given repository with a given list of matched fields
- *
- * @link    http://www.doctrine-project.org/
  */
 class NoObjectExists extends ObjectExists
 {

--- a/src/Validator/ObjectExists.php
+++ b/src/Validator/ObjectExists.php
@@ -22,8 +22,6 @@ use function sprintf;
 
 /**
  * Class that validates if objects exist in a given repository with a given list of matched fields
- *
- * @link    http://www.doctrine-project.org/
  */
 class ObjectExists extends AbstractValidator
 {

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -20,10 +20,8 @@ use function sprintf;
  *
  * @internal
  */
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractValidatorFactory implements FactoryInterface
 {
-// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
     public const DEFAULT_OBJECTMANAGER_KEY = 'doctrine.entitymanager.orm_default';
 
     /** @var mixed[] */

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -16,9 +16,9 @@ use function is_string;
 use function sprintf;
 
 /**
- * Factory for creating NoObjectExists instances
+ * Base validator factory to be extended
  *
- * @link http://www.doctrine-project.org/
+ * @internal
  */
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractValidatorFactory implements FactoryInterface

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -16,7 +16,7 @@ use function is_string;
 use function sprintf;
 
 /**
- * Base validator factory to be extended
+ * Base validator factory
  *
  * @internal
  */

--- a/src/Validator/Service/Exception/ServiceCreationException.php
+++ b/src/Validator/Service/Exception/ServiceCreationException.php
@@ -6,8 +6,6 @@ namespace DoctrineModule\Validator\Service\Exception;
 
 use RuntimeException as BaseRuntimeException;
 
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming
 class ServiceCreationException extends BaseRuntimeException
 {
 }
-// phpcs:enable SlevomatCodingStandard.Classes.SuperfluousExceptionNaming

--- a/src/Validator/Service/NoObjectExistsFactory.php
+++ b/src/Validator/Service/NoObjectExistsFactory.php
@@ -7,12 +7,7 @@ namespace DoctrineModule\Validator\Service;
 use DoctrineModule\Validator\NoObjectExists;
 use Interop\Container\ContainerInterface;
 
-/**
- * Factory for creating NoObjectExists instances
- *
- * @link    http://www.doctrine-project.org/
- */
-class NoObjectExistsFactory extends AbstractValidatorFactory
+final class NoObjectExistsFactory extends AbstractValidatorFactory
 {
     protected string $validatorClass = NoObjectExists::class;
 

--- a/src/Validator/Service/ObjectExistsFactory.php
+++ b/src/Validator/Service/ObjectExistsFactory.php
@@ -7,12 +7,7 @@ namespace DoctrineModule\Validator\Service;
 use DoctrineModule\Validator\ObjectExists;
 use Interop\Container\ContainerInterface;
 
-/**
- * Factory for creating ObjectExists instances
- *
- * @link    http://www.doctrine-project.org/
- */
-class ObjectExistsFactory extends AbstractValidatorFactory
+final class ObjectExistsFactory extends AbstractValidatorFactory
 {
     protected string $validatorClass = ObjectExists::class;
 

--- a/src/Validator/Service/UniqueObjectFactory.php
+++ b/src/Validator/Service/UniqueObjectFactory.php
@@ -7,7 +7,7 @@ namespace DoctrineModule\Validator\Service;
 use DoctrineModule\Validator\UniqueObject;
 use Interop\Container\ContainerInterface;
 
-class UniqueObjectFactory extends AbstractValidatorFactory
+final class UniqueObjectFactory extends AbstractValidatorFactory
 {
     protected string $validatorClass = UniqueObject::class;
 

--- a/src/Validator/UniqueObject.php
+++ b/src/Validator/UniqueObject.php
@@ -25,10 +25,8 @@ class UniqueObject extends ObjectExists
      */
     public const ERROR_OBJECT_NOT_UNIQUE = 'objectNotUnique';
 
-    // phpcs:disable Generic.Files.LineLength
     /** @var mixed[] */
     protected array $messageTemplates = [self::ERROR_OBJECT_NOT_UNIQUE => "There is already another object matching '%value%'"];
-    // phpcs:enable Generic.Files.LineLength
 
     protected ObjectManager $objectManager;
 

--- a/tests/Authentication/Adapter/ObjectRepositoryTest.php
+++ b/tests/Authentication/Adapter/ObjectRepositoryTest.php
@@ -14,8 +14,6 @@ use function crypt;
 
 /**
  * Tests for the ObjectRepository based authentication adapter
- *
- * @link    http://www.doctrine-project.org/
  */
 class ObjectRepositoryTest extends BaseTestCase
 {

--- a/tests/Authentication/Adapter/TestAsset/IdentityObject.php
+++ b/tests/Authentication/Adapter/TestAsset/IdentityObject.php
@@ -6,8 +6,6 @@ namespace DoctrineModuleTest\Authentication\Adapter\TestAsset;
 
 /**
  * Simple mock object for authentication adapter test
- *
- * @link    http://www.doctrine-project.org/
  */
 class IdentityObject
 {

--- a/tests/Authentication/Adapter/TestAsset/PublicPropertiesIdentityObject.php
+++ b/tests/Authentication/Adapter/TestAsset/PublicPropertiesIdentityObject.php
@@ -6,8 +6,6 @@ namespace DoctrineModuleTest\Authentication\Adapter\TestAsset;
 
 /**
  * Simple mock object for authentication adapter test with direct property access
- *
- * @link    http://www.doctrine-project.org/
  */
 class PublicPropertiesIdentityObject
 {

--- a/tests/Authentication/Storage/ObjectRepositoryTest.php
+++ b/tests/Authentication/Storage/ObjectRepositoryTest.php
@@ -11,8 +11,6 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
  * Tests for the ObjectRepository based authentication adapter
- *
- * @link    http://www.doctrine-project.org/
  */
 class ObjectRepositoryTest extends BaseTestCase
 {

--- a/tests/Cache/DoctrineCacheStorageTest.php
+++ b/tests/Cache/DoctrineCacheStorageTest.php
@@ -28,8 +28,6 @@ use function ucwords;
 /**
  * Tests for the cache bridge
  *
- * @link    http://www.doctrine-project.org/
- *
  * @todo extend \ZendTest\Cache\Storage\CommonAdapterTest instead
  * @covers \DoctrineModule\Cache\DoctrineCacheStorage
  */

--- a/tests/Cache/LaminasStorageCacheTest.php
+++ b/tests/Cache/LaminasStorageCacheTest.php
@@ -12,8 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the cache bridge
- *
- * @link    http://www.doctrine-project.org/
  */
 class LaminasStorageCacheTest extends TestCase
 {

--- a/tests/ConfigProviderTest.php
+++ b/tests/ConfigProviderTest.php
@@ -12,8 +12,6 @@ use function unserialize;
 
 /**
  * Tests used to ensure ConfigProvider operates as expected
- *
- * @link    http://www.doctrine-project.org/
  */
 class ConfigProviderTest extends TestCase
 {

--- a/tests/Form/Element/ObjectMultiCheckboxTest.php
+++ b/tests/Form/Element/ObjectMultiCheckboxTest.php
@@ -12,8 +12,6 @@ use function get_class;
 /**
  * Tests for the ObjectMultiCheckbox element
  *
- * @link    http://www.doctrine-project.org/
- *
  * @covers  \DoctrineModule\Form\Element\ObjectMultiCheckbox
  */
 class ObjectMultiCheckboxTest extends ProxyAwareElementTestCase

--- a/tests/Form/Element/ObjectSelectTest.php
+++ b/tests/Form/Element/ObjectSelectTest.php
@@ -12,8 +12,6 @@ use function get_class;
 /**
  * Tests for the ObjectSelect element
  *
- * @link    http://www.doctrine-project.org/
- *
  * @covers  \DoctrineModule\Form\Element\ObjectSelect
  */
 class ObjectSelectTest extends ProxyAwareElementTestCase

--- a/tests/Form/Element/ProxyTest.php
+++ b/tests/Form/Element/ProxyTest.php
@@ -22,8 +22,6 @@ use const PHP_VERSION_ID;
 /**
  * Tests for the Collection pagination adapter
  *
- * @link    http://www.doctrine-project.org/
- *
  * @covers  \DoctrineModule\Form\Element\Proxy
  */
 class ProxyTest extends TestCase

--- a/tests/Form/Element/TestAsset/FormObject.php
+++ b/tests/Form/Element/TestAsset/FormObject.php
@@ -8,8 +8,6 @@ use function assert;
 
 /**
  * Simple mock object for form element adapter test
- *
- * @link    http://www.doctrine-project.org/
  */
 class FormObject
 {

--- a/tests/Paginator/Adapter/CollectionAdapterTest.php
+++ b/tests/Paginator/Adapter/CollectionAdapterTest.php
@@ -12,8 +12,6 @@ use function range;
 
 /**
  * Tests for the Collection pagination adapter
- *
- * @link    http://www.doctrine-project.org/
  */
 class CollectionAdapterTest extends TestCase
 {

--- a/tests/Paginator/Adapter/SelectableAdapterTest.php
+++ b/tests/Paginator/Adapter/SelectableAdapterTest.php
@@ -13,8 +13,6 @@ use function range;
 
 /**
  * Tests for the Selectable pagination adapter
- *
- * @link    http://www.doctrine-project.org/
  */
 class SelectableAdapterTest extends TestCase
 {

--- a/tests/ServiceFactory/ModuleDefinedServicesTest.php
+++ b/tests/ServiceFactory/ModuleDefinedServicesTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test that verifies that services are defined correctly
- *
- * @link    http://www.doctrine-project.org/
  */
 class ModuleDefinedServicesTest extends TestCase
 {

--- a/tests/Validator/NoObjectExistsTest.php
+++ b/tests/Validator/NoObjectExistsTest.php
@@ -12,8 +12,6 @@ use function str_replace;
 
 /**
  * Tests for the NoObjectExists test
- *
- * @link    http://www.doctrine-project.org/
  */
 class NoObjectExistsTest extends BaseTestCase
 {

--- a/tests/Validator/ObjectExistsTest.php
+++ b/tests/Validator/ObjectExistsTest.php
@@ -13,8 +13,6 @@ use function str_replace;
 /**
  * Tests for the ObjectExists validator
  *
- * @link    http://www.doctrine-project.org/
- *
  * @covers \DoctrineModule\Validator\ObjectExists
  */
 class ObjectExistsTest extends BaseTestCase

--- a/tests/Validator/UniqueObjectTest.php
+++ b/tests/Validator/UniqueObjectTest.php
@@ -17,8 +17,6 @@ use function str_replace;
 
 /**
  * Tests for the UniqueObject validator
- *
- * @link    http://www.doctrine-project.org/
  */
 class UniqueObjectTest extends BaseTestCase
 {


### PR DESCRIPTION
**Caution:** BC Break

The `Module` and `ConfigProvider` classes, as well as the option classes and all factories are no valid extension points. They are now marked as final.