### PR TITLE
Remove unneeded autoload calls

### DIFF
--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -21,7 +21,6 @@ use function count;
 use function current;
 use function get_class;
 use function gettype;
-use function interface_exists;
 use function is_callable;
 use function is_object;
 use function is_string;
@@ -591,5 +590,3 @@ class Proxy implements ObjectManagerAwareInterface
         $this->valueOptions = $options;
     }
 }
-
-interface_exists(ObjectManager::class);

--- a/src/Options/Authentication.php
+++ b/src/Options/Authentication.php
@@ -12,7 +12,6 @@ use Laminas\Authentication\Storage\StorageInterface;
 use Laminas\Stdlib\AbstractOptions;
 
 use function gettype;
-use function interface_exists;
 use function is_callable;
 use function is_string;
 use function sprintf;
@@ -266,6 +265,3 @@ class Authentication extends AbstractOptions
         $this->storage = $storage;
     }
 }
-
-interface_exists(ClassMetadata::class);
-interface_exists(ObjectRepository::class);

--- a/src/Persistence/ObjectManagerAwareInterface.php
+++ b/src/Persistence/ObjectManagerAwareInterface.php
@@ -6,8 +6,6 @@ namespace DoctrineModule\Persistence;
 
 use Doctrine\Persistence\ObjectManager;
 
-use function interface_exists;
-
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming
 interface ObjectManagerAwareInterface
 {
@@ -23,5 +21,3 @@ interface ObjectManagerAwareInterface
      */
     public function getObjectManager(): ObjectManager;
 }
-
-interface_exists(ObjectManager::class);

--- a/src/Persistence/ProvidesObjectManager.php
+++ b/src/Persistence/ProvidesObjectManager.php
@@ -6,8 +6,6 @@ namespace DoctrineModule\Persistence;
 
 use Doctrine\Persistence\ObjectManager;
 
-use function interface_exists;
-
 /**
  * Trait to provide object manager to a form (only works from PHP 5.4)
  */
@@ -32,5 +30,3 @@ trait ProvidesObjectManager
         return $this->objectManager;
     }
 }
-
-interface_exists(ObjectManager::class);

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -17,7 +17,6 @@ use RuntimeException;
 
 use function class_exists;
 use function get_class;
-use function interface_exists;
 use function is_array;
 use function is_subclass_of;
 use function sprintf;
@@ -147,5 +146,3 @@ class DriverFactory extends AbstractFactory
         return $driver;
     }
 }
-
-interface_exists(MappingDriver::class);

--- a/src/Validator/Service/AbstractValidatorFactory.php
+++ b/src/Validator/Service/AbstractValidatorFactory.php
@@ -12,7 +12,6 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Stdlib\ArrayUtils;
 
-use function interface_exists;
 use function is_string;
 use function sprintf;
 
@@ -129,6 +128,3 @@ abstract class AbstractValidatorFactory implements FactoryInterface
         $this->creationOptions = $options;
     }
 }
-
-interface_exists(ObjectManager::class);
-interface_exists(ObjectRepository::class);


### PR DESCRIPTION
These were introduced in order to be able to support both persistence 1
and 2.

See #694 