### PR TITLE
Change return type to int for Countable implementations

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DoctrineModule;
 
+use Doctrine\Common\Cache;
+use Laminas\Authentication\Storage\Session as LaminasSessionStorage;
+
 /**
  * Config provider for DoctrineORMModule config
  */
@@ -30,9 +33,9 @@ final class ConfigProvider
     public function getDependencyConfig(): array
     {
         return [
-            'invokables' => ['DoctrineModule\Authentication\Storage\Session' => 'Laminas\Authentication\Storage\Session'],
-            'factories' => ['doctrine.cli' => 'DoctrineModule\Service\CliFactory'],
-            'abstract_factories' => ['DoctrineModule' => 'DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory'],
+            'invokables' => ['DoctrineModule\Authentication\Storage\Session' => LaminasSessionStorage::class],
+            'factories' => ['doctrine.cli' => Service\CliFactory::class],
+            'abstract_factories' => ['DoctrineModule' => ServiceFactory\AbstractDoctrineServiceFactory::class],
         ];
     }
 
@@ -46,52 +49,52 @@ final class ConfigProvider
         return [
             'cache' => [
                 'apc' => [
-                    'class'     => 'Doctrine\Common\Cache\ApcCache',
+                    'class'     => Cache\ApcCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
                 'apcu' => [
-                    'class'     => 'Doctrine\Common\Cache\ApcuCache',
+                    'class'     => Cache\ApcuCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
                 'array' => [
-                    'class' => 'Doctrine\Common\Cache\ArrayCache',
+                    'class' => Cache\ArrayCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
                 'filesystem' => [
-                    'class'     => 'Doctrine\Common\Cache\FilesystemCache',
+                    'class'     => Cache\FilesystemCache::class,
                     'directory' => 'data/DoctrineModule/cache',
                     'namespace' => 'DoctrineModule',
                 ],
                 'memcache' => [
-                    'class'     => 'Doctrine\Common\Cache\MemcacheCache',
+                    'class'     => Cache\MemcacheCache::class,
                     'instance'  => 'my_memcache_alias',
                     'namespace' => 'DoctrineModule',
                 ],
                 'memcached' => [
-                    'class'     => 'Doctrine\Common\Cache\MemcachedCache',
+                    'class'     => Cache\MemcachedCache::class,
                     'instance'  => 'my_memcached_alias',
                     'namespace' => 'DoctrineModule',
                 ],
                 'predis' => [
-                    'class'     => 'Doctrine\Common\Cache\PredisCache',
+                    'class'     => Cache\PredisCache::class,
                     'instance'  => 'my_predis_alias',
                     'namespace' => 'DoctrineModule',
                 ],
                 'redis' => [
-                    'class'     => 'Doctrine\Common\Cache\RedisCache',
+                    'class'     => Cache\RedisCache::class,
                     'instance'  => 'my_redis_alias',
                     'namespace' => 'DoctrineModule',
                 ],
                 'wincache' => [
-                    'class'     => 'Doctrine\Common\Cache\WinCacheCache',
+                    'class'     => Cache\WinCacheCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
                 'xcache' => [
-                    'class'     => 'Doctrine\Common\Cache\XcacheCache',
+                    'class'     => Cache\XcacheCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
                 'zenddata' => [
-                    'class'     => 'Doctrine\Common\Cache\ZendDataCache',
+                    'class'     => Cache\ZendDataCache::class,
                     'namespace' => 'DoctrineModule',
                 ],
             ],
@@ -126,12 +129,12 @@ final class ConfigProvider
     public function getDoctrineFactoryConfig(): array
     {
         return [
-            'cache'                 => 'DoctrineModule\Service\CacheFactory',
-            'eventmanager'          => 'DoctrineModule\Service\EventManagerFactory',
-            'driver'                => 'DoctrineModule\Service\DriverFactory',
-            'authenticationadapter' => 'DoctrineModule\Service\Authentication\AdapterFactory',
-            'authenticationstorage' => 'DoctrineModule\Service\Authentication\StorageFactory',
-            'authenticationservice' => 'DoctrineModule\Service\Authentication\AuthenticationServiceFactory',
+            'cache'                 => Service\CacheFactory::class,
+            'eventmanager'          => Service\EventManagerFactory::class,
+            'driver'                => Service\DriverFactory::class,
+            'authenticationadapter' => Service\Authentication\AdapterFactory::class,
+            'authenticationstorage' => Service\Authentication\StorageFactory::class,
+            'authenticationservice' => Service\Authentication\AuthenticationServiceFactory::class,
         ];
     }
 

--- a/src/Options/Cache.php
+++ b/src/Options/Cache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Options;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Laminas\Stdlib\AbstractOptions;
 
 /**
@@ -14,7 +15,7 @@ final class Cache extends AbstractOptions
     /**
      * Class used to instantiate the cache.
      */
-    protected string $class = 'Doctrine\Common\Cache\ArrayCache';
+    protected string $class = ArrayCache::class;
 
     /**
      * Namespace to prefix all cache ids with.

--- a/src/Paginator/Adapter/Collection.php
+++ b/src/Paginator/Adapter/Collection.php
@@ -6,7 +6,6 @@ namespace DoctrineModule\Paginator\Adapter;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Laminas\Paginator\Adapter\AdapterInterface;
-use ReturnTypeWillChange;
 
 use function array_values;
 use function count;
@@ -38,11 +37,7 @@ class Collection implements AdapterInterface
         return array_values($this->collection->slice($offset, $itemCountPerPage));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->collection);
     }

--- a/src/Paginator/Adapter/Selectable.php
+++ b/src/Paginator/Adapter/Selectable.php
@@ -7,7 +7,6 @@ namespace DoctrineModule\Paginator\Adapter;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable as DoctrineSelectable;
 use Laminas\Paginator\Adapter\AdapterInterface;
-use ReturnTypeWillChange;
 
 use function count;
 
@@ -48,11 +47,7 @@ class Selectable implements AdapterInterface
         return $this->selectable->matching($this->criteria)->toArray();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         $criteria = clone $this->criteria;
 


### PR DESCRIPTION
This should be the last BC break for the upcoming 5.0.0 release. It changes the implementations of `Countable` to a native int return type, so that the `ReturnTypeWillChange` annotation is not further needed.

Besides, configuration now consequently uses `::class` instead of strings when refering to a class.