### PR TITLE
Upgrade doctrine-laminas-hydrator to ^3.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,6 @@ jobs:
         include:
           - php-version: "7.4"
             dependencies: "lowest"
-          - php-version: "7.4"
-            dependencies: "lowest"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "doctrine/annotations": "^1.13.2",
         "doctrine/cache": "^1.12.1",
         "doctrine/collections": "^1.6.8",
-        "doctrine/doctrine-laminas-hydrator": "^2.2.1 || ^3.0.0",
+        "doctrine/doctrine-laminas-hydrator": "^3.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/inflector": "^2.0.4",
         "doctrine/persistence": "^2.2.3",

--- a/composer.json
+++ b/composer.json
@@ -50,25 +50,25 @@
         "doctrine/doctrine-laminas-hydrator": "^3.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/inflector": "^2.0.4",
-        "doctrine/persistence": "^2.2.3",
+        "doctrine/persistence": "^2.3.0",
         "laminas/laminas-authentication": "^2.9.0",
         "laminas/laminas-cache": "^3.1.2",
         "laminas/laminas-eventmanager": "^3.4.0",
-        "laminas/laminas-form": "^3.0.1",
+        "laminas/laminas-form": "^3.1.1",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc": "^3.3.0",
-        "laminas/laminas-paginator": "^2.12.1",
+        "laminas/laminas-paginator": "^2.12.2",
         "laminas/laminas-servicemanager": "^3.10.0",
-        "laminas/laminas-stdlib": "^3.6.4",
-        "laminas/laminas-validator": "^2.15.1",
-        "symfony/console": "^5.4.1 || ^6.0.1"
+        "laminas/laminas-stdlib": "^3.7.1",
+        "laminas/laminas-validator": "^2.16.0",
+        "symfony/console": "^5.4.3 || ^6.0.3"
     },
     "provide": {
         "laminas/laminas-cache-storage-implementation": "1.0.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
-        "doctrine/orm": "^2.10.4",
+        "doctrine/orm": "^2.11.1",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^2.0.0",
         "laminas/laminas-cache-storage-adapter-memory": "^2.0.0",
@@ -77,11 +77,11 @@
         "laminas/laminas-serializer": "^2.12.0",
         "laminas/laminas-session": "^2.12.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
-        "phpstan/phpstan": "^1.2.0",
+        "phpstan/phpstan": "^1.4.6",
         "phpstan/phpstan-phpunit": "^1.0.0",
-        "phpunit/phpunit": "^9.5.11",
-        "predis/predis": "^1.1.9",
-        "vimeo/psalm": "^4.16.1"
+        "phpunit/phpunit": "^9.5.13",
+        "predis/predis": "^1.1.10",
+        "vimeo/psalm": "^4.20.0"
     },
     "suggest": {
         "doctrine/data-fixtures": "Data Fixtures if you want to generate test data or bootstrap data for your deployments"

--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,7 @@
         "vimeo/psalm": "^4.16.1"
     },
     "suggest": {
-        "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",
-        "laminas/laminas-mvc-console":    "^1.1.11 if you want to use the Laminas console libraries"
+        "doctrine/data-fixtures": "Data Fixtures if you want to generate test data or bootstrap data for your deployments"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Changes doctrine-laminas-hydrator from `^2.0 || ^3.0` to `^3.0` (i.e. no BC break)
- Removes the outdated laminas-mvc-console package from `suggest` section (not used anymore since 5.0)
- Raises the minimum version constraints of dependencies ensuring compatibility with PHP 7.4
- Updates CI workflow, where CI with PHP 7.4 and lowest dependencies was running twice