### PR TITLE
Dropped symfony/console 5.x, allow symfony/console 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "laminas/laminas-stdlib": "^3.13.0",
         "laminas/laminas-validator": "^2.25.0",
         "psr/container": "^1.1.2",
-        "symfony/console": "^5.4.16 || ^6.2.1"
+        "symfony/console": "^6.2.1 || ^7.0.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0.0",

--- a/tests/Service/CliFactoryTest.php
+++ b/tests/Service/CliFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineModuleTest\Service;
+
+use DoctrineModule\Service\CliFactory;
+use DoctrineModuleTest\Service\TestAsset\DummyCliCommand;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManager;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Symfony\Component\Console\Application;
+
+/**
+ * Base test case for the setup of Doctrine CLI
+ */
+class CliFactoryTest extends BaseTestCase
+{
+    public function testSetupOfDoctrineCli(): void
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('config', []);
+        $serviceManager->setService('EventManager', new EventManager());
+
+        $factory = new CliFactory();
+        $app     = $factory->__invoke($serviceManager, 'doctrine.cli');
+
+        $this->assertInstanceOf(Application::class, $app);
+    }
+
+    public function testRegistrationOfCustomCliCommand(): void
+    {
+        $serviceManager = new ServiceManager();
+        $eventManager   = new EventManager();
+
+        $eventManager->attach(
+            'loadCli.post',
+            static function (EventInterface $event): void {
+                $target = $event->getTarget();
+                if (! ($target instanceof Application)) {
+                    return;
+                }
+
+                $target->add(new DummyCliCommand());
+            },
+        );
+
+        $serviceManager->setService('config', []);
+        $serviceManager->setService('EventManager', $eventManager);
+
+        $factory = new CliFactory();
+        $app     = $factory->__invoke($serviceManager, 'doctrine.cli');
+
+        $this->assertInstanceOf(Application::class, $app);
+        $this->assertTrue($app->has('app:dummy-command'));
+    }
+}

--- a/tests/Service/TestAsset/DummyCliCommand.php
+++ b/tests/Service/TestAsset/DummyCliCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineModuleTest\Service\TestAsset;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DummyCliCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:dummy-command')
+            ->setDescription('A dummy command for testing purposes.');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln([
+            'Dummy Command',
+            '=============',
+            '',
+        ]);
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
Now, either symfony/console 6.x or 7.x are allowed.

This PR adds some test cases for CliFactory, which have been missing before.