### PR TITLE
Add default value for $property in Proxy.php

### DIFF
--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -458,7 +458,7 @@ class Proxy implements ObjectManagerAwareInterface
             $generatedLabel = $this->generateLabel($object);
             if ($generatedLabel !== null) {
                 $label = $generatedLabel;
-            } elseif ($this->property) {
+            } elseif ($this->property !== null) {
                 $property = $this->property;
                 if (
                     ($this->getIsMethod() === false || $this->getIsMethod() === null)

--- a/src/Form/Element/Proxy.php
+++ b/src/Form/Element/Proxy.php
@@ -47,7 +47,7 @@ class Proxy implements ObjectManagerAwareInterface
     /** @var mixed[] */
     protected array $findMethod = [];
 
-    protected mixed $property;
+    protected mixed $property = null;
 
     /** @var mixed[] */
     protected array $optionAttributes = [];


### PR DESCRIPTION
When using the new 6.0 branch together with an EntitySelect which uses a proxy I am getting the following error

```
File:
/var/www/vendor/doctrine/doctrine-module/src/Form/Element/Proxy.php: 461
Message:
Typed property DoctrineModule\Form\Element\Proxy::$property must not be accessed before initialization
``` 

This is because the $property property has no default value. In this pull request I use the default value null and also changed the check on 461 to a $this->property !== null to have a correct boolean result