### PR TITLE
Fix cache configuration for better Doctrine compatibility.

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -117,33 +117,34 @@ final class ConfigProvider
      */
     public function getCachesConfig(): array
     {
+        $defaultOptions = [
+            'namespace' => 'DoctrineModule',
+            'key_pattern' => '/^[a-z0-9_\+\-\[\]\\\\$]*$/Di'
+        ];
         return [
             'doctrinemodule.cache.apcu' => [
                 'adapter' => 'apcu',
-                'options' => ['namespace' => 'DoctrineModule'],
+                'options' => $defaultOptions,
             ],
             'doctrinemodule.cache.array' => [
                 'adapter' => Memory::class,
-                'options' => ['namespace' => 'DoctrineModule'],
+                'options' => $defaultOptions,
             ],
             'doctrinemodule.cache.filesystem' => [
                 'adapter' => 'filesystem',
-                'options' => [
-                    'namespace' => 'DoctrineModule',
+                'options' => $defaultOptions + [
                     'cache_dir' => 'data/DoctrineModule/cache',
                 ],
             ],
             'doctrinemodule.cache.memcached' => [
                 'adapter' => 'memcached',
-                'options' => [
-                    'namespace' => 'DoctrineModule',
+                'options' => $defaultOptions + [
                     'servers' => [],
                 ],
             ],
             'doctrinemodule.cache.redis' => [
                 'adapter' => 'redis',
-                'options' => [
-                    'namespace' => 'DoctrineModule',
+                'options' => $defaultOptions + [
                     'server' => [
                         'host' => 'localhost',
                         'post' => 6379,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -113,14 +113,15 @@ final class ConfigProvider
     }
 
     /**
-     * @return array<non-empty-string, array{adapter: string, options?: mixed[]}>
+     * @return array<non-empty-string, array{adapter: string, options?: mixed[], plugins?: mixed[]}>
      */
     public function getCachesConfig(): array
     {
         $defaultOptions = [
             'namespace' => 'DoctrineModule',
-            'key_pattern' => '/^[a-z0-9_\+\-\[\]\\\\$]*$/Di'
+            'key_pattern' => '/^[a-z0-9_\+\-\[\]\\\\$]*$/Di',
         ];
+
         return [
             'doctrinemodule.cache.apcu' => [
                 'adapter' => 'apcu',
@@ -132,15 +133,12 @@ final class ConfigProvider
             ],
             'doctrinemodule.cache.filesystem' => [
                 'adapter' => 'filesystem',
-                'options' => $defaultOptions + [
-                    'cache_dir' => 'data/DoctrineModule/cache',
-                ],
+                'options' => $defaultOptions + ['cache_dir' => 'data/DoctrineModule/cache'],
+                'plugins' => [['name' => 'serializer']],
             ],
             'doctrinemodule.cache.memcached' => [
                 'adapter' => 'memcached',
-                'options' => $defaultOptions + [
-                    'servers' => [],
-                ],
+                'options' => $defaultOptions + ['servers' => []],
             ],
             'doctrinemodule.cache.redis' => [
                 'adapter' => 'redis',


### PR DESCRIPTION
The default Laminas cache key pattern is incompatible with Doctrine's basic assumptions. This PR loosens things up a bit. It might not be perfect -- I'm open to suggestions for cleaner regexes -- but it at least works with the current DoctrineORMModule test suite.

Additionally, the old Doctrine file system cache adapter included automatic serialization, but the Laminas file system cache adapter does not. This adjusts the configuration to fix that inconsistency and ensure compatible behavior.

See https://github.com/doctrine/DoctrineORMModule/pull/734 for related discussion.