### PR TITLE
Dropped support for doctrine/cache 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "composer-runtime-api": "^2.0",
         "composer/semver": "^3.0",
         "doctrine/annotations": "^1.13.3 || ^2",
-        "doctrine/cache": "^1.13.0 || ^2.1.0",
+        "doctrine/cache": "^2.1.0",
         "doctrine/collections": "^2.0.0",
         "doctrine/doctrine-laminas-hydrator": "^3.2.0",
         "doctrine/event-manager": "^1.2.0 || ^2.0",
@@ -80,7 +80,9 @@
         "doctrine/orm": "2.12.0"
     },
     "suggest": {
-        "doctrine/data-fixtures": "Data Fixtures if you want to generate test data or bootstrap data for your deployments"
+        "doctrine/data-fixtures": "Data Fixtures if you want to generate test data or bootstrap data for your deployments",
+        "doctrine/doctrine-mongo-odm-module": "For use with Doctrine MongDB ODM",
+        "doctrine/doctrine-orm-module": "For use with Doctrine ORM"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cache/LaminasStorageCache.php
+++ b/src/Cache/LaminasStorageCache.php
@@ -13,6 +13,8 @@ use Laminas\Cache\Storage\TotalSpaceCapableInterface;
 
 /**
  * Bridge class that allows usage of a Laminas Cache Storage as a Doctrine Cache
+ *
+ * @deprecated 6.2.0 Usage of doctrine/cache is deprecated, please use PSR-6 natively.
  */
 class LaminasStorageCache extends CacheProvider
 {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineModule;
 
-use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
-use Doctrine\Common\Cache as DoctrineCache;
 use DoctrineModule\Cache\LaminasStorageCache;
 use Laminas\Authentication\Storage\Session as LaminasSessionStorage;
 use Laminas\Cache\Storage\Adapter\Memory;
@@ -148,67 +145,12 @@ final class ConfigProvider
     }
 
     /**
-     * Use doctrine/cache config, when doctrine/cache:^1.0 is installed, and use laminas/laminas-cache,
-     * when doctrine/cache:^2.0 is installed, as the latter does not include any cache adapters anymore
+     * Use laminas/laminas-cache, as doctrine/cache ^2.0 does not include any cache adapters anymore
      *
      * @return array<non-empty-string,array{class:class-string,instance?:string,namespace?:string,directory?:string}>
      */
     private function getDoctrineCacheConfig(): array
     {
-        if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/cache', '^1.0')) {
-            return [
-                'apc' => [
-                    'class' => DoctrineCache\ApcCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-                'apcu' => [
-                    'class' => DoctrineCache\ApcuCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-                'array' => [
-                    'class' => DoctrineCache\ArrayCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-                'filesystem' => [
-                    'class' => DoctrineCache\FilesystemCache::class,
-                    'directory' => 'data/DoctrineModule/cache',
-                    'namespace' => 'DoctrineModule',
-                ],
-                'memcache' => [
-                    'class' => DoctrineCache\MemcacheCache::class,
-                    'instance' => 'my_memcache_alias',
-                    'namespace' => 'DoctrineModule',
-                ],
-                'memcached' => [
-                    'class' => DoctrineCache\MemcachedCache::class,
-                    'instance' => 'my_memcached_alias',
-                    'namespace' => 'DoctrineModule',
-                ],
-                'predis' => [
-                    'class' => DoctrineCache\PredisCache::class,
-                    'instance' => 'my_predis_alias',
-                    'namespace' => 'DoctrineModule',
-                ],
-                'redis' => [
-                    'class' => DoctrineCache\RedisCache::class,
-                    'instance' => 'my_redis_alias',
-                    'namespace' => 'DoctrineModule',
-                ],
-                'wincache' => [
-                    'class' => DoctrineCache\WinCacheCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-                'xcache' => [
-                    'class' => DoctrineCache\XcacheCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-                'zenddata' => [
-                    'class' => DoctrineCache\ZendDataCache::class,
-                    'namespace' => 'DoctrineModule',
-                ],
-            ];
-        }
-
         return [
             'apcu' => [
                 'class' => LaminasStorageCache::class,

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineModule\Service;
 
-use Doctrine\Common\Cache;
-use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache as DoctrineCache;
 use DoctrineModule\Cache\LaminasStorageCache;
 use DoctrineModule\Options\Cache as CacheOptions;
 use Psr\Container\ContainerInterface;
@@ -22,7 +21,7 @@ final class CacheFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return Cache\Cache
+     * @return DoctrineCache\Cache
      *
      * @throws RuntimeException
      */
@@ -54,12 +53,7 @@ final class CacheFactory extends AbstractFactory
             $cache = $container->get($class);
         } else {
             switch ($class) {
-                case Cache\FilesystemCache::class:
-                    $cache = new $class($options->getDirectory());
-                    break;
-
                 case LaminasStorageCache::class:
-                case Cache\PredisCache::class:
                     $cache = new $class($instance);
                     break;
 
@@ -69,15 +63,7 @@ final class CacheFactory extends AbstractFactory
             }
         }
 
-        if ($cache instanceof Cache\MemcacheCache) {
-            $cache->setMemcache($instance);
-        } elseif ($cache instanceof Cache\MemcachedCache) {
-            $cache->setMemcached($instance);
-        } elseif ($cache instanceof Cache\RedisCache) {
-            $cache->setRedis($instance);
-        }
-
-        if ($cache instanceof CacheProvider) {
+        if ($cache instanceof DoctrineCache\CacheProvider) {
             $namespace = $options->getNamespace();
             if ($namespace) {
                 $cache->setNamespace($namespace);


### PR DESCRIPTION
With this PR, only doctrine/cache ^2.0 is allowed. Since doctrine/cache v2 only contains interfaces and no implementations anymore, this means that users must use laminas-cache implementations for actual caching.