### PR TITLE
Add compatibility for persistence v3 with Mongo ODM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
+        "doctrine/mongodb-odm": "^2.3.0",
         "doctrine/orm": "^2.11.1",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^2.0.0",
@@ -104,6 +105,9 @@
     ],
     "config": {
         "sort-packages": true,
+        "platform": {
+            "ext-mongodb": "1.8.0"
+        },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -20,7 +20,7 @@ use RuntimeException;
 
 use function class_exists;
 use function get_class;
-use function is_subclass_of;
+use function is_a;
 use function sprintf;
 
 /**
@@ -76,10 +76,8 @@ final class DriverFactory extends AbstractFactory
             $class !== ORMAttributeDriver::class &&
             $class !== MongoODMAttributeDriver::class &&
             (
-                $class === ORMAnnotationDriver::class ||
-                $class === MongoODMAnnotationDriver::class ||
-                is_subclass_of($class, ORMAnnotationDriver::class) ||
-                is_subclass_of($class, MongoODMAnnotationDriver::class)
+                is_a($class, ORMAnnotationDriver::class, true) ||
+                is_a($class, MongoODMAnnotationDriver::class, true)
             )
         ) {
             $reader = new Annotations\AnnotationReader();

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace DoctrineModule\Service;
 
 use Doctrine\Common\Annotations;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver as MongoODMAnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver as MongoODMAttributeDriver;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver as ORMAnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver as ORMAttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -71,8 +73,14 @@ final class DriverFactory extends AbstractFactory
 
         // Special options for AnnotationDrivers.
         if (
-            $class !== AttributeDriver::class &&
-            ($class === AnnotationDriver::class || is_subclass_of($class, AnnotationDriver::class))
+            $class !== ORMAttributeDriver::class &&
+            $class !== MongoODMAttributeDriver::class &&
+            (
+                $class === ORMAnnotationDriver::class ||
+                $class === MongoODMAnnotationDriver::class ||
+                is_subclass_of($class, ORMAnnotationDriver::class) ||
+                is_subclass_of($class, MongoODMAnnotationDriver::class)
+            )
         ) {
             $reader = new Annotations\AnnotationReader();
             $reader = new Annotations\CachedReader(

--- a/tests/Service/DriverFactoryTest.php
+++ b/tests/Service/DriverFactoryTest.php
@@ -6,8 +6,10 @@ namespace DoctrineModuleTest\Service;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver as MongoDBODMAnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver as MongoDBODMAttributeDriver;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver as ORMAnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver as ORMAttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Service\DriverFactory;
 use DoctrineModuleTest\Service\Mock\MetadataDriverMock;
@@ -75,7 +77,7 @@ class DriverFactoryTest extends BaseTestCase
     /**
      * @requires PHP 8.0
      */
-    public function testCreateAttributeDriver(): void
+    public function testCreateORMAttributeDriver(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
@@ -83,18 +85,21 @@ class DriverFactoryTest extends BaseTestCase
             [
                 'doctrine' => [
                     'driver' => [
-                        'testDriver' => ['class' => AttributeDriver::class],
+                        'testDriver' => ['class' => ORMAttributeDriver::class],
                     ],
                 ],
             ]
         );
 
         $factory = new DriverFactory('testDriver');
-        $driver  = $factory->__invoke($serviceManager, AttributeDriver::class);
-        $this->assertInstanceOf(AttributeDriver::class, $driver);
+        $driver  = $factory->__invoke($serviceManager, ORMAttributeDriver::class);
+        $this->assertInstanceOf(ORMAttributeDriver::class, $driver);
     }
 
-    public function testCreateAnnotationDriver(): void
+    /**
+     * @requires PHP 8.0
+     */
+    public function testCreateMongoDBODMAttributeDriver(): void
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
@@ -102,7 +107,26 @@ class DriverFactoryTest extends BaseTestCase
             [
                 'doctrine' => [
                     'driver' => [
-                        'testDriver' => ['class' => AnnotationDriver::class],
+                        'testDriver' => ['class' => MongoDBODMAttributeDriver::class],
+                    ],
+                ],
+            ]
+        );
+
+        $factory = new DriverFactory('testDriver');
+        $driver  = $factory->__invoke($serviceManager, MongoDBODMAttributeDriver::class);
+        $this->assertInstanceOf(MongoDBODMAttributeDriver::class, $driver);
+    }
+
+    public function testCreateORMAnnotationDriver(): void
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'config',
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'testDriver' => ['class' => ORMAnnotationDriver::class],
                     ],
                 ],
             ]
@@ -113,8 +137,32 @@ class DriverFactoryTest extends BaseTestCase
         );
 
         $factory = new DriverFactory('testDriver');
-        $driver  = $factory->__invoke($serviceManager, AnnotationDriver::class);
-        $this->assertInstanceOf(AnnotationDriver::class, $driver);
+        $driver  = $factory->__invoke($serviceManager, ORMAnnotationDriver::class);
+        $this->assertInstanceOf(ORMAnnotationDriver::class, $driver);
+        $this->assertInstanceOf(Reader::class, $driver->getReader());
+    }
+
+    public function testCreateMongoDBODMAnnotationDriver(): void
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService(
+            'config',
+            [
+                'doctrine' => [
+                    'driver' => [
+                        'testDriver' => ['class' => MongoDBODMAnnotationDriver::class],
+                    ],
+                ],
+            ]
+        );
+        $serviceManager->setService(
+            'doctrine.cache.array',
+            new ArrayCache()
+        );
+
+        $factory = new DriverFactory('testDriver');
+        $driver  = $factory->__invoke($serviceManager, MongoDBODMAnnotationDriver::class);
+        $this->assertInstanceOf(MongoDBODMAnnotationDriver::class, $driver);
         $this->assertInstanceOf(Reader::class, $driver->getReader());
     }
 }


### PR DESCRIPTION
Unfortunatly, the changes in #787 were incomplete and did not handle the instantiation of Mongo ODM drivers correctly. This leads to the error shown in doctrine/DoctrineMongoODMModule#261. The error was introduced in DoctrineModule 5.2.0. This PR fixes the mentioned error.