### PR TITLE
Fixed broken test cases occuring with laminas-test 3.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "laminas/laminas-mvc-console": "^1.3.0",
         "laminas/laminas-serializer": "^2.11.0",
         "laminas/laminas-session": "^2.12.0",
-        "laminas/laminas-test": "^3.5.1",
+        "laminas/laminas-test": "^3.8.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^1.1.2",
         "phpstan/phpstan-phpunit": "^1.0.0",

--- a/tests/Controller/CliControllerTest.php
+++ b/tests/Controller/CliControllerTest.php
@@ -40,8 +40,7 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
      */
     public function testIndexActionCanBeAccessed(): void
     {
-        /** @phpstan-ignore-next-line */
-        $this->dispatch(new Request(['scriptname.php', 'list']));
+        $this->dispatch((string) (new Request(['scriptname.php', 'list'])));
 
         $this->assertResponseStatusCode(0);
         $this->assertModuleName('doctrinemodule');
@@ -53,16 +52,14 @@ class CliControllerTest extends AbstractConsoleControllerTestCase
 
     public function testNonZeroExitCode(): void
     {
-        /** @phpstan-ignore-next-line */
-        $this->dispatch(new Request(['scriptname.php', 'fail']));
+        $this->dispatch((string) (new Request(['scriptname.php', 'fail'])));
 
         $this->assertNotResponseStatusCode(0);
     }
 
     public function testException(): void
     {
-        /** @phpstan-ignore-next-line */
-        $this->dispatch(new Request(['scriptname.php', '-q', 'fail', '--exception']));
+        $this->dispatch((string) (new Request(['scriptname.php', '-q', 'fail', '--exception'])));
 
         $this->assertNotResponseStatusCode(0);
     }


### PR DESCRIPTION
In laminas-test 3.8.0 `declare(string_types=1)` was added internally in all files (laminas/laminas-test#52).
This breaks a few test cases in our CliControllerTest.

Note that this only affects 4.x series, as laminas-console was dropped in 5.x. I'll fix this anyways, as 4.4.x is currently still maintained.