### PR TITLE
Fix unwanted BC break from 5.x series not allowing integer input for validators

### DIFF
--- a/src/Validator/ObjectExists.php
+++ b/src/Validator/ObjectExists.php
@@ -118,14 +118,14 @@ class ObjectExists extends AbstractValidator
     }
 
     /**
-     * @param string|object|mixed[] $value a field value or an array of field values if more fields have been configured to be
+     * @param string|int|object|mixed[] $value a field value or an array of field values if more fields have been configured to be
      *                      matched
      *
      * @return mixed[]
      *
      * @throws Exception\RuntimeException
      */
-    protected function cleanSearchValue(string|object|array $value): array
+    protected function cleanSearchValue(string|int|object|array $value): array
     {
         $value = is_object($value) ? [$value] : (array) $value;
 

--- a/tests/Validator/ObjectExistsTest.php
+++ b/tests/Validator/ObjectExistsTest.php
@@ -36,6 +36,22 @@ class ObjectExistsTest extends BaseTestCase
         $this->assertTrue($validator->isValid(['matchKey' => 'matchValue']));
     }
 
+    public function testCanValidateWithIntegerId(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+
+        $repository
+            ->expects($this->exactly(2))
+            ->method('findOneBy')
+            ->with(['matchKey' => 123])
+            ->will($this->returnValue(new stdClass()));
+
+        $validator = new ObjectExists(['object_repository' => $repository, 'fields' => 'matchKey']);
+
+        $this->assertTrue($validator->isValid(123));
+        $this->assertTrue($validator->isValid(['matchKey' => 123]));
+    }
+
     public function testCanValidateWithMultipleFields(): void
     {
         $repository = $this->createMock(ObjectRepository::class);


### PR DESCRIPTION
Closes #818 

The release of the 6.x series introduced an unwanted behaviour not allowing integer input to the form validators. This needs to be changed, as integers (e.g. IDs) should be an acceptable input.