### PR TITLE
Mark doctrine/orm 2.12.0 as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
-        "doctrine/orm": "^2.10.2",
+        "doctrine/orm": "^2.10.5",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^1.2.1 || ^2.0.0",
         "laminas/laminas-cache-storage-adapter-memory": "^1.0.1 || ^2.0.0",
@@ -84,6 +84,9 @@
         "phpunit/phpunit": "^9.5.10",
         "predis/predis": "^1.1.9",
         "vimeo/psalm": "^4.11.2"
+    },
+    "conflict": {
+        "doctrine/orm": "2.12.0"
     },
     "suggest": {
         "doctrine/data-fixtures":         "Data Fixtures if you want to generate test data or bootstrap data for your deployments",


### PR DESCRIPTION
ORM 2.12.0 has a BC break which is fixed with 2.12.1. This change marks 2.12.0 as a conflict, to prevent installation.

Fixes #774 