### PR TITLE
Drop support for doctrine/persistence 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/doctrine-laminas-hydrator": "^3.2.0",
         "doctrine/event-manager": "^1.2.0 || ^2.0",
         "doctrine/inflector": "^2.0.6",
-        "doctrine/persistence": "^2.5.5 || ^3.1.0",
+        "doctrine/persistence": "^3.0.0",
         "laminas/laminas-authentication": "^2.12.0",
         "laminas/laminas-cache": "^3.6.0",
         "laminas/laminas-cache-storage-adapter-filesystem": "^2.2.0",


### PR DESCRIPTION
With this PR, doctrine/persistence 3.x is required and 2.x is not supported anymore.