### PR TITLE
Drop support for doctrine/collections 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "composer/semver": "^3.0",
         "doctrine/annotations": "^1.13.3 || ^2",
         "doctrine/cache": "^1.13.0 || ^2.1.0",
-        "doctrine/collections": "^1.8.0 || ^2.1",
+        "doctrine/collections": "^2.0.0",
         "doctrine/doctrine-laminas-hydrator": "^3.2.0",
         "doctrine/event-manager": "^1.2.0 || ^2.0",
         "doctrine/inflector": "^2.0.6",


### PR DESCRIPTION
With this PR, doctrine/collections 2.x is required and 1.x is not supported anymore.