### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -8,8 +8,13 @@ on:
     branches:
       - "*.x"
 
+permissions:
+  contents: read
+
 jobs:
   coding-standards:
+    permissions:
+      contents: none
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,9 @@ on:
       - '[0-9]+.[0-9]+.x'
       - 'refs/pull/*'
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: "PHPUnit"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -5,8 +5,13 @@ on:
     types:
       - "closed"
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: none
     name: "Git tag, release & create merge-up PR"
     uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.4.1"
     with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,8 +8,13 @@ on:
     branches:
       - "*.x"
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
+    permissions:
+      contents: none
     name: "Static Analysis"
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.1"
     with:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
