### PR TITLE
Adapt to new type hierarchy

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,6 @@ parameters:
         - src
         - tests
 includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/jangregor/phpstan-prophecy/extension.neon

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace DoctrineModule\Service;
 
 use Doctrine\Common\Annotations;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
-use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -14,12 +12,12 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Options\Driver;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
+use ReflectionClass;
 use RuntimeException;
 
 use function class_exists;
 use function get_class;
 use function interface_exists;
-use function is_subclass_of;
 use function sprintf;
 
 /**
@@ -70,10 +68,10 @@ final class DriverFactory extends AbstractFactory
         // Not all drivers (DriverChain) require paths.
         $paths = $options->getPaths();
 
+        $constructor = (new ReflectionClass($class))->getConstructor();
         // Special options for AnnotationDrivers.
         if (
-            $class !== AttributeDriver::class &&
-            ($class === AnnotationDriver::class || is_subclass_of($class, AnnotationDriver::class))
+            $constructor !== null && $constructor->getNumberOfParameters() === 2
         ) {
             $reader = new Annotations\AnnotationReader();
             $reader = new Annotations\CachedReader(

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Service;
 
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Service\DriverFactory;
@@ -89,5 +92,30 @@ class DriverFactoryTest extends BaseTestCase
         $factory = new DriverFactory('testDriver');
         $driver  = $factory->__invoke($serviceManager, AttributeDriver::class);
         $this->assertInstanceOf(AttributeDriver::class, $driver);
+    }
+
+    public function testCreateAnnotationDriver(): void
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'config',
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'testDriver' => ['class' => AnnotationDriver::class],
+                    ],
+                ],
+            ]
+        );
+        $serviceManager->setService(
+            'doctrine.cache.array',
+            new ArrayCache()
+        );
+
+        $factory = new DriverFactory('testDriver');
+        $driver  = $factory->__invoke($serviceManager, AnnotationDriver::class);
+        $this->assertInstanceOf(AnnotationDriver::class, $driver);
+        assert($driver instanceof AnnotationDriver);
+        $this->assertInstanceOf(Reader::class, $driver->getReader());
     }
 }

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -115,7 +115,6 @@ class DriverFactoryTest extends BaseTestCase
         $factory = new DriverFactory('testDriver');
         $driver  = $factory->__invoke($serviceManager, AnnotationDriver::class);
         $this->assertInstanceOf(AnnotationDriver::class, $driver);
-        assert($driver instanceof AnnotationDriver);
         $this->assertInstanceOf(Reader::class, $driver->getReader());
     }
 }


### PR DESCRIPTION
In recent versions of ORM and ODM, annotation driver no longer extend a
base class in doctrine/persistence. Instead of testing for that base
class, detecting the number of constructor arguments seems like a more
robust way to figure out what arguments to pass.

Fixes #774 

Alternative to https://github.com/doctrine/DoctrineModule/pull/775