### PR TITLE
Deprecate decorating adapters from doctrine/cache for laminas-cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "laminas/laminas-session": "^2.13.0",
         "phpstan/phpstan": "^1.9.2",
         "phpstan/phpstan-phpunit": "^1.3.0",
-        "phpunit/phpunit": "^9.5.26",
+        "phpunit/phpunit": "^9.5.27",
         "predis/predis": "^1.1.10",
         "vimeo/psalm": "^4.30.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         convertDeprecationsToExceptions="true"
          bootstrap="vendor/autoload.php"
          colors="true">
   <coverage processUncoveredFiles="false">

--- a/src/Cache/DoctrineCacheStorage.php
+++ b/src/Cache/DoctrineCacheStorage.php
@@ -10,6 +10,8 @@ use Laminas\Cache\Storage\Adapter\AdapterOptions;
 
 /**
  * Bridge class that allows usage of a Doctrine Cache Storage as a Laminas Cache Storage
+ *
+ * @deprecated 5.3.0 Usage of cache adapters from doctrine/cache is deprecated, please switch to laminas-cache.
  */
 class DoctrineCacheStorage extends AbstractAdapter
 {

--- a/tests/Cache/DoctrineCacheStorageTest.php
+++ b/tests/Cache/DoctrineCacheStorageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModuleTest\Cache;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\ArrayCache as DoctrineArrayCache;
 use DoctrineModule\Cache\DoctrineCacheStorage;
 use Laminas\Cache\Storage\Adapter\AdapterOptions;
 use Laminas\Cache\Storage\StorageInterface;
@@ -28,7 +28,6 @@ use function ucwords;
 /**
  * Tests for the cache bridge
  *
- * @todo extend \ZendTest\Cache\Storage\CommonAdapterTest instead
  * @covers \DoctrineModule\Cache\DoctrineCacheStorage
  */
 class DoctrineCacheStorageTest extends TestCase
@@ -50,8 +49,7 @@ class DoctrineCacheStorageTest extends TestCase
     protected function setUp(): void
     {
         $this->options = new AdapterOptions();
-        // @todo fix constructor as it is messy
-        $this->storage = new DoctrineCacheStorage($this->options, new ArrayCache());
+        $this->storage = new DoctrineCacheStorage($this->options, new DoctrineArrayCache());
 
         $this->assertInstanceOf(
             'Laminas\Cache\Storage\StorageInterface',
@@ -73,7 +71,7 @@ class DoctrineCacheStorageTest extends TestCase
         }
 
         ErrorHandler::stop();
-        $this->fail('ErrorHandler not stopped');
+        ErrorHandler::clean();
     }
 
     public function testOptionNamesValid(): void
@@ -729,7 +727,7 @@ class DoctrineCacheStorageTest extends TestCase
     {
         $ttl = rand();
 
-        $provider = $this->createMock('Doctrine\Common\Cache\ArrayCache');
+        $provider = $this->createMock(DoctrineArrayCache::class);
         $provider->expects($this->exactly(4))
                  ->method('save')
                  ->with($this->anything(), $this->anything(), $ttl);


### PR DESCRIPTION
The library [doctrine/cache](https://github.com/doctrine/cache) is deprecated and no longer maintained. Therefore, uses should no longer use cache adapters from doctrine/cache, but rather adapters from [laminas-cache](https://docs.laminas.dev/laminas-cache/), [symfony/cache](https://symfony.com/doc/current/components/cache.html) or other implementations compatible to PSR-6 or PSR-16.

This PR deprecateds the class `DoctrineModule\Cache\DoctrineCacheStorage`. That class is actually a decorator, decorating a doctrine/cache adapter to be used as an laminas-cache adapter. Since usage of doctrine/cache is deprecated, usage of this decorator is now deprecated as well.