### PR TITLE
Adjust dependencies/code for doctrine/annotations 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "homepage": "http://www.doctrine-project.org/",
     "require": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-        "doctrine/annotations": "^1.13.3",
+        "doctrine/annotations": "^1.13.3 || ^2",
         "doctrine/cache": "^1.13.0",
         "doctrine/collections": "^1.8.0",
         "doctrine/doctrine-laminas-hydrator": "^3.2.0",
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.2",
-        "doctrine/mongodb-odm": "^2.4.2",
+        "doctrine/mongodb-odm": "^2.5.0",
         "doctrine/orm": "^2.13.4",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "laminas/laminas-cache-storage-adapter-blackhole": "^2.0.0",
@@ -101,7 +101,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "platform": {
-            "ext-mongodb": "1.8.0"
+            "ext-mongodb": "1.11.0"
         },
         "sort-packages": true
     },

--- a/src/Module.php
+++ b/src/Module.php
@@ -18,11 +18,6 @@ final class Module implements ConfigProviderInterface, InitProviderInterface
 {
     public function init(ModuleManagerInterface $manager): void
     {
-        AnnotationRegistry::registerLoader(
-            static function ($className) {
-                return class_exists($className);
-            }
-        );
     }
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -5,18 +5,12 @@ declare(strict_types=1);
 namespace DoctrineModule;
 
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
-use Laminas\ModuleManager\Feature\InitProviderInterface;
-use Laminas\ModuleManager\ModuleManagerInterface;
 
 /**
  * Base module for integration of Doctrine projects with Laminas applications
  */
-final class Module implements ConfigProviderInterface, InitProviderInterface
+final class Module implements ConfigProviderInterface
 {
-    public function init(ModuleManagerInterface $manager): void
-    {
-    }
-
     /**
      * @return array<string, mixed>
      */

--- a/src/Module.php
+++ b/src/Module.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineModule;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\InitProviderInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;

--- a/src/Module.php
+++ b/src/Module.php
@@ -8,8 +8,6 @@ use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\InitProviderInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
 
-use function class_exists;
-
 /**
  * Base module for integration of Doctrine projects with Laminas applications
  */

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use DoctrineModule\Options\Driver;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
@@ -81,6 +82,7 @@ final class DriverFactory extends AbstractFactory
             )
         ) {
             $reader = new Annotations\IndexedReader(new Annotations\AnnotationReader());
+
             // Decorate reader with cache behavior if available:
             if (class_exists(Annotations\CachedReader::class)) {
                 // For Doctrine Annotations 1.x, use the old CachedReader; this can
@@ -89,14 +91,15 @@ final class DriverFactory extends AbstractFactory
                     $reader,
                     $container->get($options->getCache())
                 );
-            } else if (class_exists(Annotations\PsrCachedReader::class)) {
+            } elseif (class_exists(Annotations\PsrCachedReader::class)) {
                 // For Doctrine Annotations 2.x, we can use the PsrCachedReader if
                 // the cache supports the appropriate interface.
                 $cache = $container->get($options->getCache());
-                if ($cache instanceof \Psr\Cache\CacheItemPoolInterface) {
+                if ($cache instanceof CacheItemPoolInterface) {
                     $reader = new Annotations\PsrCachedReader($reader, $cache);
                 }
             }
+
             $driver = new $class($reader, $paths);
         } else {
             $driver = new $class($paths);

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -81,10 +81,13 @@ final class DriverFactory extends AbstractFactory
             )
         ) {
             $reader = new Annotations\AnnotationReader();
-            $reader = new Annotations\CachedReader(
-                new Annotations\IndexedReader($reader),
-                $container->get($options->getCache())
-            );
+            // Decorate reader with cache behavior if available:
+            if (class_exists(Annotations\CachedReader::class)) {
+                $reader = new Annotations\CachedReader(
+                    new Annotations\IndexedReader($reader),
+                    $container->get($options->getCache())
+                );
+            }
             $driver = new $class($reader, $paths);
         } else {
             $driver = new $class($paths);

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -80,13 +80,22 @@ final class DriverFactory extends AbstractFactory
                 is_a($class, MongoODMAnnotationDriver::class, true)
             )
         ) {
-            $reader = new Annotations\AnnotationReader();
+            $reader = new Annotations\IndexedReader(new Annotations\AnnotationReader());
             // Decorate reader with cache behavior if available:
             if (class_exists(Annotations\CachedReader::class)) {
+                // For Doctrine Annotations 1.x, use the old CachedReader; this can
+                // be removed when Annotations 1.x support is dropped.
                 $reader = new Annotations\CachedReader(
-                    new Annotations\IndexedReader($reader),
+                    $reader,
                     $container->get($options->getCache())
                 );
+            } else if (class_exists(Annotations\PsrCachedReader::class)) {
+                // For Doctrine Annotations 2.x, we can use the PsrCachedReader if
+                // the cache supports the appropriate interface.
+                $cache = $container->get($options->getCache());
+                if ($cache instanceof \Psr\Cache\CacheItemPoolInterface) {
+                    $reader = new Annotations\PsrCachedReader($reader, $cache);
+                }
             }
             $driver = new $class($reader, $paths);
         } else {

--- a/tests/Service/CacheFactoryTest.php
+++ b/tests/Service/CacheFactoryTest.php
@@ -77,19 +77,7 @@ class CacheFactoryTest extends BaseTestCase
             $serviceManager->configure((new BlackHole\ConfigProvider())->getServiceDependencies());
             $serviceManager->setService('config', $config);
         } else {
-            // setup for laminas-cache 2 and 3 with blackhole adapter 1
-            $config['caches']['my-laminas-cache']['name'] = 'blackhole';
-            $pluginManager                                = $serviceManager->get(AdapterPluginManager::class);
-            assert($pluginManager instanceof AdapterPluginManager);
-            $pluginManager->configure([
-                'factories' => [
-                    BlackHole::class => InvokableFactory::class,
-                ],
-                'aliases'   => [
-                    'blackhole'  => BlackHole::class,
-                ],
-            ]);
-            $serviceManager->setService('config', $config);
+            $this->markTestSkipped("Test requires blackhole adapter 2");
         }
 
         $cache = $factory->__invoke($serviceManager, LaminasStorageCache::class);

--- a/tests/Service/CacheFactoryTest.php
+++ b/tests/Service/CacheFactoryTest.php
@@ -11,8 +11,6 @@ use DoctrineModule\Cache\LaminasStorageCache;
 use DoctrineModule\Service\CacheFactory;
 use Laminas\Cache\ConfigProvider;
 use Laminas\Cache\Storage\Adapter\BlackHole;
-use Laminas\Cache\Storage\AdapterPluginManager;
-use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -77,7 +75,7 @@ class CacheFactoryTest extends BaseTestCase
             $serviceManager->configure((new BlackHole\ConfigProvider())->getServiceDependencies());
             $serviceManager->setService('config', $config);
         } else {
-            $this->markTestSkipped("Test requires blackhole adapter 2");
+            $this->markTestSkipped('Test requires blackhole adapter 2');
         }
 
         $cache = $factory->__invoke($serviceManager, LaminasStorageCache::class);


### PR DESCRIPTION
This PR is work in progress on addressing #800.

TODO
- [x] Resolve cache-related issues
- [x] Test with doctrine/annotations 1.x after finishing code changes to see if backward-compatibility is maintained, or if we need to fully bump the required version