### PR TITLE
Fix setOptions typehints.

### DIFF
--- a/src/Form/Element/ObjectMultiCheckbox.php
+++ b/src/Form/Element/ObjectMultiCheckbox.php
@@ -30,7 +30,7 @@ class ObjectMultiCheckbox extends MultiCheckbox
     /**
      * @return $this
      */
-    public function setOption(mixed $key, mixed $value): self
+    public function setOption(string $key, mixed $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/Form/Element/ObjectRadio.php
+++ b/src/Form/Element/ObjectRadio.php
@@ -25,7 +25,7 @@ class ObjectRadio extends RadioElement
     /**
      * @return $this
      */
-    public function setOption(mixed $key, mixed $value): self
+    public function setOption(string $key, mixed $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 

--- a/src/Form/Element/ObjectSelect.php
+++ b/src/Form/Element/ObjectSelect.php
@@ -30,7 +30,7 @@ class ObjectSelect extends SelectElement
     /**
      * @return $this
      */
-    public function setOption(mixed $key, mixed $value): self
+    public function setOption(string $key, mixed $value): self
     {
         $this->getProxy()->setOptions([$key => $value]);
 


### PR DESCRIPTION
The argument 1 typehint on setOption conflicts with the Laminas\Form\ElementInterface -- see: https://github.com/laminas/laminas-form/blob/3.11.x/src/ElementInterface.php#L36

This problem was detected by Psalm when I began work on adding DoctrineModule v6 support to DoctrineORMModule.

This string typehint was introduced in laminas-form v3, so the "mixed" typehint probably worked in combination with v2 and earlier. Since this module depends on laminas-form v3.4.1 or later, there should be no problem with making this adjustment.